### PR TITLE
dapp: faster builds with single solc pass

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0] - 2019-07-08
+### Changed
+- Faster `dapp build`, with a single compilation pass. Consolidates solc
+  output into a single `out/dapp.sol.json`, which may break some
+  workflows. `dapp build --extract` can be used to extract .abi, .bin,
+  .bin-runtime files from the json into `out/`.
+- The version of `hevm` is now shown in `dapp --version`.
+
 ## [0.22.0] - 2019-06-21
 ### Changed
 - geth upgraded to 1.8.27
@@ -112,3 +120,4 @@ changelog.
 [0.20.0]: https://github.com/dapphub/dapptools/tree/dapp/0.20.0
 [0.21.0]: https://github.com/dapphub/dapptools/tree/dapp/0.21.0
 [0.22.0]: https://github.com/dapphub/dapptools/tree/dapp/0.22.0
+[0.23.0]: https://github.com/dapphub/dapptools/tree/dapp/0.23.0

--- a/src/dapp/default.nix
+++ b/src/dapp/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   name = "dapp-${version}";
-  version = "0.22.0";
+  version = "0.23.0";
   src = ./.;
 
   nativeBuildInputs = [makeWrapper shellcheck coreutils nodejs];

--- a/src/dapp/libexec/dapp/dapp
+++ b/src/dapp/libexec/dapp/dapp
@@ -12,6 +12,7 @@ export DAPPTOOLS=${DAPPTOOLS-~/.dapp/dapptools}
 export DAPP_SRC=${DAPP_SRC-src}
 export DAPP_LIB=${DAPP_LIB-lib}
 export DAPP_OUT=${DAPP_OUT-out}
+export DAPP_JSON=${DAPP_JSON-${DAPP_OUT}/dapp.sol.json}
 
 set -e
 

--- a/src/dapp/libexec/dapp/dapp---version
+++ b/src/dapp/libexec/dapp/dapp---version
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-echo dapp 0.22.0
+echo dapp 0.23.0
 solc --version
 echo "hevm $(hevm version)"

--- a/src/dapp/libexec/dapp/dapp-build
+++ b/src/dapp/libexec/dapp/dapp-build
@@ -1,10 +1,43 @@
 #!/usr/bin/env bash
 ### dapp-build -- compile the source code
-### Usage: dapp build
+### Usage: dapp build [--extract]
+###
+###  --extract: After building, write the .abi, .bin and .bin-runtime
+###             files from the solc json into $DAPP_OUT. Beware of contract
+###             name collisions. This is provided for compatibility with older
+###             workflows.
 set -e
 
+while [[ $# -gt 0 ]]; do
+  opt=$1; shift
+  case $opt in
+    --extract)
+      DAPP_BUILD_EXTRACT=1
+      ;;
+    *)
+      info "unknown argument: $opt"
+      exit 1
+      ;;
+  esac
+done
+
+info() {
+  while [[ $# -gt 0 ]]; do
+    opt=$1; shift
+    case $opt in
+      -*)
+        FLAGS=$opt;
+        ;;
+      *)
+        ARGS=$opt;
+        ;;
+    esac
+  done
+  echo >&2 "$FLAGS" "${0##*/}: $ARGS"
+}
+
 IFS=" " read -r -a opts <<<"$SOLC_FLAGS"
-json_opts=--combined-json=abi,bin,bin-runtime,srcmap,srcmap-runtime,ast
+json_opts=--combined-json=abi,bin,bin-runtime,srcmap,srcmap-runtime,ast,metadata
 solc --help | grep -q -- --overwrite && opts+=(--overwrite)
 
 remappings=$(dapp remappings)
@@ -20,7 +53,7 @@ if [ "$DAPP_LINK_TEST_LIBRARIES" = 1 ]; then
 
   if [[ ${#libraries[@]} -eq 0 ]]; then exit; fi
 
-  echo >&2 "${0##*/}: rebuilding with linked libraries"
+  info "rebuilding with linked libraries"
   for lib in "${libraries[@]}"; do
     address=$(dapp address "$sender" "$nonce")
     links+=" $lib:$address"
@@ -31,12 +64,24 @@ else
   (set -x; dapp clean)
 fi
 
-find "${DAPP_SRC}" -name '*.sol' | while read -r x; do
-  dir=${x%\/*}
-  dir=${dir#$DAPP_SRC}
-  dir=${dir#/}
-  mkdir -p "$DAPP_OUT/$dir"
-  (set -x; solc "${opts[@]}" --abi --bin --bin-runtime --metadata /=/ -o "$DAPP_OUT/$dir" "$x")
-  json_file=$DAPP_OUT/$dir/${x##*/}.json
-  (set -x; solc "${opts[@]}" "${json_opts[@]}" /=/ "$x" >"$json_file")
-done
+mkdir -p "$DAPP_OUT"
+mapfile -t files < <(find "${DAPP_SRC}" -name '*.sol')
+(set -x; solc "${opts[@]}" "${json_opts[@]}" /=/ "${files[@]}" > "${DAPP_JSON}")
+
+if [ "$DAPP_BUILD_EXTRACT" ]; then
+  mapfile -t contracts < <(<"$DAPP_JSON" jq '.contracts|keys[]' -r | sort -u -t: -k2 | sort)
+  data=$(<"$DAPP_JSON" jq '.contracts' -r)
+  count=1
+  total=${#contracts[@]}
+  for path in "${contracts[@]}"; do
+    info -ne "Extracting build data... [$count/$total]\\r"
+    ((count++))
+    name="${path#*:}"
+    contract=$(echo "$data" | jq '.[''"'"$path"'"'']')
+    echo "$contract" | jq '.["abi"]' -r > "$DAPP_OUT/$name.abi"
+    echo "$contract" | jq '.["bin"]' -r > "$DAPP_OUT/$name.bin"
+    echo "$contract" | jq '.["bin-runtime"]' -r > "$DAPP_OUT/$name.bin-runtime"
+  done
+  echo
+  info "warning: --extract is slow and may have filename collisions. All build data can be found in $DAPP_JSON.\\n"
+fi

--- a/src/dapp/libexec/dapp/dapp-debug
+++ b/src/dapp/libexec/dapp/dapp-debug
@@ -25,7 +25,7 @@ trap clean EXIT
 
 shopt -s nullglob
 shopt -s globstar
-jsons=(out/**/*.sol.json)
+jsons=("$DAPP_OUT"/**/*.sol.json)
 if [[ "${#jsons[@]}" -gt 1 ]]; then
   if [[ "$#" -gt 0 ]]; then
     target="$1"; shift
@@ -39,6 +39,8 @@ if [[ "${#jsons[@]}" -gt 1 ]]; then
     echo >&2 "${0##*/}:"
     exit 1
   fi
+elif [[ "${#jsons[@]}" -eq 1 ]]; then
+  target="${jsons[0]}"
 elif [[ "${#jsons[@]}" -eq 0 ]]; then
   echo >&2 "${0##*/}: error: No compilation outputs; nothing to debug."
 fi

--- a/src/dapp/libexec/dapp/dapp-test-hevm
+++ b/src/dapp/libexec/dapp/dapp-test-hevm
@@ -28,5 +28,4 @@ state=$(dapp --make-library-state)
 function clean() { rm -rf "$state"; }
 trap clean EXIT
 
-find "${DAPP_OUT?}" -type f -name '*.sol.json' -print0 |
-  xargs -0 -n1 -I{} hevm dapp-test --json-file={} --dapp-root=. --state="$state" "${opts[@]}"
+hevm dapp-test --json-file="${DAPP_JSON}" --dapp-root=. --state="$state" "${opts[@]}"

--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 [[ $ETHERSCAN_API_KEY ]] || {
   cat >&2 <<.
 
   You need an Etherscan Api Key to verify contracts.
   Create one at https://etherscan.io/myapikey
-  
+
   Then export it with \`export ETHERSCAN_API_KEY=xxxxxxxx'
 
 .
@@ -28,14 +28,17 @@ case "$chain" in
     exit 1
 esac
 
-meta=$(cat "$DAPP_OUT"/"${1?contractname}"_meta.json)
+path=${1?contractname}
+name=${path#*:}
+address=${2?contractaddress}
+
+meta=$(<"$DAPP_JSON" jshon -e contracts -e "$path" -e metadata -u)
 version=$(jshon <<<"$meta" -e compiler -e version -u)
 file=$(jshon <<<"$meta" -e settings -e compilationTarget -k)
 optimized=$(jshon <<<"$meta" -e settings -e optimizer -e enabled -u)
 runs=$(jshon <<<"$meta" -e settings -e optimizer -e runs -u)
 
 version=v"$version"
-file="${file##*/}"
 if [[ "$optimized" = "true" ]]; then
   optimized=1
 else
@@ -44,13 +47,12 @@ fi
 
 params=(
   "module=contract" "action=verifysourcecode"
-  "contractname=${1?contractname}" "contractaddress=${2?contractaddress}"
+  "contractname=$name" "contractaddress=$address}"
   "optimizationUsed=$optimized" "runs=$runs"
   "apikey=$ETHERSCAN_API_KEY"
 )
 
-source=$(hevm flatten --source-file "$DAPP_SRC/$file" \
---json-file "$DAPP_OUT/$file".json)
+source=$(hevm flatten --source-file "$file" --json-file "$DAPP_JSON")
 
 source=$(cat <<.
 // Verified using https://dapp.tools
@@ -66,7 +68,7 @@ while [ $count -lt 5 ]; do
   response=$(curl -fsS "$ETHERSCAN_API_URL" -d "$query" \
   --data-urlencode "compilerversion=$version" \
   --data-urlencode "sourceCode@"<(echo "$source") -X POST)
-  
+
   status=$(jshon <<<"$response" -e status -u)
   #message=$(jshon <<<"$response" -e message -u)
   guid=$(jshon <<<"$response" -e result -u)
@@ -92,11 +94,11 @@ while [ $count -lt 5 ]; do
   sleep 10
   response=$(curl -fsS "$ETHERSCAN_API_URL" \
   -d "module=contract&action=checkverifystatus&guid=$guid")
-  
+
   status=$(jshon <<<"$response" -e status -u)
   # message=$(jshon <<<"$response" -e message -u)
   result=$(jshon <<<"$response" -e result -u)
-  
+
   [[ $status = 1 ]] && {
     echo >&2 "$result"
     echo >&2 "Go to $ETHERSCAN_URL/$2#code"


### PR DESCRIPTION
N.B. breaking change as .abi .bin and .bin-runtime artefacts are no longer generated.

Pass all of the source files to solc at once for much faster compilation. Previously we iterated through each file, which isn't necessary with the solc json output.

A positive side effect is no more test duplication in `dapp test`, which can occur with more complex projects (see e.g. https://github.com/makerdao/dss).

TODO:
  - [x] fix shellcheck issue
  - [x] if needed, extract .abi .bin .bin-runtime from the json
  - [x] ~decide on `--legacy` vs `--fast` flag~ --extract as optional
  - [x] update `dapp debug`