### PR TITLE
nix: fix dapp-use for unreleased solc versions

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -116,8 +116,9 @@ in rec {
           repo = "nixpkgs";
         }) {}).solc;
       in
-        fetchNixpkgs { owner = "NixOS"; attr = super.system; }
-        // { unreleased = fetchNixpkgs { owner = "dapphub"; attr = "unreleased"; }; };
+        fetchNixpkgs { owner = "NixOS";   attr = super.system; }
+        //
+        fetchNixpkgs { owner = "dapphub"; attr = "unreleased"; };
   solc = solc-versions.solc_0_5_3;
 
   hevm = self.pkgs.haskell.lib.justStaticExecutables self.haskellPackages.hevm;


### PR DESCRIPTION
Before this patch, unreleased versions were under
`solc-versions.unreleased`.

dapp-use though expects all solc versions to be under the `solc-versions`
attribute.