### PR TITLE
hevm: add "e" for stepping to end in interactive

### DIFF
--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -625,9 +625,11 @@ drawHelpBar = hBorder <=> hCenter help
       , ("p", "step back")
       , ("N", "step more")
       , ("C-n", "step over")
---      , ("  Enter", "browse")
+      , ("a", "step to start")
+      , ("e", "step to end")
       , ("m", "toggle memory")
-      , ("  Esc", "exit")
+      , ("Esc", "exit")
+--      , ("Enter", "browse")
       ]
 
 stepOneOpcode :: UiVmState -> UiVmState

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -41,7 +41,7 @@ import Control.Monad.State.Strict hiding (state)
 
 import Data.Aeson.Lens
 import Data.ByteString (ByteString)
-import Data.Maybe (fromJust, fromMaybe)
+import Data.Maybe (isJust, fromJust, fromMaybe)
 import Data.Monoid ((<>))
 import Data.Text (Text, unpack, pack)
 import Data.Text.Encoding (decodeUtf8)
@@ -428,7 +428,7 @@ app opts =
         (UiVmScreen s, VtyEvent (Vty.EvKey (Vty.KChar 'e') [])) ->
           takeStep s
             StepNormally
-            (StepUntil (\_ -> False))
+            (StepUntil (isExecutionHalted s))
 
         (UiVmScreen s, VtyEvent (Vty.EvKey (Vty.KChar 'a') [])) ->
             takeStep (view uiVmFirstState s) StepTimidly StepNone
@@ -671,6 +671,9 @@ isNextSourcePositionWithoutEntering ui vm =
                 True
         in
            moved && not deeper && not boring
+
+isExecutionHalted :: UiVmState -> Pred VM
+isExecutionHalted _ vm = isJust (view result vm)
 
 currentSrcMap :: DappInfo -> VM -> Maybe SrcMap
 currentSrcMap dapp vm =

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -413,6 +413,9 @@ app opts =
             StepNormally
             (StepUntil (\_ -> False))
 
+        (UiVmScreen s, VtyEvent (Vty.EvKey (Vty.KChar 'a') [])) ->
+            takeStep (view uiVmFirstState s) StepTimidly StepNone
+
         (UiVmScreen s, VtyEvent (Vty.EvKey (Vty.KChar 'p') [])) ->
           case view uiVmStepCount s of
             0 ->


### PR DESCRIPTION
By popular demand: also made is so that advancing past the end of execution just blocks instead of halting `hevm`. To exit `hevm` you have to press `Esc`.