### PR TITLE
hevm: UnitTest.hs: fix nonce initialisation bug (fixes #222)

### DIFF
--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # hevm changelog
 
+## 0.32 - 2019-06-14
+ - Fix dapp-test [nonce initialisation bug][224]
+
+[224]: https://github.com/dapphub/dapptools/pull/224
+
 ## 0.31 - 2019-05-29
  - Precompiles: SHA256, RIPEMD, IDENTITY, MODEXP, ECADD, ECMUL,
    ECPAIRING, MODEXP

--- a/src/hevm/default.nix
+++ b/src/hevm/default.nix
@@ -12,7 +12,7 @@
 }:
 mkDerivation {
   pname = "hevm";
-  version = "0.31";
+  version = "0.32";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.2
 name:
   hevm
 version:
-  0.31
+  0.32
 synopsis:
   Ethereum virtual machine evaluator
 description:

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -113,10 +113,6 @@ initializeUnitTest UnitTestOptions { .. } = do
   -- Mutate the current contract to use the new code
   Stepper.evm $ replaceCodeOfSelf (RuntimeCode bytes)
 
-  -- Increase the nonce, in case the constructor created contracts
-  Just n <- Stepper.evm (preuse (env . contracts . ix ethrunAddress . nonce))
-  Stepper.evm $ assign (env . contracts . ix addr . nonce) n
-
   -- Give a balance to the test target
   Stepper.evm $
     env . contracts . ix addr . balance += w256 (testBalanceCreate testParams)


### PR DESCRIPTION
this was an old, unnoticed bug in the unit-test runner, which was
brought to light when correct EIP684 collision semantics were recently
introduced. The nonce was being incorrectly reset to that of the
ethrun account, to adjust for it being potentially incremented during
the execution of the test contract's constructor, if that constructor
itself contains contract creations. However, since the creation
happens on behalf of the test contract, and not the ethrun address,
the nonce should be left as is, since replaceCode will propagate the
correct nonce.

Presumably this mistake was made because prior to commit
070cc9e39f23e1053da2c378d1d551d7f579be67, the nonce didn't get
propagated after a creation at all, so this line was introduced in a
flawed attempt to propagate it.

Any dapp tests which had creations inside the constructor (including
implicit creations that initialise storage variables) would have had
their nonces set incorrectly, and were also assigned the wrong
addresses. This had gone unnoticed since previously hevm would
overwrite on contract collisions, instead of throwing (which is the
correct behaviour). Creations in setUp() were not affected.

Fixes #222 

cc @gbalabasquer @rainbreak 