### PR TITLE
attempt to add spacing, tabs and colors to test output

### DIFF
--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -428,13 +428,13 @@ runUnitTestContract
                      (fromIntegral gasSpent :: Integer)
                in
                  pure
-                   ( "\t\x1b[32mPASS\x1b[0m " <> testName <> " (gas: " <> gasText <> ")"
+                   ( "\x1b[32mPASS\x1b[0m " <> testName <> " (gas: " <> gasText <> ")"
                    , Right (passOutput vm dapp opts testName)
                    )
              (Right False, vm) ->
-               pure ("\t\x1b[91mFAIL\x1b[0m " <> testName, Left (failOutput vm dapp opts testName))
+               pure ("\x1b[91mFAIL\x1b[0m " <> testName, Left (failOutput vm dapp opts testName))
              (Left _, _)       ->
-               pure ("\t\x1b[41;1mOOPS\x1b[0m " <> testName, Left ("VM error for " <> testName))
+               pure ("\x1b[41;1mOOPS\x1b[0m " <> testName, Left ("VM error for " <> testName))
 
       let inform = \(x, y) -> Text.putStrLn x >> pure y
 

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -389,6 +389,7 @@ runUnitTestContract
   opts@(UnitTestOptions {..}) contractMap sources (name, testNames) = do
 
   -- Print a header
+  putStrLn "\n\n----------------------------------------------------------------------------------"
   putStrLn $ "Running " ++ show (length testNames) ++ " tests for "
     ++ unpack name
 
@@ -427,13 +428,13 @@ runUnitTestContract
                      (fromIntegral gasSpent :: Integer)
                in
                  pure
-                   ( "PASS " <> testName <> " (gas: " <> gasText <> ")"
+                   ( "\t\x1b[32mPASS\x1b[0m " <> testName <> " (gas: " <> gasText <> ")"
                    , Right (passOutput vm dapp opts testName)
                    )
              (Right False, vm) ->
-               pure ("FAIL " <> testName, Left (failOutput vm dapp opts testName))
+               pure ("\t\x1b[91mFAIL\x1b[0m " <> testName, Left (failOutput vm dapp opts testName))
              (Left _, _)       ->
-               pure ("OOPS " <> testName, Left ("VM error for " <> testName))
+               pure ("\t\x1b[41;1mOOPS\x1b[0m " <> testName, Left ("VM error for " <> testName))
 
       let inform = \(x, y) -> Text.putStrLn x >> pure y
 


### PR DESCRIPTION
Goal:
Add some minor formatting improvements to `dapp test` outputs. Specifically, add a couple of line breaks and a visual separator at the beginning of the tests.  Also indent each test result by one tab and add appropriate colors to `PASS`, `FAIL`, and `OOPS`