### PR TITLE
add create gitattributes to dapp-init

### DIFF
--- a/src/dapp/libexec/dapp/dapp-init
+++ b/src/dapp/libexec/dapp/dapp-init
@@ -25,6 +25,10 @@ insert .gitignore <<.
 /out
 .
 
+create .gitattributes <<.
+*.sol linguist-language=Solidity
+.
+
 name=$(basename "$(pwd)")
 name=$(<<<"$name" tr '[:upper:]' '[:lower:]')
 IFS=" " read -r -a nouns <<<"${name//[^a-z]/ }"


### PR DESCRIPTION
@nanexcool made this one really easy with a previous commit referenced in the issue. :-)  I moved his [code](https://github.com/dapphub/dapp/pull/80/files) over to this repo.  When I manually ran `dapp-init` in this repo, `.gitattributes` is created and checked in with other init files.

Closes Issue #33 