### PR TITLE
Add `solcFlags` argument to `solidityPackage` that passes flags to `solc`

### DIFF
--- a/nix/solidity-package.nix
+++ b/nix/solidity-package.nix
@@ -19,6 +19,7 @@ in
     , deps ? []
     , solc ? pkgs.solc
     , test-hevm ? pkgs.dapp2.test-hevm
+    , solcFlags ? ""
     , ...
     } @ attrs:
       pkgs.stdenv.mkDerivation (rec {

--- a/nix/solidity-package.sh
+++ b/nix/solidity-package.sh
@@ -1,6 +1,7 @@
 source $stdenv/setup
 unpackPhase
 
+IFS=" " read -r -a opts <<<"$solcFlags"
 jsonopts=--combined-json=abi,bin,bin-runtime,srcmap,srcmap-runtime,ast
 
 export DAPP_SRC=$src
@@ -11,9 +12,9 @@ find "$DAPP_SRC" -name '*.sol' | while read -r x; do
   dir=${dir#$DAPP_SRC}
   dir=${dir#/}
   mkdir -p "$DAPP_OUT/$dir"
-  (set -x; solc --overwrite $REMAPPINGS --allow-paths $DAPP_SRC --abi --bin --bin-runtime -o "$DAPP_OUT/$dir" "$x")
+  (set -x; solc --overwrite $REMAPPINGS --allow-paths $DAPP_SRC "${opts[@]}" --abi --bin --bin-runtime -o "$DAPP_OUT/$dir" "$x")
   json_file=$DAPP_OUT/$dir/${x##*/}.json
-  (set -x; solc $REMAPPINGS --allow-paths $DAPP_SRC $jsonopts "$x" >"$json_file")
+  (set -x; solc $REMAPPINGS --allow-paths $DAPP_SRC "${opts[@]}" $jsonopts "$x" >"$json_file")
 done
 
 mkdir lib

--- a/nix/solidity-package.sh
+++ b/nix/solidity-package.sh
@@ -1,7 +1,6 @@
 source $stdenv/setup
 unpackPhase
 
-IFS=" " read -r -a opts <<<"$solcFlags"
 jsonopts=--combined-json=abi,bin,bin-runtime,srcmap,srcmap-runtime,ast
 
 export DAPP_SRC=$src
@@ -12,9 +11,9 @@ find "$DAPP_SRC" -name '*.sol' | while read -r x; do
   dir=${dir#$DAPP_SRC}
   dir=${dir#/}
   mkdir -p "$DAPP_OUT/$dir"
-  (set -x; solc --overwrite $REMAPPINGS --allow-paths $DAPP_SRC "${opts[@]}" --abi --bin --bin-runtime -o "$DAPP_OUT/$dir" "$x")
+  (set -x; solc --overwrite $REMAPPINGS --allow-paths $DAPP_SRC $solcFlags --abi --bin --bin-runtime -o "$DAPP_OUT/$dir" "$x")
   json_file=$DAPP_OUT/$dir/${x##*/}.json
-  (set -x; solc $REMAPPINGS --allow-paths $DAPP_SRC "${opts[@]}" $jsonopts "$x" >"$json_file")
+  (set -x; solc $REMAPPINGS --allow-paths $DAPP_SRC $solcFlags $jsonopts "$x" >"$json_file")
 done
 
 mkdir lib


### PR DESCRIPTION
To be able to set e.g. `--optimize` flag when using `solidityPackage` Nix expression to build solidity contracts.

This is equivalent to setting `SOLC_FLAGS` for `dapp build`.