### PR TITLE
Revert changes to how `seth --send-params` are passed to `jshon`

### DIFF
--- a/src/seth/libexec/seth/seth-call
+++ b/src/seth/libexec/seth/seth-call
@@ -20,8 +20,8 @@ DATA=$(seth calldata "${@:2}")
 jshon+=(-n {})
 jshon+=(-s "$TO"   -i to)
 jshon+=(-s "$DATA" -i data)
-IFS=" " read -r -a params <<< "$(seth --send-params)"
-jshon+=( "${params[@]}" )
+# shellcheck disable=SC2207
+jshon+=($(seth --send-params))
 jshon+=(-i append)
 [[ $ETH_BLOCK = [0-9]* ]] && ETH_BLOCK=$(seth --to-hex "$ETH_BLOCK")
 jshon+=(-s "${ETH_BLOCK-latest}" -i append)

--- a/src/seth/libexec/seth/seth-estimate
+++ b/src/seth/libexec/seth/seth-estimate
@@ -32,8 +32,8 @@ fi
 jshon+=(-n {})
 [[ $TO ]] && jshon+=(-s "$TO" -i to)
 jshon+=(-s "$DATA" -i data)
-IFS=" " read -r -a params <<< "$(seth --send-params)"
-jshon+=( "${params[@]}" )
+# shellcheck disable=SC2207
+jshon+=($(seth --send-params))
 jshon+=(-i append)
 : "${ETH_BLOCK:=latest}" # geth doesn't like this argument
 [[ $ETH_BLOCK = latest ]] || jshon+=(-s "$ETH_BLOCK" -i append)

--- a/src/seth/libexec/seth/seth-send
+++ b/src/seth/libexec/seth/seth-send
@@ -49,8 +49,8 @@ fi
 jshon+=(-n {})
 [[ $TO ]] && jshon+=(-s "$TO" -i to)
 [[ $DATA ]] && jshon+=(-s "$DATA" -i data)
-IFS=" " read -r -a params <<< "$(seth --send-params)"
-jshon+=( "${params[@]}" )
+# shellcheck disable=SC2207
+jshon+=($(seth --send-params))
 jshon+=(-i append)
 
 if [[ -z $ETH_RPC_ACCOUNTS ]]; then


### PR DESCRIPTION
This caused subtle errors when using `ETH_RPC_ACCOUNTS=yes` together with
`seth send`.