### PR TITLE
dapp: add changelog

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.9.0] - 2018-12-04
+
+From this release on, we will document changes, additions and removals in this
+changelog.
+
+[0.9.0]: https://github.com/dapphub/dapptools/tree/dapp/0.9.0


### PR DESCRIPTION
Adds an empty changelog, as it doesn't make sense to list any features, since this is the first release with a changelog, and we'd have to list them all under "Added".