### PR TITLE
Remove channel-based install instructions

### DIFF
--- a/src/hevm/README.md
+++ b/src/hevm/README.md
@@ -42,22 +42,8 @@ or you can enter the interactive debugger using
 
 ### Nix
 
-DappHub maintains a repository for the [Nix](https://nixos.org/nix/)
-package manager, which works on any Linux distribution, OS X, and
-other Unix-likes.
-
-These commands will install Nix, add the DappHub "channel", and
-install `hevm`. The channel has cached binaries for Linux and OS X.
-
-    $ curl https://nixos.org/nix/install | sh
-    $ nix-channel --add https://nix.dapphub.com/pkgs/dapphub
-    $ nix-channel --update
-    $ nix-env -iA dapphub.hevm
-
-This Nix channel can also be used to install
-[`dapp`](https://github.com/dapphub/dapp), our development tool:
-
-    $ nix-env -iA dapphub.dapp
+`hevm` is distributed as part of the [Dapp
+tools](https://github.com/dapphub/dapptools) suite.
 
 ### Static binary
 

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -86,30 +86,8 @@ Contents
 Installing
 ------------------------------------------------------------------------
 
-Seth is distributed via [the Nix package manager], enabling
-cryptographically precise dependency tracking.  First, install Nix
-itself:
-
-    $ curl https://nixos.org/nix/install | sh
-
-Then add DappHub's distribution channel and install `seth`:
-
-    $ nix-channel --add https://nix.dapphub.com/pkgs/dapphub
-    $ nix-channel --update
-    $ nix-env -iA dapphub.seth
-
-See [dapp.tools](https://dapp.tools) for more software available
-through our channel.
-
-### Upgrading
-
-To upgrade Seth to the latest release, update the channel and then
-reinstall:
-
-    $ nix-channel --update
-    $ nix-env -iA dapphub.seth
-
-<br />
+Seth is distributed as part of the [Dapp
+tools](https://github.com/dapphub/dapptools) suite.
 
 Configuration
 ------------------------------------------------------------------------


### PR DESCRIPTION
Instead, tell people to install as part of Dapp tools.