### PR TITLE
IDENTITY, SHA256, RIPEMD160 precompile

### DIFF
--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -368,7 +368,7 @@ runVMTest diffmode execmode mode (name, x) = do
     action <- async $
       case mode of
         Run ->
-          timeout (1e6) . evaluate $ do
+          timeout (1e7) . evaluate $ do
             execState (VMTest.interpret m) vm0
         Debug ->
           Just <$> EVM.TTY.runFromVM vm0


### PR DESCRIPTION
The identity, sha256, and ripemd160 precompiles now pass the eth tests.

This begins a work-in-progress refactor for handling precompiles which aims to address the gas cost calculation issues present on the old implementation.

More tests are _correctly_ failing now. For example a bunch of ecmul and modexp precompiles were passing despite not being implemented. 

**Test results**
Before:  5080 passed, 3999 bad-balance, 1533 failed
After: ~4425 passed, 3728 bad-balance, 2459 failed~  need to re-run since sha256/ripemd are done

- Prettify balance/state output for easier mole whacking of eth tests
- Start refactor of handling precompiles
- implement identity, sha256, ripemd160
- fix costOfCall bug for new accounts with no tx value
- increased vmTest timeout from 1 to 10 seconds