### PR TITLE
Add `solc` argument to `solidityPackage`

### DIFF
--- a/nix/solidity-package.nix
+++ b/nix/solidity-package.nix
@@ -15,9 +15,9 @@
          xs);
 in
   pkgs.lib.makeOverridable (
-    attrs @ { test ? true, deps ? [], ... }:
+    attrs @ { test ? true, deps ? [], solc ? pkgs.solc, ... }:
       pkgs.stdenv.mkDerivation (rec {
-        buildInputs = [pkgs.dapp2.test-hevm pkgs.solc];
+        buildInputs = [pkgs.dapp2.test-hevm solc];
         passthru = {
           remappings = remappings deps;
           libPaths = libPaths deps;


### PR DESCRIPTION
To allow for inversion of control of which version of `solc` to compile with.

This is useful when you need to provide a version of `solc` other then the current default one so that you can comply with the pragma of the contracts you want to compile.