### PR TITLE
Add `solc --allow-paths` flag for nix store paths in `solidityPackage` builder

### DIFF
--- a/nix/solidity-package.sh
+++ b/nix/solidity-package.sh
@@ -11,9 +11,9 @@ find "$DAPP_SRC" -name '*.sol' | while read -r x; do
   dir=${dir#$DAPP_SRC}
   dir=${dir#/}
   mkdir -p "$DAPP_OUT/$dir"
-  (set -x; solc --overwrite $REMAPPINGS --abi --bin --bin-runtime -o "$DAPP_OUT/$dir" "$x")
+  (set -x; solc --overwrite $REMAPPINGS --allow-paths $DAPP_SRC --abi --bin --bin-runtime -o "$DAPP_OUT/$dir" "$x")
   json_file=$DAPP_OUT/$dir/${x##*/}.json
-  (set -x; solc $REMAPPINGS $jsonopts "$x" >"$json_file")
+  (set -x; solc $REMAPPINGS --allow-paths $DAPP_SRC $jsonopts "$x" >"$json_file")
 done
 
 mkdir lib


### PR DESCRIPTION
To fix `Source “<filename>” not found: File outside of allowed directories.` problem when using `solidityPackage` with `deps`.