### PR TITLE
dapp: add gnumake as a dependency

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2019-02-22
+
+### Fixed
+- Fix missing runtime dependency to `gnumake` in `dapp`.
+
 ## [0.13.0] - 2018-02-04
 ### Added
 - Support for solc 0.5.4
@@ -48,3 +53,4 @@ changelog.
 [0.11.0]: https://github.com/dapphub/dapptools/tree/dapp/0.11.0
 [0.12.0]: https://github.com/dapphub/dapptools/tree/dapp/0.12.0
 [0.13.0]: https://github.com/dapphub/dapptools/tree/dapp/0.13.0
+[0.14.0]: https://github.com/dapphub/dapptools/tree/dapp/0.14.0

--- a/src/dapp/default.nix
+++ b/src/dapp/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper, glibcLocales
-, coreutils, git, gnused, hevm, jshon, jq, nix, nodejs, perl, seth, shellcheck, solc }:
+, coreutils, git, gnused, gnumake, hevm, jshon, jq, nix
+, nodejs, perl, seth , shellcheck , solc }:
 
 stdenv.mkDerivation rec {
   name = "dapp-${version}";
@@ -12,7 +13,7 @@ stdenv.mkDerivation rec {
   checkPhase = "make test";
   makeFlags = ["prefix=$(out)"];
   postInstall = let path = lib.makeBinPath [
-    coreutils git gnused hevm jshon jq nix nodejs perl seth solc
+    coreutils git gnused gnumake hevm jshon jq nix nodejs perl seth solc
   ]; in ''
     wrapProgram "$out/bin/dapp" --prefix PATH : "${path}" \
       ${if glibcLocales != null then

--- a/src/dapp/default.nix
+++ b/src/dapp/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   name = "dapp-${version}";
-  version = "0.13.0";
+  version = "0.14.0";
   src = ./.;
 
   nativeBuildInputs = [makeWrapper shellcheck coreutils nodejs];


### PR DESCRIPTION
it's used by dapp-init.

Closes #111.