### PR TITLE
ethsign: add no-prefix flag

### DIFF
--- a/src/ethsign/CHANGELOG
+++ b/src/ethsign/CHANGELOG
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2019-03-25
+
+### Changed
+
+- add flag no-prefix to sign a message without the "Begin Ethereum Message" prefix.
+
+[0.12.0]: https://github.com/dapphub/dapptools/tree/ethsign/0.11.0
+
 ## [0.11.0] - 2019-02-20
 
 ### Changed

--- a/src/ethsign/default.nix
+++ b/src/ethsign/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "ethsign-${version}";
-  version = "0.11.0";
+  version = "0.12.0";
 
   goPackagePath = "github.com/dapphub/ethsign";
   hardeningDisable = ["fortify"];


### PR DESCRIPTION
Adds a flag to sign message without the sacred prefix `\x19Ethereum Signed Message:\n`
Read https://github.com/ethereum/go-ethereum/pull/2940 or https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md for additional context