### PR TITLE
(re)enable cheat address

### DIFF
--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # hevm changelog
 
+## 0.19 - 2018-10-09
+- Enable experimental 'cheat' address, allowing for modification of the
+  EVM environment from within the tests. Currently just the block
+  timestamp can be adjusted.
+
 ## 0.18 - 2018-10-09
  - Fix [duplicate address bug](https://github.com/dapphub/dapptools/issues/70)
 

--- a/src/hevm/default.nix
+++ b/src/hevm/default.nix
@@ -11,7 +11,7 @@
 }:
 mkDerivation {
   pname = "hevm";
-  version = "0.18";
+  version = "0.19";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -1,7 +1,7 @@
 name:
   hevm
 version:
-  0.18
+  0.19
 synopsis:
   Ethereum virtual machine evaluator
 description:

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -871,6 +871,10 @@ exec1 = do
              ) ->
               case xTo of
                 n | n > 0 && n <= 8 -> precompiledContract
+                n | num n == cheatCode ->
+                  do
+                    assign (state . stack) xs
+                    cheat (xInOffset, xInSize) (xOutOffset, xOutSize)
                 _ ->
                   let
                     availableGas = the state gas
@@ -1169,6 +1173,9 @@ refund n = do
 -- * Cheat codes
 
 -- The cheat code is 7109709ecfa91a80626ff3989d68f67f5b1dd12d.
+-- Call this address using one of the cheatActions below to do
+-- special things, e.g. changing the block timestamp. Beware that
+-- these are necessarily hevm specific.
 cheatCode :: Addr
 cheatCode = num (keccak "hevm cheat code")
 


### PR DESCRIPTION
Experimental feature. This allows for setting the block timestamp from
within ds-test.

This feature should be used carefully as it is hevm specific and
prevents your ds-tests from running on arbitrary EVM implementations.

Usage:

```
hevm = Hevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
hevm.warp(42);
```

where

```
contract Hevm {
    function warp(uint256) public;
}
```