### PR TITLE
More control over hevm test output

### DIFF
--- a/src/dapp/libexec/dapp/dapp-test-hevm
+++ b/src/dapp/libexec/dapp/dapp-test-hevm
@@ -9,8 +9,11 @@ while [[ $# -gt 0 ]]; do
     -r|--regex)
       opts+=(--match "$1"); shift
       ;;
+    -vv)
+      opts+=(--verbose 2);
+      ;;
     -v|--verbose)
-      opts+=(--verbose);
+      opts+=(--verbose 1);
       ;;
     *)
       echo >&2 "dapp-test-hevm: unknown argument: $opt"

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # hevm changelog
 
+## 0.30 - 2019-05-09
+ - Adjustable verbosity level for `dapp-test` with `--verbose={0,1,2}`
+ - Working stack build
+
 ## 0.29 - 2019-04-03
  - Significant jump in compliance with client tests
  - Add support for running GeneralStateTests

--- a/src/hevm/default.nix
+++ b/src/hevm/default.nix
@@ -12,7 +12,7 @@
 }:
 mkDerivation {
   pname = "hevm";
-  version = "0.29";
+  version = "0.30";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -90,7 +90,7 @@ data Command
       , dappRoot           :: Maybe String
       , debug              :: Bool
       , rpc                :: Maybe URL
-      , verbose            :: Bool
+      , verbose            :: Maybe Int
       , coverage           :: Bool
       , state              :: Maybe String
       , match              :: Maybe String

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -1,7 +1,7 @@
 name:
   hevm
 version:
-  0.29
+  0.30
 synopsis:
   Ethereum virtual machine evaluator
 description:

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -40,7 +40,7 @@ ghciTest root path state =
     let
       opts = UnitTestOptions
         { oracle = EVM.Fetch.zero
-        , verbose = False
+        , verbose = Nothing
         , match = ""
         , vmModifier = loadFacts
         , testParams = params
@@ -67,7 +67,7 @@ ghciTty root path state =
     let
       testOpts = UnitTestOptions
         { oracle = EVM.Fetch.zero
-        , verbose = False
+        , verbose = Nothing
         , match = ""
         , vmModifier = loadFacts
         , testParams = params

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -471,7 +471,7 @@ defaultUnitTestOptions = do
   params <- liftIO getParametersFromEnvironmentVariables
   pure UnitTestOptions
     { oracle            = Fetch.zero
-    , verbose           = False
+    , verbose           = Nothing
     , match             = ""
     , vmModifier        = id
     , testParams        = params

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -268,7 +268,7 @@ runFromVM vm = do
 
     testOpts = UnitTestOptions
       { oracle            = Fetch.zero
-      , verbose           = False
+      , verbose           = Nothing
       , match             = ""
       , vmModifier        = id
       , testParams        = error "irrelevant"


### PR DESCRIPTION
Modifies the `dapp test` output, hiding the trace by default and allowing showing the trace for passing tests.

- `dapp test`: only assertion failures for failing tests
- `dapp test -v`: full trace for failing tests
- `dapp test -vv`: full trace for all tests

Also, display unknown event output in `logn` binary form, including topics.

Fixes #159