### PR TITLE
Use upstream geth

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -131,9 +131,7 @@ in rec {
   seth = self.callPackage (import ./src/seth) {};
   dapp = self.callPackage (import ./src/dapp) {};
 
-  ethsign = (self.callPackage (import ./src/ethsign) {
-    inherit geth-version geth-sha;
-  }).bin;
+  ethsign = (self.callPackage (import ./src/ethsign) {}).bin;
 
   evmdis = self.callPackage ./nix/evmdis.nix {};
 
@@ -145,27 +143,10 @@ in rec {
   terra = self.callPackage (import ./submodules/terra) {};
   chief = self.callPackage (import ./submodules/chief) {};
 
-  geth-version = "1.8.22";
-  geth-sha = "0ag9qxrf7n0qkccaf6v4jaysivpxvsy5zfzar3mcm65223pqy375";
-  go-ethereum = super.go-ethereum.overrideDerivation (_: rec {
-    name = "go-ethereum-${version}";
-    version = geth-version;
-    src = self.pkgs.fetchFromGitHub {
-      owner = "ethereum";
-      repo = "go-ethereum";
-      rev = "v${version}";
-      sha256 = geth-sha;
-    };
-    # (mbrock backported) fix for usb-related segmentation faults on darwin
-    propagatedBuildInputs =
-      stdenv.lib.optionals stdenv.isDarwin
-      (with self.pkgs; [ darwin.libobjc darwin.apple_sdk.frameworks.IOKit ]);
-  });
-
   # We use this to run private testnets without
   # the pesky transaction size limit.
-  go-ethereum-unlimited = self.go-ethereum.overrideDerivation (this: rec {
-    name = "go-ethereum-unlimited-${this.version}";
+  go-ethereum-unlimited = super.go-ethereum.overrideAttrs (geth: rec {
+    name = "${geth.pname}-unlimited-${geth.version}";
     preConfigure = ''
       # Huge transaction calldata
       substituteInPlace core/tx_pool.go --replace 'return ErrOversizedData' ""

--- a/src/ethsign/default.nix
+++ b/src/ethsign/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, fetchgit, geth-version, geth-sha, clang }:
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchgit, go-ethereum, clang }:
 
 buildGoPackage rec {
   name = "ethsign-${version}";
@@ -11,12 +11,7 @@ buildGoPackage rec {
   extraSrcs = [
     {
       goPackagePath = "github.com/ethereum/go-ethereum";
-      src = fetchFromGitHub {
-        owner = "ethereum";
-        repo = "go-ethereum";
-        rev = geth-version;
-        sha256 = geth-sha;
-      };
+      src = go-ethereum.src;
     }
     {
       goPackagePath = "gopkg.in/urfave/cli.v1";


### PR DESCRIPTION
Now that the backported fixes have been upstreamed, there's no reason to keep pinning a version of geth.

This means we'll use the latest version in the pinned nixpkgs, which currently is 1.8.27.