### PR TITLE
Fix stack.yaml to build with GHC 8.4

### DIFF
--- a/src/hevm/stack.yaml
+++ b/src/hevm/stack.yaml
@@ -1,41 +1,27 @@
-resolver: lts-8.15
+resolver: lts-12.10
 packages:
 - .
 extra-deps:
-  - HSH-2.1.3
-  - HUnit-1.6.0.0
-  - Only-0.1
-  - aeson-1.2.4.0
-  - brick-0.26.1
-  - cpphs-1.20.8
-  - data-clist-0.1.2.2
-  - data-dword-0.3.1
-  - directory-1.3.3.2
-  - ghci-pretty-0.0.2
-  - ipprint-0.6
-  - lens-4.17
-  - megaparsec-7.0.4
-  - optparse-applicative-0.14.3.0
-  - optparse-generic-1.3.0
-  - parser-combinators-1.0.1
-  - profunctors-5.3
-  - restless-git-0.6
-  - rosezipper-0.2
-  - s-cargot-0.1.4.0
-  - semver-range-0.2.7
-  - sr-extra-1.46.3.2
-  - tasty-1.2
-  - tasty-hunit-0.10.0.1
-  - tasty-quickcheck-0.10
-  - th-abstraction-0.2.11.0
-  - time-1.8.0.4
-  - tree-view-0.5
-  - unix-2.7.2.2
-  - vector-0.12.0.2
-  - wcwidth-0.0.2
-  - witherable-0.3
-  - word-wrap-0.4.1
-allow-newer: true
+- config-ini-0.2.4.0
+- brick-0.46
+- data-clist-0.1.2.2
+- ghci-pretty-0.0.2
+- HSH-2.1.3
+- ipprint-0.6
+- megaparsec-7.0.5
+- multiset-0.3.4.1
+- restless-git-0.7
+- rosezipper-0.2
+- s-cargot-0.1.4.0
+- sr-extra-1.46.3.2
+- tree-view-0.5
+- text-format-0.3.2
+- text-zipper-0.10.1
+- Unixutils-1.54.1
+- vty-5.25.1
+- word-wrap-0.4.1
+- github: dmjio/semver-range
+  commit: d8d9db892ddb6ae267c9bcbc4f6602668433f12a
 flags: {}
 extra-package-dbs: []
 image:


### PR DESCRIPTION
I would have updated to build with GHC 8.6, but that has problems with quickcheck's `Gen` not having a `MonadFail` instance