### PR TITLE
solc: make z3 support optional, but defaulted true

### DIFF
--- a/nix/solc/post-0.5.2.nix
+++ b/nix/solc/post-0.5.2.nix
@@ -1,5 +1,9 @@
 version: rev: sha256:
-{ stdenv, fetchzip, fetchFromGitHub, boost, cmake, z3 }:
+{ stdenv, fetchzip, fetchFromGitHub, boost, cmake,
+  z3Support ? true, z3 ? null
+}:
+
+assert z3Support -> z3 != null;
 
 let
   jsoncppURL = https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz;
@@ -31,14 +35,17 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-DBoost_USE_STATIC_LIBS=OFF"
     "-DBUILD_SHARED_LIBS=ON"
+  ] ++ stdenv.lib.optionals (!z3Support) [
+    "-DUSE_Z3=OFF"
   ];
+
 
   doCheck = stdenv.hostPlatform.isLinux && stdenv.hostPlatform == stdenv.buildPlatform;
   checkPhase = "LD_LIBRARY_PATH=./libsolc:./libsolidity:./liblll:./libevmasm:./libdevcore:./libyul:./liblangutil:$LD_LIBRARY_PATH " +
                "./test/soltest -p -- --no-ipc --no-smt --testpath ../test";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ boost z3 ];
+  buildInputs = [ boost ] ++ stdenv.lib.optionals z3Support [ z3 ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
It's an [optional flag](https://solidity.readthedocs.io/en/latest/installing-solidity.html#smt-solvers), and we don't need it in the dss deployment scripts.