### PR TITLE
hevm: add version subcommand

### DIFF
--- a/src/hevm/default.nix
+++ b/src/hevm/default.nix
@@ -4,9 +4,9 @@
 , fgl, filepath, ghci-pretty, haskeline, here, HUnit, lens
 , lens-aeson, megaparsec, memory, monad-par, mtl, multiset
 , operational, optparse-generic, process, QuickCheck
-, quickcheck-text, regex-tdfa, restless-git, rosezipper
-, s-cargot, scientific, secp256k1, semver-range, stdenv, tasty
-, tasty-hunit, tasty-quickcheck, temporary, text, text-format, time
+, quickcheck-text, regex-tdfa, restless-git, rosezipper, s-cargot
+, scientific, secp256k1, semver-range, stdenv, tasty, tasty-hunit
+, tasty-quickcheck, temporary, text, text-format, time
 , transformers, tree-view, unordered-containers, vector, vty
 , witherable, wreq
 }:
@@ -23,18 +23,17 @@ mkDerivation {
     cryptonite data-dword deepseq directory fgl filepath ghci-pretty
     haskeline lens lens-aeson megaparsec memory monad-par mtl multiset
     operational optparse-generic process QuickCheck quickcheck-text
-    restless-git rosezipper s-cargot scientific semver-range
-    temporary text text-format time transformers tree-view
-    unordered-containers vector vty witherable wreq
+    restless-git rosezipper s-cargot scientific semver-range temporary
+    text text-format time transformers tree-view unordered-containers
+    vector vty witherable wreq
   ];
   librarySystemDepends = [ secp256k1 ];
   executableHaskellDepends = [
     aeson ansi-wl-pprint async base base16-bytestring base64-bytestring
     binary brick bytestring containers cryptonite data-dword deepseq
     directory filepath ghci-pretty lens lens-aeson memory mtl
-    optparse-generic process QuickCheck quickcheck-text
-    regex-tdfa temporary text text-format unordered-containers vector
-    vty
+    optparse-generic process QuickCheck quickcheck-text regex-tdfa
+    temporary text text-format unordered-containers vector vty
   ];
   testHaskellDepends = [
     base base16-bytestring binary bytestring ghci-pretty here HUnit

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -338,6 +338,7 @@ launchTest execmode cmd = do
   let parser = case execmode of
         ExecuteAsVMTest -> VMTest.parseSuite
         ExecuteAsBlockchainTest -> VMTest.parseBCSuite
+        ExecuteNormally -> error "cannot launchTest normally"
   parsed <- parser <$> LazyByteString.readFile (file cmd)
   case parsed of
      Left err -> print err
@@ -362,6 +363,7 @@ runVMTest diffmode execmode mode (name, x) = do
       -- whether or not to "finalize the tx"
       ExecuteAsVMTest -> void EVM.Stepper.execFully >> EVM.Stepper.evm (EVM.finalize False)
       ExecuteAsBlockchainTest -> void EVM.Stepper.execFully >> EVM.Stepper.evm (EVM.finalize True)
+      ExecuteNormally -> error "cannot launchTest normally"
   putStr (name ++ " ")
   hFlush stdout
   result <- do

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -46,6 +46,7 @@ import Data.ByteString            (ByteString)
 import Data.List                  (intercalate, isSuffixOf)
 import Data.Text                  (Text, unpack, pack)
 import Data.Maybe                 (fromMaybe)
+import Data.Version               (showVersion)
 import System.Directory           (withCurrentDirectory, listDirectory)
 import System.Exit                (die, exitFailure)
 import System.IO                  (hFlush, stdout)
@@ -122,6 +123,7 @@ data Command
     , dappRoot   :: Maybe String
     }
   | Emacs
+  | Version
   deriving (Show, Options.Generic, Eq)
 
 type URL = Text
@@ -162,6 +164,7 @@ main = do
   let
     root = fromMaybe "." (dappRoot cmd)
   case cmd of
+    Version {} -> putStrLn (showVersion Paths.version)
     Exec {} ->
       launchExec cmd
     VmTest {} ->

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -59,7 +59,8 @@ library
     EVM.TTYCenteredList,
     EVM.Types,
     EVM.UnitTest,
-    EVM.VMTest,
+    EVM.VMTest
+  other-modules:
     Paths_hevm
   ghc-options:
     -Wall -Wno-deprecations
@@ -143,6 +144,8 @@ executable hevm
     hevm-cli.hs
   ghc-options:
     -Wall -threaded -with-rtsopts=-N
+  other-modules:
+    Paths_hevm
   build-depends:
     QuickCheck                        >= 2.9,
     aeson                             >= 1.0,


### PR DESCRIPTION
```
$ hevm version
0.30
```

Not sure if `--version` is preferable, or even how to get optparse-generic to do that.