### PR TITLE
Use release-19.03 as base

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,6 @@
 { system ? builtins.currentSystem , ... }:
 
 let
-  # this is a branch rather than a tag
-  version = "release-18.09";
   # Import a specific Nixpkgs revision to use as the base for our overlay.
   nixpkgs = builtins.fetchTarball {
     name = "nixpkgs-${version}";

--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,10 @@
 { system ? builtins.currentSystem , ... }:
 
 let
-  # Import a specific Nixpkgs revision to use as the base for our overlay.
-  nixpkgs = builtins.fetchTarball {
-    name = "nixpkgs-${version}";
-    # pin the current release-18.09 commit
-    url = "https://github.com/nixos/nixpkgs/archive/185ab27b8a2ff2c7188bc29d056e46b25dd56218.tar.gz";
-    sha256 = "0bflmi7w3gas9q8wwwwbnz79nkdmiv2c1bpfc3xyplwy8npayxh2";
+  nixpkgs = builtins.fetchGit {
+    url = "https://github.com/nixos/nixpkgs";
+    ref = "release-19.03";
+    rev = "f1707d8875276cfa110139435a7e8998b4c2a4fd";
   };
 in
   # Now return the Nixpkgs configured to use our overlay.

--- a/haskell.nix
+++ b/haskell.nix
@@ -26,6 +26,7 @@ in self-hs: super-hs:
         rev = "patch-1";
         sha256 = "1l20hni4v4k6alxj867z00625pa5hkf0h5sdaj1mjc237k5v78j9";
       };
+      meta.broken = false;
     });
 
     hevm = pkgs.haskell.lib.dontHaddock ((

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,11 +1,6 @@
 self: super:
 
 let
-  # This is a specific revision of Nixpkgs that we use to avoid
-  # rebuilding all the versions of solc when we bump our submodule, or
-  # to allow a package to succeed when something breaks in nixpkgs.
-  version = "18.09";
-
   lib = self.pkgs.lib;
   stdenv = self.pkgs.stdenv;
 

--- a/src/hevm/src/EVM/ABI.hs
+++ b/src/hevm/src/EVM/ABI.hs
@@ -358,8 +358,9 @@ genAbiValue :: AbiType -> Gen AbiValue
 genAbiValue = \case
    AbiUIntType n -> genUInt n
    AbiIntType n ->
-     do AbiUInt _ x <- genUInt n
+     do a <- genUInt n
         b <- arbitrary
+        let AbiUInt _ x = a
         pure $ AbiInt n (signedWord x * if b then 1 else -1)
    AbiAddressType ->
      (\(AbiUInt _ x) -> AbiAddress (fromIntegral x)) <$> genUInt 20

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -403,10 +403,12 @@ app opts =
         (UiVmScreen s, VtyEvent (Vty.EvKey (Vty.KChar ' ') [])) ->
           let
             loop = do
-              Just hey <- Readline.getInputLine "% "
-              Readline.outputStrLn hey
-              Just hey' <- Readline.getInputLine "% "
-              Readline.outputStrLn hey'
+              Readline.getInputLine "% " >>= \case
+                Just hey -> Readline.outputStrLn hey
+                Nothing  -> pure ()
+              Readline.getInputLine "% " >>= \case
+                Just hey' -> Readline.outputStrLn hey'
+                Nothing   -> pure ()
               return (UiVmScreen s)
           in
             suspendAndResume $


### PR DESCRIPTION
This means we're using `release-19.03` at commit [`f1707d8875276cfa110139435a7e8998b4c2a4fd`](https://github.com/NixOS/nixpkgs/tree/f1707d8875276cfa110139435a7e8998b4c2a4fd) when pushing to cachix.