### PR TITLE
Add support for solc 0.5.3

### DIFF
--- a/nix/solc/patches/post-0.5.3.patch
+++ b/nix/solc/patches/post-0.5.3.patch
@@ -1,0 +1,75 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 399dd9df..44a5c53d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,6 +51,22 @@ add_subdirectory(libyul)
+ add_subdirectory(libsolidity)
+ add_subdirectory(libsolc)
+ 
++install(DIRECTORY libdevcore/
++	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libdevcore
++	FILES_MATCHING PATTERN "*.h")
++install(DIRECTORY libevmasm/
++	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libevmasm
++	FILES_MATCHING PATTERN "*.h")
++install(DIRECTORY libsolidity/
++	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libsolidity
++	FILES_MATCHING PATTERN "*.h")
++install(DIRECTORY libyul/
++	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libyul
++	FILES_MATCHING PATTERN "*.h")
++install(DIRECTORY liblangutil/
++	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/liblangutil
++	FILES_MATCHING PATTERN "*.h")
++
+ if (NOT EMSCRIPTEN)
+ 	add_subdirectory(solc)
+ 	if (LLL)
+diff --git a/libdevcore/CMakeLists.txt b/libdevcore/CMakeLists.txt
+index e68ac10a..a344c6bd 100644
+--- a/libdevcore/CMakeLists.txt
++++ b/libdevcore/CMakeLists.txt
+@@ -34,3 +34,4 @@ target_link_libraries(devcore PUBLIC jsoncpp ${Boost_FILESYSTEM_LIBRARIES} ${Boo
+ target_include_directories(devcore PUBLIC "${CMAKE_SOURCE_DIR}")
+ target_include_directories(devcore SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+ add_dependencies(devcore solidity_BuildInfo.h)
++install(TARGETS devcore LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+diff --git a/libevmasm/CMakeLists.txt b/libevmasm/CMakeLists.txt
+index 42679938..513cec66 100644
+--- a/libevmasm/CMakeLists.txt
++++ b/libevmasm/CMakeLists.txt
+@@ -37,3 +37,4 @@ set(sources
+ 
+ add_library(evmasm ${sources})
+ target_link_libraries(evmasm PUBLIC devcore)
++install(TARGETS evmasm LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+diff --git a/liblangutil/CMakeLists.txt b/liblangutil/CMakeLists.txt
+index b172108b..d377c0e6 100644
+--- a/liblangutil/CMakeLists.txt
++++ b/liblangutil/CMakeLists.txt
+@@ -23,3 +23,4 @@ set(sources
+ 
+ add_library(langutil ${sources})
+ target_link_libraries(langutil PUBLIC devcore)
++install(TARGETS langutil LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+diff --git a/libsolidity/CMakeLists.txt b/libsolidity/CMakeLists.txt
+index 8c2ab347..8b019e3c 100644
+--- a/libsolidity/CMakeLists.txt
++++ b/libsolidity/CMakeLists.txt
+@@ -127,6 +127,7 @@ endif()
+ 
+ add_library(solidity ${sources} ${z3_SRCS} ${cvc4_SRCS})
+ target_link_libraries(solidity PUBLIC yul evmasm langutil devcore ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
++install(TARGETS solidity LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
+ if (${Z3_FOUND})
+   target_link_libraries(solidity PUBLIC Z3::Z3)
+diff --git a/libyul/CMakeLists.txt b/libyul/CMakeLists.txt
+index 52c4ac8e..0f634c6d 100644
+--- a/libyul/CMakeLists.txt
++++ b/libyul/CMakeLists.txt
+@@ -96,3 +96,4 @@ add_library(yul
+ 	optimiser/VarDeclInitializer.h
+ )
+ target_link_libraries(yul PUBLIC evmasm devcore langutil)
++install(TARGETS yul LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/nix/solc/post-0.5.3.nix
+++ b/nix/solc/post-0.5.3.nix
@@ -1,0 +1,56 @@
+version: rev: sha256:
+{ stdenv, fetchzip, fetchFromGitHub, boost, cmake, z3 }:
+
+let
+  version = "0.5.3";
+  rev = "10d17f245839f208ec5085309022a32cd2502f55";
+  sha256 = "1jq41pd3nj534cricy1nq6wgk4wlwg239387n785aswpwd705jbb";
+  jsoncppURL = https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz;
+  jsoncpp = fetchzip {
+    url = jsoncppURL;
+    sha256 = "1z0gj7a6jypkijmpknis04qybs1hkd04d1arr3gy89lnxmp6qzlm";
+  };
+in
+stdenv.mkDerivation {
+  name = "solc-${version}";
+
+  src = fetchFromGitHub {
+    owner = "ethereum";
+    repo = "solidity";
+    inherit rev sha256;
+  };
+
+  patches = [
+    ./patches/post-0.5.3.patch
+  ];
+
+  postPatch = ''
+    touch prerelease.txt
+    echo >commit_hash.txt "${rev}"
+    substituteInPlace cmake/jsoncpp.cmake \
+      --replace "${jsoncppURL}" ${jsoncpp}
+  '';
+
+  cmakeFlags = [
+    "-DBoost_USE_STATIC_LIBS=OFF"
+    "-DBUILD_SHARED_LIBS=ON"
+  ];
+
+  doCheck = stdenv.hostPlatform.isLinux && stdenv.hostPlatform == stdenv.buildPlatform;
+  checkPhase = "LD_LIBRARY_PATH=./libsolc:./libsolidity:./liblll:./libevmasm:./libdevcore:./libyul:./liblangutil:$LD_LIBRARY_PATH " +
+               "./test/soltest -p -- --no-ipc --no-smt --testpath ../test";
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost z3 ];
+
+  outputs = [ "out" "dev" ];
+
+  meta = with stdenv.lib; {
+    description = "Compiler for Ethereum smart contract language Solidity";
+    homepage = https://github.com/ethereum/solidity;
+    license = licenses.gpl3;
+    platforms = with platforms; linux ++ darwin;
+    maintainers = with maintainers; [ dbrock akru ];
+    inherit version;
+  };
+}

--- a/nix/solc/versions.nix
+++ b/nix/solc/versions.nix
@@ -4,6 +4,7 @@ let
    mk3 = import ./post-0.4.24.nix;
    mk4 = import ./post-0.5.1.nix;
    mk5 = import ./post-0.5.2.nix;
+   mk6 = import ./post-0.5.3.nix;
 in {
 
   ## I looked up the hashes for all the older versions, but prior to
@@ -65,4 +66,5 @@ in {
   solc_0_5_0  = mk3 "0.5.0"   "1d4f565a64988a3400847d2655ca24f73f234bc6" "0phzk2whvgrrf8xpl5pz886glhd5s40y1hbbvq9q3fxf6vc3lisy";
   solc_0_5_1  = mk4 "0.5.1"   "c8a2cb62832afb2dc09ccee6fd42c1516dfdb981" "0d6mfnixlr9m5yr3r4p6cv6vwrrivcamyar5d0f9rvir9w9ypzrr";
   solc_0_5_2  = mk5 "0.5.2"   "1df8f40cd2fd7b47698d847907b8ca7b47eb488d" "009kjyb3r2p64wpdzfcmqr9swm5haaixbzvsbw1nd4wipwbp66y0";
+  solc_0_5_3  = mk6 "0.5.3"   "10d17f245839f208ec5085309022a32cd2502f55" "1jq41pd3nj534cricy1nq6wgk4wlwg239387n785aswpwd705jbb";
 }

--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2018-02-02
+### Added
+- Support for solc 0.5.3
+
 ## [0.10.0] - 2018-01-24
 ### Changed
 - Default to running solc 0.5.2
@@ -29,3 +33,4 @@ changelog.
 [0.9.1]: https://github.com/dapphub/dapptools/tree/dapp/0.9.1
 [0.9.2]: https://github.com/dapphub/dapptools/tree/dapp/0.9.2
 [0.10.0]: https://github.com/dapphub/dapptools/tree/dapp/0.10.0
+[0.10.0]: https://github.com/dapphub/dapptools/tree/dapp/0.10.1

--- a/src/dapp/default.nix
+++ b/src/dapp/default.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   name = "dapp-${version}";
-  version = "0.9.1";
+  version = "0.10.1";
   src = ./.;
 
   nativeBuildInputs = [makeWrapper shellcheck coreutils];

--- a/src/dapp/libexec/dapp/dapp---version
+++ b/src/dapp/libexec/dapp/dapp---version
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo dapp 0.9.1
+echo dapp 0.10.1
 solc --version


### PR DESCRIPTION
This can be simplified, since solc 0.5.2 and 0.5.3 use the exact same patch, so ideally we'd have them both be `mk5` in versions, instead of what I did that was have 2 patches and 2 nix versions.