### PR TITLE
Emacs srcmap fix

### DIFF
--- a/src/hevm/hevm.el
+++ b/src/hevm/hevm.el
@@ -167,6 +167,12 @@ and send it as input.")
        (fit-window-to-buffer)
        (other-window 1)))
 
+    ;; Incoming new VM step information without srcmap
+    (`(step (vm ,vm))
+     (hevm-update vm)
+     (hevm-highlight-source-region 0 0 'JumpRegular)
+     (message "No srcmap!"))
+
     ;; We sent some command that Hevm didn't understand.
     ('(unrecognized-command)
      (error "Unrecognized Hevm input command."))

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -305,7 +305,7 @@ outputVm = do
     noMap =
       output $
         L [ A "step"
-          , L [A ("pc" :: Text), A (txt (view (uiVm . state . pc) s))]]
+        , L [A ("vm" :: Text), sexp (view uiVm s)]]
 
   fromMaybe noMap $ do
     dapp <- view uiVmDapp s


### PR DESCRIPTION
Currently, on steps with no srcmap, `hevm emacs` omits not only the srcmap-related data but also all VM data except for the `pc`, for some reason. I changed it to only omit the data that is actually missing, so that on steps where there is no source, `hevm.el` can update the stack, clear the source overlay, and display `No srcmap!` in the minibuffer. This behaviour is more or less consistent with what `hevm interactive` does when the srcmap is missing.

Perhaps this fails on some edge cases but I wasn't able to find them...

(fixes #113 )