### PR TITLE
solc: disable 0.4.24 on macOS

### DIFF
--- a/nix/solc-versions.nix
+++ b/nix/solc-versions.nix
@@ -32,7 +32,7 @@ rec {
   };
 
   # some versions do not compile on macOS
-  x86_64-darwin = removeAttrs x86_64-linux [ "solc_0_4_6" "solc_0_4_8" "solc_0_4_11" "solc_0_4_12" ];
+  x86_64-darwin = removeAttrs x86_64-linux [ "solc_0_4_6" "solc_0_4_8" "solc_0_4_11" "solc_0_4_12" "solc_0_4_24" ];
 
   # these versions have not been upstreamed on NixOS/nixpkgs yet, and come from our fork at dapptools/nixpkgs
   unreleased = {};


### PR DESCRIPTION
Using it fails with:

dyld: Library not loaded: /usr/lib/system/libsystem_network.dylib
  Referenced from: /nix/store/xn55wd7nimdi085kji54mrrqqnqvcasz-Libsystem-osx-10.11.6/lib/libSystem.B.dylib
  Reason: image not found