### PR TITLE
seth: fix SC2207 by using the read builtin

### DIFF
--- a/src/seth/libexec/seth/seth-call
+++ b/src/seth/libexec/seth/seth-call
@@ -20,8 +20,8 @@ DATA=$(seth calldata "${@:2}")
 jshon+=(-n {})
 jshon+=(-s "$TO"   -i to)
 jshon+=(-s "$DATA" -i data)
-# shellcheck disable=SC2207
-jshon+=($(seth --send-params))
+IFS=" " read -r -a params <<< "$(seth --send-params)"
+jshon+=( "${params[@]}" )
 jshon+=(-i append)
 [[ $ETH_BLOCK = [0-9]* ]] && ETH_BLOCK=$(seth --to-hex "$ETH_BLOCK")
 jshon+=(-s "${ETH_BLOCK-latest}" -i append)

--- a/src/seth/libexec/seth/seth-estimate
+++ b/src/seth/libexec/seth/seth-estimate
@@ -32,8 +32,8 @@ fi
 jshon+=(-n {})
 [[ $TO ]] && jshon+=(-s "$TO" -i to)
 jshon+=(-s "$DATA" -i data)
-# shellcheck disable=SC2207
-jshon+=($(seth --send-params))
+IFS=" " read -r -a params <<< "$(seth --send-params)"
+jshon+=( "${params[@]}" )
 jshon+=(-i append)
 : "${ETH_BLOCK:=latest}" # geth doesn't like this argument
 [[ $ETH_BLOCK = latest ]] || jshon+=(-s "$ETH_BLOCK" -i append)

--- a/src/seth/libexec/seth/seth-send
+++ b/src/seth/libexec/seth/seth-send
@@ -49,8 +49,8 @@ fi
 jshon+=(-n {})
 [[ $TO ]] && jshon+=(-s "$TO" -i to)
 [[ $DATA ]] && jshon+=(-s "$DATA" -i data)
-# shellcheck disable=SC2207
-jshon+=($(seth --send-params))
+IFS=" " read -r -a params <<< "$(seth --send-params)"
+jshon+=( "${params[@]}" )
 jshon+=(-i append)
 
 if [[ -z $ETH_RPC_ACCOUNTS ]]; then


### PR DESCRIPTION
The output of `seth---send-params` is a space-separated list of words on
one line, rather than on multiple lines, so mapfile followed by `$params[@]` was
outputting a quoted string, which broke json parsing.

Closes #180.

/cc @nanexcool @icetan @kmbarry1