### PR TITLE
Injection of `test-hevm`

### DIFF
--- a/nix/solidity-package.nix
+++ b/nix/solidity-package.nix
@@ -15,15 +15,18 @@
          xs);
 in
   pkgs.lib.makeOverridable (
-    attrs @ { test ? true, deps ? [], solc ? pkgs.solc, ... }:
+    { doCheck ? true
+    , deps ? []
+    , solc ? pkgs.solc
+    , ...
+    } @ attrs:
       pkgs.stdenv.mkDerivation (rec {
         buildInputs = [pkgs.dapp2.test-hevm solc];
+        inherit doCheck;
         passthru = {
           remappings = remappings deps;
           libPaths = libPaths deps;
         };
-
-        TEST = test;
 
         REMAPPINGS =
           pkgs.lib.mapAttrsToList

--- a/nix/solidity-package.nix
+++ b/nix/solidity-package.nix
@@ -18,11 +18,12 @@ in
     { doCheck ? true
     , deps ? []
     , solc ? pkgs.solc
+    , test-hevm ? pkgs.dapp2.test-hevm
     , ...
     } @ attrs:
       pkgs.stdenv.mkDerivation (rec {
-        buildInputs = [pkgs.dapp2.test-hevm solc];
         inherit doCheck;
+        buildInputs = [ test-hevm solc ];
         passthru = {
           remappings = remappings deps;
           libPaths = libPaths deps;

--- a/nix/solidity-package.sh
+++ b/nix/solidity-package.sh
@@ -20,7 +20,10 @@ mkdir lib
 echo "$LIBSCRIPT" > setup.sh
 source setup.sh
 export DAPP_LIB=lib
-dapp2-test-hevm
+
+if [ "$doCheck" == 1 ]; then
+  dapp2-test-hevm
+fi
 
 mkdir -p $out/dapp/$name
 cp -r $src $out/dapp/$name/src


### PR DESCRIPTION
To be able to build `solidityPackage`s with specific requirements on HEVM version to run tests.