### PR TITLE
seth: pass current solidity version to seth-abi

### DIFF
--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.7.0] - 2018-12-14
+
+From this release on, changes, additions and removals will be documented in this
+changelog.
+
+### Changed
+- `seth abi`: use the current `solc` version in the `pragma` directive.
+[#99](https://github.com/dapphub/dapptools/pull/99)
+
+[0.7.0]: https://github.com/dapphub/dapptools/tree/seth/0.7.0

--- a/src/seth/libexec/seth/seth---version
+++ b/src/seth/libexec/seth/seth---version
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 cat <<.
-seth 0.6.3
+seth 0.7.0
 Copyright (C) 2016, 2017  Daniel Brockman <daniel@dapphub.com>
 License: GNU GPL version 3 or later <https://gnu.org/licenses/gpl>.
 This is free software: you are free to change and redistribute it.

--- a/src/seth/libexec/seth/seth-abi
+++ b/src/seth/libexec/seth/seth-abi
@@ -2,8 +2,14 @@
 ### seth-abi -- convert an ABI from Solidity syntax to JSON form
 ### Usage: seth abi <solidity-fragment>
 set -e
+
+solc_version=$(solc --version)
+solc_version=$(<<<"$solc_version" grep ^Version:)
+solc_version=${solc_version#* }
+solc_version=${solc_version%%+*}
+
 [[ $1 ]] || seth --fail-usage "$0"
-input="pragma solidity >=0.4.8; contract A { $1 }"
+input="pragma solidity ^${solc_version}; contract A { $1 }"
 json=$(solc --combined-json=abi - <<<"$input")
 # Changed from "A" to "<stdin>:A" in solc 0.4.10:
 name=$(jshon <<<"$json" -e contracts -k)


### PR DESCRIPTION
This way, we don't have to update it manually whenever there are new,
backwards-incompatible solc releases.

See #82 and the fix in eee3859cc155e6e89e99bc16139ad72adbc3e5fc.