### PR TITLE
`RETURN` opcode handling fixed (in case of variable length return data)

### DIFF
--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -926,7 +926,7 @@ exec1 = do
                         popTrace
 
                       ctx@(CallContext yOffset ySize _ _ _ _) -> do
-                        let output = readMemory (num xOffset) (num ySize) vm
+                        let output = readMemory (num xOffset) (num xSize) vm
                         assign state (view frameState nextFrame)
 
                         -- Take back the remaining gas allowance


### PR DESCRIPTION
While capturing the returndata, it was the length from the `CALL` opcode, but not the length from the `RETURN` that was being used as the returndata length. It means that if a `CALL` was made with `outsize=0`, no returndata got saved so even subsequent `RETURNDATASIZE` and `RETURNDATACOPY` opcodes could not retrieve it.