### PR TITLE
enable hevm traces on passing unit tests

### DIFF
--- a/src/dapp/default.nix
+++ b/src/dapp/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   name = "dapp-${version}";
-  version = "0.9.0";
+  version = "0.9.1";
   src = ./.;
 
   nativeBuildInputs = [makeWrapper shellcheck coreutils];

--- a/src/dapp/libexec/dapp/dapp---version
+++ b/src/dapp/libexec/dapp/dapp---version
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo dapp 0.9.0
+echo dapp 0.9.1
 solc --version

--- a/src/dapp/libexec/dapp/dapp-test-hevm
+++ b/src/dapp/libexec/dapp/dapp-test-hevm
@@ -9,6 +9,9 @@ while [[ $# -gt 0 ]]; do
     -r|--regex)
       opts+=(--match "$1"); shift
       ;;
+    -v|--verbose)
+      opts+=(--verbose);
+      ;;
     *)
       echo >&2 "dapp-test-hevm: unknown argument: $opt"
       exit 1

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -1,5 +1,8 @@
 # hevm changelog
 
+## 0.23 - 2018-12-12
+ - Show passing test traces with --verbose flag
+
 ## 0.22 - 2018-11-13
  - Simple memory view in TTY
 

--- a/src/hevm/default.nix
+++ b/src/hevm/default.nix
@@ -11,7 +11,7 @@
 }:
 mkDerivation {
   pname = "hevm";
-  version = "0.22";
+  version = "0.23";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -1,7 +1,7 @@
 name:
   hevm
 version:
-  0.22
+  0.23
 synopsis:
   Ethereum virtual machine evaluator
 description:


### PR DESCRIPTION
With this change:

- `dapp test`: shows traces for failing tests
- `dapp test --verbose`: also show traces for passing tests

Also, emit raw event data in the case of anonymous events (e.g. ds-note).

@gbalabasquer @nanexcool :)