### PR TITLE
Announce new commits on dapphub chat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then nix-build -j2 release.nix -A dapphub.linux.stable | cachix push dapp; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then nix-build -j2 release.nix -A dapphub.darwin.stable | cachix push dapp; fi
 after_success:
-  - nix run nixpkgs.httpie -c http -f https://dapphub.chat/api/v1/chat.postMessage X-Auth-Token:"$CHAT_AUTH_TOKEN" X-User-Id:"$CHAT_USER_ID" channel=#announce text="Another test"
+  - nix run nixpkgs.httpie -c http -f https://dapphub.chat/api/v1/chat.postMessage X-Auth-Token:"$CHAT_AUTH_TOKEN" X-User-Id:"$CHAT_USER_ID" channel=#announce text="New commit $TRAVIS_COMMIT at https://github.com/dapphub/dapptools/commit/$TRAVIS_COMMIT"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,4 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then nix-build -j2 release.nix -A dapphub.linux.stable | cachix push dapp; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then nix-build -j2 release.nix -A dapphub.darwin.stable | cachix push dapp; fi
 after_success:
-  - nix-env -iA nixpkgs.httpie
-  - http -f https://dapphub.chat/api/v1/chat.postMessage X-Auth-Token:"$CHAT_AUTH_TOKEN" X-User-Id:"$CHAT_USER_ID" channel=#announce text="Another test"
->>>>>>> 6632658... CI: Use httpie instead of curl
+  - nix run nixpkgs.httpie -c http -f https://dapphub.chat/api/v1/chat.postMessage X-Auth-Token:"$CHAT_AUTH_TOKEN" X-User-Id:"$CHAT_USER_ID" channel=#announce text="Another test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then nix-build -j2 release.nix -A dapphub.linux.stable | cachix push dapp; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then nix-build -j2 release.nix -A dapphub.darwin.stable | cachix push dapp; fi
 after_success:
-  - nix run nixpkgs.httpie -c http -f https://dapphub.chat/api/v1/chat.postMessage X-Auth-Token:"$CHAT_AUTH_TOKEN" X-User-Id:"$CHAT_USER_ID" channel=#announce text="New commit $TRAVIS_COMMIT at https://github.com/dapphub/dapptools/commit/$TRAVIS_COMMIT"
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      nix run nixpkgs.httpie -c http -f https://dapphub.chat/api/v1/chat.postMessage X-Auth-Token:"$CHAT_AUTH_TOKEN" X-User-Id:"$CHAT_USER_ID" channel=#announce text="New commit $TRAVIS_COMMIT at https://github.com/dapphub/dapptools/commit/$TRAVIS_COMMIT"
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ script:
   - cachix push --watch-store dapp &
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then nix-build -j2 release.nix -A dapphub.linux.stable | cachix push dapp; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then nix-build -j2 release.nix -A dapphub.darwin.stable | cachix push dapp; fi
-
+after_success:
+  - curl -H "X-Auth-Token: $CHAT_AUTH_TOKEN" -H "X-User-Id: $CHAT_USER_ID" -H "Content-type:application/json" https://dapphub.chat/api/v1/chat.postMessage -d '{ "channel": "#announce", "text": "Hi everyone!" }'

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,6 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then nix-build -j2 release.nix -A dapphub.linux.stable | cachix push dapp; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then nix-build -j2 release.nix -A dapphub.darwin.stable | cachix push dapp; fi
 after_success:
-  - curl -H "X-Auth-Token: $CHAT_AUTH_TOKEN" -H "X-User-Id: $CHAT_USER_ID" -H "Content-type:application/json" https://dapphub.chat/api/v1/chat.postMessage -d '{ "channel": "#announce", "text": "Hi everyone!" }'
+  - nix-env -iA nixpkgs.httpie
+  - http -f https://dapphub.chat/api/v1/chat.postMessage X-Auth-Token:"$CHAT_AUTH_TOKEN" X-User-Id:"$CHAT_USER_ID" channel=#announce text="Another test"
+>>>>>>> 6632658... CI: Use httpie instead of curl

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,26 @@ install:
   - cachix use dapp
 script:
   - cachix push --watch-store dapp &
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then nix-build -j2 release.nix -A dapphub.linux.stable | cachix push dapp; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then nix-build -j2 release.nix -A dapphub.darwin.stable | cachix push dapp; fi
+  - |
+    PLATFORM=linux
+
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PLATFORM=darwin; fi
+
+    # the additional call to `cachix push` is there to prevent a race condition
+    # that happens when the above daemon is killed mid-push at the end of this
+    # script.
+    nix-build -j2 release.nix -A dapphub.$PLATFORM.stable | cachix push dapp
 after_success:
   - |
+    COMMIT_HASH=$(echo $TRAVIS_COMMIT | cut -c 1-8)
+
+    # Only run this on Linux to avoid announcing to the channel twice.
+    # Using build stages is another option but is inefficient because it requires initialization of an additional VM.
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      nix run nixpkgs.httpie -c http -f https://dapphub.chat/api/v1/chat.postMessage X-Auth-Token:"$CHAT_AUTH_TOKEN" X-User-Id:"$CHAT_USER_ID" channel=#announce text="New commit $TRAVIS_COMMIT at https://github.com/dapphub/dapptools/commit/$TRAVIS_COMMIT"
+      nix run nixpkgs.httpie -c \
+      http -f https://dapphub.chat/api/v1/chat.postMessage \
+        X-Auth-Token:"$CHAT_AUTH_TOKEN" \
+        X-User-Id:"$CHAT_USER_ID" \
+        channel=#announce \
+        text="Linux and Darwin packages for commit \`$COMMIT_HASH\` on branch \`$TRAVIS_BRANCH\` built and uploaded to \`dapp.cachix.org\`"
     fi


### PR DESCRIPTION
Every successful Travis build will be announced on the `#announce` channel on dapphub.chat.

Currently, all commits to all branches produce an announce message.

The messages looks like 

> Linux and Darwin packages for commit `8114cf4a` on branch `asymmetric/ci-bot` built and uploaded to `dapp.cachix.org`

**NOTE**: Two new env variables introduced:

* `CHAT_AUTH_TOKEN`
* `CHAT_USER_ID`

These must be set as project variables on Travis.