### PR TITLE
--signature-only feature added for tx to return signature only

### DIFF
--- a/src/ethsign/ethsign.go
+++ b/src/ethsign/ethsign.go
@@ -158,7 +158,7 @@ func main() {
 					Usage: "make a contract creation transaction",
 				},
 				cli.BoolFlag{
-					Name: "signature-only",
+					Name: "sig",
 					Usage: "create the signature only",
 				},
 				cli.StringFlag{
@@ -339,7 +339,7 @@ func main() {
 					return cli.NewExitError("ethsign: failed to sign tx", 1)
 				}
 
-				signature := c.Bool("signature-only")
+				signature := c.Bool("sig")
 				if(signature){
 					v, r, s := signed.RawSignatureValues()
 					fmt.Println(fmt.Sprintf("0x%064x%064x%02x", r, s, v))

--- a/src/ethsign/ethsign.go
+++ b/src/ethsign/ethsign.go
@@ -157,6 +157,10 @@ func main() {
 					Name: "create",
 					Usage: "make a contract creation transaction",
 				},
+				cli.BoolFlag{
+					Name: "signature-only",
+					Usage: "create the signature only",
+				},
 				cli.StringFlag{
 					Name: "from",
 					Usage: "address of signing account",
@@ -329,15 +333,20 @@ func main() {
 				} else {
 					tx = types.NewTransaction(nonce, to, value, gasLimit, gasPrice, data)
 				}
-				
+
 				signed, err := wallet.SignTxWithPassphrase(*acct, passphrase, tx, chainID)
 				if err != nil {
 					return cli.NewExitError("ethsign: failed to sign tx", 1)
 				}
 
-				encoded, _ := rlp.EncodeToBytes(signed)
-				fmt.Println(hexutil.Encode(encoded[:]))
-				
+				signature := c.Bool("signature-only")
+				if(signature){
+					v, r, s := signed.RawSignatureValues()
+					fmt.Println(fmt.Sprintf("0x%064x%064x%02x", r, s, v))
+				}else{
+					encoded, _ := rlp.EncodeToBytes(signed)
+					fmt.Println(hexutil.Encode(encoded[:]))
+				}
 				return nil
 			},
 		},


### PR DESCRIPTION
This request enables to use the feature `ethsign tx --signature-only ...` to only return the signature , and not the whole raw tx data. This enables us to use ethsign with Metamasks new external signing feature.