### PR TITLE
Bump NixOS version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,13 @@
 { system ? null , ... }:
 let
-  version = "18.09";
+  # this is a branch rather than a tag
+  version = "release-18.09";
   # Import a specific Nixpkgs revision to use as the base for our overlay.
   nixpkgs = builtins.fetchTarball {
     name = "nixpkgs-${version}";
-    url = "https://github.com/nixos/nixpkgs/archive/${version}.tar.gz";
-    sha256 = "1ib96has10v5nr6bzf7v8kw7yzww8zanxgw2qi1ll1sbv6kj6zpd";
+    # pin the current release-18.09 commit
+    url = "https://github.com/nixos/nixpkgs/archive/185ab27b8a2ff2c7188bc29d056e46b25dd56218.tar.gz";
+    sha256 = "0bflmi7w3gas9q8wwwwbnz79nkdmiv2c1bpfc3xyplwy8npayxh2";
   };
 in
   # Now return the Nixpkgs configured to use our overlay.


### PR DESCRIPTION
Go 1.9 has been deprecated ([0][], [1][]) for security reasons, making the overlay difficult to use with more recent versions of nixpkgs.

[0]: https://github.com/NixOS/nixpkgs/commit/a687ef973990cbde6dd350a8db54deb86a4c5d83#diff-501e4080c647067030adbce370423f53
[1]:
https://github.com/NixOS/nixpkgs/commit/d32e779ae850a7053218ebc6d99d34a3f2e6eed3#diff-501e4080c647067030adbce370423f53