### PR TITLE
hevm gst compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - |
     [[ "$TRAVIS_OS_NAME" == "osx" ]] && PLATFORM=darwin || PLATFORM=linux
 
-    nix-build -j auto release.nix -A dapphub.$PLATFORM.stable
+    nix-build -j auto release.nix -A dapphub.$PLATFORM.stable &&
 
     # this is here to let cachix finish pushing the last artifact before the script is killed
     sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ script:
   - |
     [[ "$TRAVIS_OS_NAME" == "osx" ]] && PLATFORM=darwin || PLATFORM=linux
 
-    nix-build -j auto release.nix -A dapphub.$PLATFORM.stable &&
+    nix-build -j auto release.nix -A dapphub.$PLATFORM.stable
+    success=$?
+    [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ $success -gt 0 ]] && exit $success
 
     # this is here to let cachix finish pushing the last artifact before the script is killed
     sleep 10

--- a/release.nix
+++ b/release.nix
@@ -18,7 +18,7 @@ let
     export PATH=${x.pkgs.hevm}/bin:${x.pkgs.jq}/bin:$PATH
     ${x.pkgs.hevm}/bin/hevm compliance \
       --tests ${ethereum-test-suite x} \
-      --skip "modexp"
+      --skip "(modexp|RevertPrecompiledTouch_storage_d0g0v0|RevertPrecompiledTouch_storage_d3g0v0)"
   '';
 
   # These packages should always work and be available in the binary cache.

--- a/release.nix
+++ b/release.nix
@@ -15,10 +15,12 @@ let
   # run all General State Tests, skipping modexp as it is
   # problematic for darwin. todo: don't skip for linux
   hevmCompliance = x: x.runCommand "hevm-compliance" {} ''
+    mkdir "$out"
     export PATH=${x.pkgs.hevm}/bin:${x.pkgs.jq}/bin:$PATH
     ${x.pkgs.hevm}/bin/hevm compliance \
       --tests ${ethereum-test-suite x} \
-      --skip "(modexp|RevertPrecompiledTouch_storage_d0g0v0|RevertPrecompiledTouch_storage_d3g0v0)"
+      --skip "(modexp|RevertPrecompiledTouch_storage_d0g0v0|RevertPrecompiledTouch_storage_d3g0v0)" \
+      --html > $out/index.html
   '';
 
   # These packages should always work and be available in the binary cache.

--- a/release.nix
+++ b/release.nix
@@ -8,15 +8,17 @@ let
   ethereum-test-suite = x: x.fetchFromGitHub {
     owner = "ethereum";
     repo = "tests";
-    rev = "7e361956bd68f5cac72fe41f29e5734ee94ae2de";
-    sha256 = "0l5qalgbscr77vjhyf7b542055wnp4pddpfslnypp5sqws5w940w";
+    rev = "da6d391922cb0e3c6bda24871c89d33bc815c1dc";
+    sha256 = "06h3hcsm09kp4hzq5sm9vqkmvx2nvgbh5i788qnqh5iiz9fpaa9k";
   };
 
-  hevmTestReport = x: x.runCommand "hevm-test-report" {} ''
+  hevmCompliance = x: x.runCommand "hevm-compliance" {} ''
     mkdir -p $out/nix-support
     export PATH=${x.pkgs.hevm}/bin:$PATH
-    ${x.pkgs.hevm}/bin/hevm vm-test-report \
-      --tests ${ethereum-test-suite x} > $out/index.html
+    ${x.pkgs.hevm}/bin/hevm compliance \
+      --tests ${ethereum-test-suite x} \
+      --skip modexp \
+      --html > $out/index.html
     echo report testlog $out index.html > $out/nix-support/hydra-build-products
   '';
 
@@ -36,7 +38,7 @@ let
     inherit setzer;
     inherit token;
 
-    hevm-test-report = hevmTestReport dist;
+    hevm-compliance = hevmCompliance dist;
   # the union is necessary because nix-build does not evaluate sets
   # recursively, and `solc-versions` is a set
   } // dist.pkgs.solc-versions ;

--- a/release.nix
+++ b/release.nix
@@ -12,14 +12,13 @@ let
     sha256 = "06h3hcsm09kp4hzq5sm9vqkmvx2nvgbh5i788qnqh5iiz9fpaa9k";
   };
 
+  # run all General State Tests, skipping modexp as it is
+  # problematic for darwin. todo: don't skip for linux
   hevmCompliance = x: x.runCommand "hevm-compliance" {} ''
-    mkdir -p $out/nix-support
-    export PATH=${x.pkgs.hevm}/bin:$PATH
+    export PATH=${x.pkgs.hevm}/bin:${x.pkgs.jq}/bin:$PATH
     ${x.pkgs.hevm}/bin/hevm compliance \
       --tests ${ethereum-test-suite x} \
-      --skip modexp \
-      --html > $out/index.html
-    echo report testlog $out index.html > $out/nix-support/hydra-build-products
+      --skip "modexp"
   '';
 
   # These packages should always work and be available in the binary cache.

--- a/src/hevm/README.md
+++ b/src/hevm/README.md
@@ -1,26 +1,10 @@
 # hevm [![Build Status](https://travis-ci.org/dapphub/hevm.svg?branch=master)](https://travis-ci.org/dapphub/hevm) [![GitHub (pre-)release](https://img.shields.io/github/release/dapphub/hevm/all.svg)](https://github.com/dapphub/hevm/releases)
 
-The `hevm` project is an implementation of the Ethereum virtual
-machine (EVM) made specifically for unit testing and debugging smart
-contracts.  It is developed by [DappHub](https://github.com/dapphub)
-and integrates especially well with the
-[`dapp` tool suite](https://github.com/dapphub/dapp).  The `hevm`
-command line program can run unit tests, interactively debug contracts
-while showing the Solidity source, or run arbitrary EVM code.
+The `hevm` project is an implementation of the Ethereum virtual machine (EVM) made specifically for unit testing and debugging smart contracts.  It is developed by [DappHub](https://github.com/dapphub) and integrates especially well with the [`dapp` tool suite](https://github.com/dapphub/dapp). The `hevm` command line program can run unit tests, interactively debug contracts while showing the Solidity source, or run arbitrary EVM code.
 
-*This is not yet a complete EVM*.  For example, the precompiled
-contracts are missing.  We do well on Ethereum's `VMTests` suite (see
-[hevm v0.11.1 test report]) but we can't guarantee exact
-consensus conformance.  The precompiled contracts are entirely missing
-for now, and we're in the process of implementing the Metropolis EIPs.
+### Usage
 
-[![asciicast](https://asciinema.org/a/dTPBLV10gixo62ngiSFTK2dVu.png)](https://asciinema.org/a/dTPBLV10gixo62ngiSFTK2dVu)
-
-## Usage
-
-Note: the `hevm` test runner and debugger currently assumes the use of
-the `ds-test` framework for Solidity unit tests and the [`dapp` tool
-suite](https://github.com/dapphub/dapp).
+Note: the `hevm` test runner and debugger currently assumes the use of the `ds-test` framework for Solidity unit tests and the [`dapp` tool suite](https://github.com/dapphub/dapp).
 
 After running `dapp build`, you can run your unit test suite with
 
@@ -30,27 +14,45 @@ or you can enter the interactive debugger using
 
     $ hevm interactive
 
-### Debugger key bindings
+### Commands
+
+    hevm -- Ethereum evaluator
+
+    Usage: hevm [<options>] <command>
+       or: hevm <command> --help
+
+    Commands:
+
+      exec            Execute a given program with specified env & calldata
+      dapp-test       Run unit tests
+      interactive     Browse and run unit tests interactively
+      vm-test         Run an Ethereum VMTest
+      vm-test-report  Run all VM Tests
+      bc-test         Run an Ethereum GeneralState test
+      flatten         Concat all dependencies for a given source file
+      emacs           Emacs console
+      version         Show hevm version
+
+### Interactive debugger key bindings
 
   - `Esc`: exit debugger
-  - `n`: step by one instruction
+  - `a`: step to start
+  - `e`: step to end
+  - `n`: step forwards by one instruction
   - `p`: step backwards by one instruction
   - `N`: step to the next source position
   - `C-n`: step to the next source position and don't enter `CALL` or `CREATE`
+  - `m`: toggle memory view
 
 ## Installing
 
 ### Nix
 
-`hevm` is distributed as part of the [Dapp
-tools](https://github.com/dapphub/dapptools) suite.
+`hevm` is distributed as part of the [Dapp tools](https://github.com/dapphub/dapptools) suite.
 
 ### Static binary
 
-If you don't want to compile anything, and you're on x86-64 Linux, you
-can download a static binary from the "Releases" tab on GitHub.
-If the static binary complains about a "terminfo" file, you have to
-set the `TERMINFO` environment variable; on Ubuntu, you should do
+If you don't want to compile anything, and you're on x86-64 Linux, you can download a static binary from the "Releases" tab on GitHub. If the static binary complains about a "terminfo" file, you have to set the `TERMINFO` environment variable; on Ubuntu, you should do
 
     $ export TERMINFO=/lib/terminfo
 
@@ -58,27 +60,20 @@ set the `TERMINFO` environment variable; on Ubuntu, you should do
 
 ### Building with Stack or Cabal
 
-If you can't or won't use Nix, the easiest way especially if you don't
-have GHC (the Haskell compiler) installed already, is to use
-[Stack](https://docs.haskellstack.org/en/stable/README/), which can
-take care of installing GHC for you.  These commands should work:
+If you can't or won't use Nix, the easiest way especially if you don't have GHC (the Haskell compiler) installed already, is to use [Stack](https://docs.haskellstack.org/en/stable/README/), which can take care of installing GHC for you. These commands should work:
 
     $ curl -sSL https://get.haskellstack.org/ | sh
     $ git clone https://github.com/dapphub/dapptools.git
     $ cd dapptools/src/hevm && stack setup && stack install
 
-Also, hevm is in Hackage so you can execute `stack install hevm` to
-get it up and running.
+Also, hevm is in Hackage so you can execute `stack install hevm` to get it up and running.
 
-If you prefer to use your own installation of GHC and the basic
-Haskell package manager, Cabal, simply run:
+If you prefer to use your own installation of GHC and the basic Haskell package manager, Cabal, simply run:
 
     $ git clone https://github.com/dapphub/dapptools.git
     $ cd dapptools/src/hevm && cabal configure && cabal install
 
-**Note:** If you are on macOS when building with Stack, 
-you will first need to install the `secp256k1` library. 
-These commands should be enough:
+**Note:** If you are on macOS when building with Stack, you will first need to install the [secp256k1](https://github.com/bitcoin-core/secp256k1) and [libff](https://github.com/scipr-lab/libff) libraries. These commands should be enough:
 
     $ git clone https://github.com/bitcoin-core/secp256k1.git
     $ cd secp256k1
@@ -88,9 +83,19 @@ These commands should be enough:
     $ sudo make install
     $ cd .. && rm -rf secp256k1 # optional (cleanup)
 
+    $ git clone https://github.com/scipr-lab/libff --recursive
+    $ cd libff
+    $ export LDFLAGS=-L/usr/local/opt/openssl/lib
+    $ export CPPFLAGS=-I/usr/local/opt/openssl/include
+    $ export CXXFLAGS=-I/usr/local/opt/openssl/include
+    $ ARGS="-DWITH_PROCPS=OFF -DOPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include/openssl -DCURVE=ALT_BN128"
+    $ sed -i '' 's/STATIC/SHARED/' libff/CMakeLists.txt
+    $ sed -i '' 's/STATIC/SHARED/' depends/CMakeLists.txt
+    $ mkdir build
+    $ cd build
+    $ CXXFLAGS="-fPIC $CXXFLAGS" cmake $ARGS ..
+    $ make && sudo make install
+
 ## Contact
 
-You can find us in the DappHub chat at https://dapphub.chat/,
-especially the `#dev` channel.
-
-[hevm v0.11.1 test report]: https://hydra.dapp.tools/build/357/download/1/index.html
+You can find us in the DappHub chat at https://dapphub.chat/, especially the `#dev` channel.

--- a/src/hevm/README.md
+++ b/src/hevm/README.md
@@ -23,15 +23,17 @@ or you can enter the interactive debugger using
 
     Commands:
 
-      exec            Execute a given program with specified env & calldata
-      dapp-test       Run unit tests
-      interactive     Browse and run unit tests interactively
-      vm-test         Run an Ethereum VMTest
-      vm-test-report  Run all VM Tests
-      bc-test         Run an Ethereum GeneralState test
-      flatten         Concat all dependencies for a given source file
-      emacs           Emacs console
-      version         Show hevm version
+      exec         Execute a given program with specified env & calldata
+      dapp-test    Run unit tests
+      interactive  Browse and run unit tests interactively
+      flatten      Concat all dependencies for a given source file
+
+      bc-test      Run an Ethereum Blockchain/GeneralState test
+      vm-test      Run an Ethereum VMTest
+      compliance   Run Blockchain or VMTest compliance report
+
+      emacs        Emacs console
+      version      Show hevm version
 
 ### Interactive debugger key bindings
 

--- a/src/hevm/ethjet/ethjet.c
+++ b/src/hevm/ethjet/ethjet.c
@@ -69,6 +69,11 @@ ethjet_ecrecover (secp256k1_context *ctx,
   input64 = in + 64;
   recid = in[63] - 27;
 
+  /* higher bytes of V should be zero  */
+  static const char z31 [31];
+  if (memcmp (z31, in + 32, 31))
+    return 0;
+
   if (recid < 0 || recid > 3)
     return 0;
 

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -181,10 +181,12 @@ main = do
       withCurrentDirectory root $ do
         testFile <- findJsonFile (jsonFile cmd)
         testOpts <- unitTestOptions cmd
-        case coverage cmd of
-          False ->
+        case (coverage cmd, optsMode cmd) of
+          (False, Run) ->
             dappTest testOpts (optsMode cmd) testFile
-          True ->
+          (False, Debug) ->
+            EVM.TTY.main testOpts root testFile
+          (True, _) ->
             dappCoverage testOpts (optsMode cmd) testFile
     Interactive {} ->
       withCurrentDirectory root $ do

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -2,12 +2,16 @@
 
 {-# Language BangPatterns #-}
 {-# Language CPP #-}
+{-# Language DataKinds #-}
+{-# Language FlexibleInstances #-}
 {-# Language DeriveGeneric #-}
 {-# Language GeneralizedNewtypeDeriving #-}
 {-# Language LambdaCase #-}
 {-# Language NumDecimals #-}
 {-# Language OverloadedStrings #-}
+{-# Language StandaloneDeriving #-}
 {-# Language TemplateHaskell #-}
+{-# Language TypeOperators #-}
 
 import EVM.Concrete (w256)
 
@@ -33,9 +37,9 @@ import EVM.UnitTest (runUnitTestContract)
 import EVM.UnitTest (getParametersFromEnvironmentVariables, testNumber)
 import EVM.Dapp (findUnitTests, dappInfo)
 
-import qualified EVM.UnitTest as EVM.UnitTest
-
-import qualified Paths_hevm as Paths
+import qualified EVM.Facts     as Facts
+import qualified EVM.Facts.Git as Git
+import qualified EVM.UnitTest  as EVM.UnitTest
 
 import Control.Concurrent.Async   (async, waitCatch)
 import Control.Exception          (evaluate)
@@ -57,88 +61,87 @@ import qualified Data.ByteString.Base16 as BS16
 import qualified Data.ByteString.Char8  as Char8
 import qualified Data.ByteString.Lazy   as LazyByteString
 import qualified Data.Map               as Map
-import qualified Options.Generic        as Options
+import qualified Data.Sequence          as Seq
 import qualified System.Timeout         as Timeout
 
-import qualified EVM.Facts     as Facts
-import qualified EVM.Facts.Git as Git
-
+import qualified Paths_hevm      as Paths
 import qualified Text.Regex.TDFA as Regex
-import qualified Data.Sequence as Seq
+
+import Options.Generic as Options
 
 -- This record defines the program's command-line options
 -- automatically via the `optparse-generic` package.
-data Command
-  = Exec
-      { code        :: ByteString
-      , calldata    :: Maybe ByteString
-      , address     :: Maybe Addr
-      , caller      :: Maybe Addr
-      , origin      :: Maybe Addr
-      , coinbase    :: Maybe Addr
-      , value       :: Maybe W256
-      , gas         :: Maybe W256
-      , number      :: Maybe W256
-      , timestamp   :: Maybe W256
-      , gaslimit    :: Maybe W256
-      , gasprice    :: Maybe W256
-      , maxcodesize :: Maybe W256
-      , difficulty  :: Maybe W256
-      , debug       :: Bool
-      , state       :: Maybe String
+data Command w
+  = Exec -- Execute a given program with specified env & calldata
+      { code        :: w ::: ByteString       <?> "Program bytecode"
+      , calldata    :: w ::: Maybe ByteString <?> "Tx: calldata"
+      , address     :: w ::: Maybe Addr       <?> "Tx: address"
+      , caller      :: w ::: Maybe Addr       <?> "Tx: caller"
+      , origin      :: w ::: Maybe Addr       <?> "Tx: origin"
+      , coinbase    :: w ::: Maybe Addr       <?> "Block: coinbase"
+      , value       :: w ::: Maybe W256       <?> "Tx: Eth amount"
+      , gas         :: w ::: Maybe W256       <?> "Tx: gas amount"
+      , number      :: w ::: Maybe W256       <?> "Block: number"
+      , timestamp   :: w ::: Maybe W256       <?> "Block: timestamp"
+      , gaslimit    :: w ::: Maybe W256       <?> "Tx: gas limit"
+      , gasprice    :: w ::: Maybe W256       <?> "Tx: gas price"
+      , maxcodesize :: w ::: Maybe W256       <?> "Block: max code size"
+      , difficulty  :: w ::: Maybe W256       <?> "Block: difficulty"
+      , debug       :: w ::: Bool             <?> "Run interactively"
+      , state       :: w ::: Maybe String     <?> "Path to state repository"
       }
-  | DappTest
-      { jsonFile           :: Maybe String
-      , dappRoot           :: Maybe String
-      , debug              :: Bool
-      , rpc                :: Maybe URL
-      , verbose            :: Maybe Int
-      , coverage           :: Bool
-      , state              :: Maybe String
-      , match              :: Maybe String
+  | DappTest -- Run DSTest unit tests
+      { jsonFile    :: w ::: Maybe String <?> "Filename or path to dapp build output (default: out/*.solc.json)"
+      , dappRoot    :: w ::: Maybe String <?> "Path to dapp project root directory (default: . )"
+      , debug       :: w ::: Bool         <?> "Run interactively"
+      , rpc         :: w ::: Maybe URL    <?> "Fetch state from a remote node"
+      , verbose     :: w ::: Maybe Int    <?> "Append call trace: {1} failures {2} all"
+      , coverage    :: w ::: Bool         <?> "Coverage analysis"
+      , state       :: w ::: Maybe String <?> "Path to state repository"
+      , match       :: w ::: Maybe String <?> "Test case filter - only run methods matching regex"
       }
-  | Interactive
-      { jsonFile           :: Maybe String
-      , dappRoot           :: Maybe String
-      , rpc                :: Maybe URL
-      , state              :: Maybe String
+  | Interactive -- Browse & run unit tests interactively
+      { jsonFile :: w ::: Maybe String <?> "Filename or path to dapp build output (default: out/*.solc.json)"
+      , dappRoot :: w ::: Maybe String <?> "Path to dapp project root directory (default: . )"
+      , rpc      :: w ::: Maybe URL    <?> "Fetch state from a remote node"
+      , state    :: w ::: Maybe String <?> "Path to state repository"
       }
-  | VmTest
-      { file    :: String
-      , test    :: [String]
-      , debug   :: Bool
-      , diff    :: Bool
-      , timeout :: Maybe Int
+  | VmTest -- Run an Ethereum VMTest
+      { file    :: w ::: String    <?> "Path to .json test file"
+      , test    :: w ::: [String]  <?> "Test case filter - only run specified test method(s)"
+      , debug   :: w ::: Bool      <?> "Run interactively"
+      , diff    :: w ::: Bool      <?> "Print expected vs. actual state on failure"
+      , timeout :: w ::: Maybe Int <?> "Execution timeout (default: 10 sec.)"
       }
-  | VmTestReport
-      { tests :: String
+  | VmTestReport -- Run all Ethereum VMTests
+      { tests :: w ::: String <?> "Path to Ethereum VMTests directory"
       }
-  | BcTest
-      { file    :: String
-      , test    :: [String]
-      , debug   :: Bool
-      , diff    :: Bool
-      , timeout :: Maybe Int
+  | BcTest -- Run Ethereum Blockhain/GeneralState test
+      { file    :: w ::: String    <?> "Path to .json test file"
+      , test    :: w ::: [String]  <?> "Test case filter - only run specified test method(s)"
+      , debug   :: w ::: Bool      <?> "Run interactively"
+      , diff    :: w ::: Bool      <?> "Print expected vs. actual state on failure"
+      , timeout :: w ::: Maybe Int <?> "Execution timeout (default: 10 sec.)"
       }
-  | Flatten
-    { sourceFile :: String
-    , jsonFile   :: Maybe String
-    , dappRoot   :: Maybe String
+  | Flatten -- Concat all dependencies for a given source file
+    { sourceFile :: w ::: String       <?> "Path to solidity source file e.g. src/contract.sol"
+    , jsonFile   :: w ::: Maybe String <?> "Filename or path to dapp build output (default: out/*.solc.json)"
+    , dappRoot   :: w ::: Maybe String <?> "Path to dapp project root directory (default: . )"
     }
   | Emacs
   | Version
-  deriving (Show, Options.Generic, Eq)
+  deriving (Options.Generic)
 
 type URL = Text
 
-instance Options.ParseRecord Command where
+instance Options.ParseRecord (Command Options.Wrapped) where
   parseRecord =
     Options.parseRecordWithModifiers Options.lispCaseModifiers
 
-optsMode :: Command -> Mode
+optsMode :: Command Options.Unwrapped -> Mode
 optsMode x = if debug x then Debug else Run
 
-unitTestOptions :: Command -> IO UnitTestOptions
+unitTestOptions :: Command Options.Unwrapped -> IO UnitTestOptions
 unitTestOptions cmd = do
   vmModifier <-
     case state cmd of
@@ -163,7 +166,7 @@ unitTestOptions cmd = do
 
 main :: IO ()
 main = do
-  cmd <- Options.getRecord "hevm -- Ethereum evaluator"
+  cmd <- Options.unwrapRecord "hevm -- Ethereum evaluator"
   let
     root = fromMaybe "." (dappRoot cmd)
   case cmd of
@@ -278,7 +281,7 @@ dappCoverage opts _ solcFile = do
       Nothing ->
         error ("Failed to read Solidity JSON for `" ++ solcFile ++ "'")
 
-launchExec :: Command -> IO ()
+launchExec :: Command Options.Unwrapped -> IO ()
 launchExec cmd = do
   let vm = vmFromCommand cmd
   vm1 <- case state cmd of
@@ -310,7 +313,7 @@ launchExec cmd = do
     Debug ->
       void (EVM.TTY.runFromVM vm1)
 
-vmFromCommand :: Command -> EVM.VM
+vmFromCommand :: Command Options.Unwrapped -> EVM.VM
 vmFromCommand cmd =
   vm1 & EVM.env . EVM.contracts . ix address' . EVM.balance +~ (w256 value')
   where
@@ -339,7 +342,7 @@ vmFromCommand cmd =
     word f def = maybe def id (f cmd)
     addr f def = maybe def id (f cmd)
 
-launchTest :: ExecMode -> Command ->  IO ()
+launchTest :: ExecMode -> Command Options.Unwrapped ->  IO ()
 launchTest execmode cmd = do
 #if MIN_VERSION_aeson(1, 0, 0)
   let parser = case execmode of

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -114,7 +114,7 @@ data Command w
       , timeout :: w ::: Maybe Int <?> "Execution timeout (default: 10 sec.)"
       }
   | VmTestReport -- Run all Ethereum VMTests
-      { tests :: w ::: String <?> "Path to Ethereum VMTests directory"
+      { tests :: w ::: String <?> "Path to Ethereum Tests directory"
       }
   | BcTest -- Run Ethereum Blockhain/GeneralState test
       { file    :: w ::: String    <?> "Path to .json test file"
@@ -122,6 +122,9 @@ data Command w
       , debug   :: w ::: Bool      <?> "Run interactively"
       , diff    :: w ::: Bool      <?> "Print expected vs. actual state on failure"
       , timeout :: w ::: Maybe Int <?> "Execution timeout (default: 10 sec.)"
+      }
+  | BcTestReport -- Run all Ethereum Blockchain/GeneralState tests
+      { tests :: w ::: String <?> "Path to Ethereum Tests directory"
       }
   | Flatten -- Concat all dependencies for a given source file
     { sourceFile :: w ::: String       <?> "Path to solidity source file e.g. src/contract.sol"
@@ -193,6 +196,10 @@ main = do
         testFile <- findJsonFile (jsonFile cmd)
         testOpts <- unitTestOptions cmd
         EVM.TTY.main testOpts root testFile
+    BcTestReport {} ->
+      withCurrentDirectory (tests cmd) $ do
+        dataDir <- Paths.getDataDir
+        callProcess "bash" [dataDir ++ "/run-blockchain-tests", "."]
     VmTestReport {} ->
       withCurrentDirectory (tests cmd) $ do
         dataDir <- Paths.getDataDir

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -123,7 +123,8 @@ data Command w
   | Compliance -- Run Ethereum Blockhain or VMTest compliance report
       { tests   :: w ::: String       <?> "Path to Ethereum Tests directory"
       , group   :: w ::: Maybe String <?> "Report group to run: VM or Blockchain (default: Blockchain)"
-      , skip    :: w ::: Maybe String <?> "Test case filter - skip tests containing word"
+      , skip    :: w ::: Maybe String <?> "Test case filter - skip tests containing string"
+      , html    :: w ::: Bool         <?> "Output html report"
       , timeout :: w ::: Maybe Int    <?> "Execution timeout (default: 10 sec.)"
       }
   | Flatten -- Concat all dependencies for a given source file
@@ -221,8 +222,9 @@ launchScript script cmd = do
     callProcess "bash"
       [ dataDir ++ script
       , "."
-      , show $ fromMaybe 10 (timeout cmd)
+      , show (html cmd)
       , fromMaybe "" (skip cmd)
+      , show $ fromMaybe 10 (timeout cmd)
       ]
 
 findJsonFile :: Maybe String -> IO String

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -70,21 +70,22 @@ import qualified Data.Sequence as Seq
 -- automatically via the `optparse-generic` package.
 data Command
   = Exec
-      { code       :: ByteString
-      , calldata   :: Maybe ByteString
-      , address    :: Maybe Addr
-      , caller     :: Maybe Addr
-      , origin     :: Maybe Addr
-      , coinbase   :: Maybe Addr
-      , value      :: Maybe W256
-      , gas        :: Maybe W256
-      , number     :: Maybe W256
-      , timestamp  :: Maybe W256
-      , gaslimit   :: Maybe W256
-      , gasprice   :: Maybe W256
-      , difficulty :: Maybe W256
-      , debug      :: Bool
-      , state      :: Maybe String
+      { code        :: ByteString
+      , calldata    :: Maybe ByteString
+      , address     :: Maybe Addr
+      , caller      :: Maybe Addr
+      , origin      :: Maybe Addr
+      , coinbase    :: Maybe Addr
+      , value       :: Maybe W256
+      , gas         :: Maybe W256
+      , number      :: Maybe W256
+      , timestamp   :: Maybe W256
+      , gaslimit    :: Maybe W256
+      , gasprice    :: Maybe W256
+      , maxcodesize :: Maybe W256
+      , difficulty  :: Maybe W256
+      , debug       :: Bool
+      , state       :: Maybe String
       }
   | DappTest
       { jsonFile           :: Maybe String
@@ -328,6 +329,7 @@ vmFromCommand cmd =
       , EVM.vmoptTimestamp     = word timestamp 0
       , EVM.vmoptBlockGaslimit = word gaslimit 0
       , EVM.vmoptGasprice      = word gasprice 0
+      , EVM.vmoptMaxCodeSize   = word maxcodesize 0xffffffff
       , EVM.vmoptDifficulty    = word difficulty 0
       , EVM.vmoptSchedule      = FeeSchedule.metropolis
       , EVM.vmoptCreate        = False

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -123,6 +123,7 @@ data Command w
   | Compliance -- Run Ethereum Blockhain or VMTest compliance report
       { tests   :: w ::: String       <?> "Path to Ethereum Tests directory"
       , group   :: w ::: Maybe String <?> "Report group to run: VM or Blockchain (default: Blockchain)"
+      , match   :: w ::: Maybe String <?> "Test case filter - only run methods matching regex"
       , skip    :: w ::: Maybe String <?> "Test case filter - skip tests containing string"
       , html    :: w ::: Bool         <?> "Output html report"
       , timeout :: w ::: Maybe Int    <?> "Execution timeout (default: 10 sec.)"
@@ -223,6 +224,7 @@ launchScript script cmd = do
       [ dataDir ++ script
       , "."
       , show (html cmd)
+      , fromMaybe "" (match cmd)
       , fromMaybe "" (skip cmd)
       , show $ fromMaybe 10 (timeout cmd)
       ]

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -123,8 +123,7 @@ data Command w
   | Compliance -- Run Ethereum Blockhain or VMTest compliance report
       { tests   :: w ::: String       <?> "Path to Ethereum Tests directory"
       , group   :: w ::: Maybe String <?> "Report group to run: VM or Blockchain (default: Blockchain)"
-      , match   :: w ::: Maybe String <?> "Test case filter - only run methods matching regex"
-      , skip    :: w ::: Maybe String <?> "Test case filter - skip methods matching regex"
+      , skip    :: w ::: Maybe String <?> "Test case filter - skip tests containing word"
       , timeout :: w ::: Maybe Int    <?> "Execution timeout (default: 10 sec.)"
       }
   | Flatten -- Concat all dependencies for a given source file
@@ -222,9 +221,8 @@ launchScript script cmd = do
     callProcess "bash"
       [ dataDir ++ script
       , "."
-      , fromMaybe "" (match cmd)
-      , fromMaybe "" (skip cmd)
       , show $ fromMaybe 10 (timeout cmd)
+      , fromMaybe "" (skip cmd)
       ]
 
 findJsonFile :: Maybe String -> IO String

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -25,6 +25,7 @@ category:
 build-type:
   Simple
 data-files:
+  run-blockchain-tests
   run-consensus-tests
 extra-source-files:
   CHANGELOG.md

--- a/src/hevm/run-blockchain-tests
+++ b/src/hevm/run-blockchain-tests
@@ -45,7 +45,7 @@ h1, h2 { text-align: center; margin-top: 2rem  }
 <header>
 <h1>hevm consensus test report</h1>
 <p>$(date +%Y-%m-%d)</p>
-<p>$(echo "$npass passed, $nbal bad-balance, $nfail failed, $nskip skipped, $ntime timeout")</p>
+<p>$(echo "$npass passed, $nbal bad-balance, $nnon bad-nonce, $nstr bad-storage, $nfail failed, $nskip skipped, $ntime timeout")</p>
 (Test suite: <span class=GeneralStateTests</span>GeneralStateTests</span> for ConstantinopleFix)
 </header>
 <h2>Failed tests</h2>

--- a/src/hevm/run-blockchain-tests
+++ b/src/hevm/run-blockchain-tests
@@ -103,12 +103,14 @@ shopt -s nocasematch
     esac
   done
 
-  npass=$(echo -ne "$passed" | wc -l | awk '{print $1}')
-  nbal=$(echo -ne "$balancefailed" | wc -l | awk '{print $1}')
-  nnon=$(echo -ne "$noncefailed" | wc -l | awk '{print $1}')
-  nstr=$(echo -ne "$storagefailed" | wc -l | awk '{print $1}')
-  nfail=$(echo -ne "$failed" | wc -l | awk '{print $1}')
-  nskip=$(echo -ne "$skipped" | wc -l | awk '{print $1}')
+  sum () { echo -ne "$1" | wc -l | awk '{print $1}'; }
+
+  npass=$(sum "$passed")
+  nbal=$(sum "$balancefailed")
+  nnon=$(sum "$noncefailed")
+  nstr=$(sum "$storagefailed")
+  nfail=$(sum "$failed")
+  nskip=$(sum "$skipped")
 
   echo >&2 "passed: $npass"
   echo >&2 "bad-balance: $nbal"

--- a/src/hevm/run-blockchain-tests
+++ b/src/hevm/run-blockchain-tests
@@ -3,25 +3,15 @@ set -e
 
 HEVM=${HEVM:-hevm}
 
-skip=''
-test=''
-timeout=10
-usage() { echo "Usage: $(basename "$0") [--skip=<pattern>] [--test=<pattern>] [--timeout=<seconds>] <tests-dir>" 1>&2; exit 1; }
-OPTS=$(getopt --name="$0" --options=d --longoptions="skip:,test:,timeout:" -- "$@") || usage
-eval set -- "$OPTS"
-while true; do
-  case "$1" in
-    --skip)    skip=$2; shift 2 ;;
-    --test)    test=$2; shift 2 ;;
-    --timeout) timeout=$2; shift 2 ;;
-    --) shift; break ;;
-    *) usage ;;
-  esac
-done
-if [[ $# -ne 1 ]]; then
-  usage
+if [[ $# != 1 ]]; then
+  echo >&2 "usage: $(basename "$0") <tests-dir>"
+  exit 1
 fi
+
 tests=$1
+test=$2
+skip=$3
+timeout=${4:-10}
 
 shopt -s nocasematch
 {

--- a/src/hevm/run-blockchain-tests
+++ b/src/hevm/run-blockchain-tests
@@ -61,7 +61,7 @@ $(echo $balancefailed)
 <h2>Timeout tests</h2>
 <table id=timeout>
 <tbody>
-$(echo $timeout)
+$(echo $timeouts)
 </table>
 <h2>Skipped tests</h2>
 <table id=skipped>
@@ -102,7 +102,7 @@ shopt -s nocasematch
       bad-balance) balancefailed+=$row ;;
       bad-nonce)   noncefailed+=$row ;;
       bad-storage) storagefailed+=$row ;;
-      timeout)     timeout+=$row ;;
+      timeout)     timeouts+=$row ;;
       skip)        skipped+=$row ;;
       *)           failed+=$row ;;
     esac
@@ -115,7 +115,7 @@ shopt -s nocasematch
   nnon=$(sum "$noncefailed")
   nstr=$(sum "$storagefailed")
   nfail=$(sum "$failed")
-  ntime=$(sum "$timeout")
+  ntime=$(sum "$timeouts")
   nskip=$(sum "$skipped")
 
   echo >&2 "passed: $npass"

--- a/src/hevm/run-blockchain-tests
+++ b/src/hevm/run-blockchain-tests
@@ -30,7 +30,9 @@ shopt -s nocasematch
         echo -n "$x " ; echo -n "$job " ; echo "skip"
       done
     elif [[ $x =~ .*$test.* ]]; then
-      echo -n "$x " ; "$HEVM" bc-test --file $x
+      set +e
+      echo -n "$x " ; "$HEVM" bc-test --file $x 2>&1
+      set -e
     fi
   done
 } | {

--- a/src/hevm/run-blockchain-tests
+++ b/src/hevm/run-blockchain-tests
@@ -3,15 +3,14 @@ set -e
 
 HEVM=${HEVM:-hevm}
 
-if [[ $# != 1 ]]; then
+if [[ "$#" -lt 1 ]]; then
   echo >&2 "usage: $(basename "$0") <tests-dir>"
   exit 1
 fi
 
 tests=$1
-test=$2
+timeout=${2:-10}
 skip=$3
-timeout=${4:-10}
 
 shopt -s nocasematch
 {

--- a/src/hevm/run-blockchain-tests
+++ b/src/hevm/run-blockchain-tests
@@ -129,4 +129,8 @@ shopt -s nocasematch
   if [[ $html == "True" ]]; then
     _html
   fi
+
+  nbad=$(($nbal + $nnon + $nstr + $nfail))
+
+  [[ $nbad -gt 0 ]] && exit 1 || exit 0
 }

--- a/src/hevm/run-blockchain-tests
+++ b/src/hevm/run-blockchain-tests
@@ -2,7 +2,7 @@
 set -e
 
 # Invoke with hevm e.g.
-# hevm compliance --tests ~/ethereum-tests --skip quadratic --timeout 20 --html
+# hevm compliance --tests ~/ethereum-tests --skip modexp --timeout 20 --html
 
 HEVM=${HEVM:-hevm}
 
@@ -13,22 +13,20 @@ fi
 
 tests=$1
 html=$2
-skip=$3
-timeout=${4:-10}
+match=$3
+skip=$4
+timeout=${5:-10}
 
 _html () {
 cat <<.
 <!doctype html>
 <title>hevm test results</title>
 <style>
-* {
-  font-family:
-    "latin modern mono", "fantasque sans mono",
-    inconsolata, menlo, monospace;
-  font-size: 22px;
-  line-height: 26px;
-}
-
+* { font-family:
+"latin modern mono", "fantasque sans mono",
+inconsolata, menlo, monospace;
+font-size: 22px;
+line-height: 26px; }
 body { margin: 2rem; }
 header { text-align: center; margin: 4rem 0; }
 table { border-collapse: collapse; width: 100%; }
@@ -76,11 +74,11 @@ shopt -s nocasematch
 {
   cd "$tests"
   for x in BlockchainTests/GeneralStateTests/*/*; do
-    if [[ $x =~ .*$test.* ]] && [[ -n $skip && $x =~ .*$skip.* ]]; then
+    if [[ $x =~ .*$match.* ]] && [[ -n $skip && $x =~ .*$skip.* ]]; then
       for job in $(<$x jq '.|keys[]' -r); do
         echo -n "$x " ; echo -n "$job " ; echo "skip"
       done
-    elif [[ $x =~ .*$test.* ]]; then
+    elif [[ $x =~ .*$match.* ]]; then
       set +e
       echo -n "$x " ; "$HEVM" bc-test --file $x --timeout $timeout 2>&1
       set -e

--- a/src/hevm/run-blockchain-tests
+++ b/src/hevm/run-blockchain-tests
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+# Invoke with hevm e.g.
+# hevm compliance --tests ~/ethereum-tests --skip quadratic --timeout 20 --html
+
 HEVM=${HEVM:-hevm}
 
 if [[ "$#" -lt 1 ]]; then
@@ -9,8 +12,65 @@ if [[ "$#" -lt 1 ]]; then
 fi
 
 tests=$1
-timeout=${2:-10}
+html=$2
 skip=$3
+timeout=${4:-10}
+
+_html () {
+cat <<.
+<!doctype html>
+<title>hevm test results</title>
+<style>
+* {
+  font-family:
+    "latin modern mono", "fantasque sans mono",
+    inconsolata, menlo, monospace;
+  font-size: 22px;
+  line-height: 26px;
+}
+
+body { margin: 2rem; }
+header { text-align: center; margin: 4rem 0; }
+table { border-collapse: collapse; width: 100%; }
+tr:nth-child(even) { background: rgba(0, 0, 0, 0.05); }
+td:not(:first-child):not(:last-child) { padding: 0 1rem; }
+.category { opacity: 0.6; text-align: right }
+a { color: darkblue; text-decoration: none; }
+h1, h2 { text-align: center; margin-top: 2rem  }
+.testcase { font-weight: bold }
+#failed .testcase { color: rgb(200, 0, 0) }
+#balancefailed .testcase { color: rgb(200, 200, 0) }
+#passed .testcase { color: rgb(0, 150, 0) }
+#skipped .testcase { color: rgb(0, 100, 250) }
+</style>
+<header>
+<h1>hevm consensus test report</h1>
+<p>$(date +%Y-%m-%d)</p>
+<p>$(echo "$npass passed, $nbal bad-balance, $nfail failed, $nskip skipped")</p>
+(Test suite: <span class=GeneralStateTests</span>GeneralStateTests</span> for ConstantinopleFix)
+</header>
+<h2>Failed tests</h2>
+<table id=failed>
+<tbody>
+$(echo $failed)
+</table>
+<h2>Failed tests (due to balance only)</h2>
+<table id=balancefailed>
+<tbody>
+$(echo $balancefailed)
+</table>
+<h2>Skipped tests</h2>
+<table id=skipped>
+<tbody>
+$(echo $skipped)
+</table>
+<h2>Passed tests</h2>
+<table id=passed>
+<tbody>
+$(echo $passed)
+</table>
+.
+}
 
 shopt -s nocasematch
 {
@@ -43,81 +103,12 @@ shopt -s nocasematch
     esac
   done
 
-  npass=$(echo -ne "$passed" | wc -l)
-  nbal=$(echo -ne "$balancefailed" | wc -l)
-  nnon=$(echo -ne "$noncefailed" | wc -l)
-  nstr=$(echo -ne "$storagefailed" | wc -l)
-  nfail=$(echo -ne "$failed" | wc -l)
-  nskip=$(echo -ne "$skipped" | wc -l)
-
-  cat <<.
-<!doctype html>
-<title>hevm test results</title>
-<style>
-* {
-  font-family:
-    "latin modern mono", "fantasque sans mono",
-    inconsolata, menlo, monospace;
-  font-size: 22px;
-  line-height: 26px;
-}
-
-body { margin: 2rem; }
-header { text-align: center; margin: 4rem 0; }
-table { border-collapse: collapse; width: 100%; }
-tr:nth-child(even) { background: rgba(0, 0, 0, 0.05); }
-td:not(:first-child):not(:last-child) { padding: 0 1rem; }
-.category { opacity: 0.6; text-align: right }
-a { color: darkblue; text-decoration: none; }
-h1, h2 { text-align: center; margin-top: 2rem  }
-.testcase { font-weight: bold }
-#failed .testcase { color: rgb(200, 0, 0) }
-#balancefailed .testcase { color: rgb(200, 200, 0) }
-#passed .testcase { color: rgb(0, 150, 0) }
-#skipped .testcase { color: rgb(0, 100, 250) }
-</style>
-<header>
-<h1>hevm consensus test report</h1>
-<p>
-$(date +%Y-%m-%d)
-<p>
-.
-
-  echo "$npass passed, $nbal bad-balance, $nfail failed, $nskip skipped"
-
-  cat <<.
-<p>
-(Test suite: <span class=GeneralStateTests</span>GeneralStateTests</span> for ConstantinopleFix)
-</header>
-<h2>Failed tests</h2>
-<table id=failed>
-<tbody>
-.
-  echo "$failed"
-  cat <<.
-</table>
-<h2>Failed tests (due to balance only)</h2>
-<table id=balancefailed>
-<tbody>
-.
-  echo "$balancefailed"
-  cat <<.
-</table>
-<h2>Skipped tests</h2>
-<table id=skipped>
-<tbody>
-.
-  echo "$skipped"
-  cat <<.
-</table>
-<h2>Passed tests</h2>
-<table id=passed>
-<tbody>
-.
-  echo "$passed"
-  cat <<.
-</table>
-.
+  npass=$(echo -ne "$passed" | wc -l | awk '{print $1}')
+  nbal=$(echo -ne "$balancefailed" | wc -l | awk '{print $1}')
+  nnon=$(echo -ne "$noncefailed" | wc -l | awk '{print $1}')
+  nstr=$(echo -ne "$storagefailed" | wc -l | awk '{print $1}')
+  nfail=$(echo -ne "$failed" | wc -l | awk '{print $1}')
+  nskip=$(echo -ne "$skipped" | wc -l | awk '{print $1}')
 
   echo >&2 "passed: $npass"
   echo >&2 "bad-balance: $nbal"
@@ -125,4 +116,8 @@ $(date +%Y-%m-%d)
   echo >&2 "bad-storage: $nstr"
   echo >&2 "failed: $nfail"
   echo >&2 "skipped: $nskip"
+
+  if [[ $html == "True" ]]; then
+    _html
+  fi
 }

--- a/src/hevm/run-blockchain-tests
+++ b/src/hevm/run-blockchain-tests
@@ -40,11 +40,12 @@ h1, h2 { text-align: center; margin-top: 2rem  }
 #balancefailed .testcase { color: rgb(200, 200, 0) }
 #passed .testcase { color: rgb(0, 150, 0) }
 #skipped .testcase { color: rgb(0, 100, 250) }
+#timeout .testcase { color: rgb(0, 0, 250) }
 </style>
 <header>
 <h1>hevm consensus test report</h1>
 <p>$(date +%Y-%m-%d)</p>
-<p>$(echo "$npass passed, $nbal bad-balance, $nfail failed, $nskip skipped")</p>
+<p>$(echo "$npass passed, $nbal bad-balance, $nfail failed, $nskip skipped, $ntime timeout")</p>
 (Test suite: <span class=GeneralStateTests</span>GeneralStateTests</span> for ConstantinopleFix)
 </header>
 <h2>Failed tests</h2>
@@ -56,6 +57,11 @@ $(echo $failed)
 <table id=balancefailed>
 <tbody>
 $(echo $balancefailed)
+</table>
+<h2>Timeout tests</h2>
+<table id=timeout>
+<tbody>
+$(echo $timeout)
 </table>
 <h2>Skipped tests</h2>
 <table id=skipped>
@@ -96,6 +102,7 @@ shopt -s nocasematch
       bad-balance) balancefailed+=$row ;;
       bad-nonce)   noncefailed+=$row ;;
       bad-storage) storagefailed+=$row ;;
+      timeout)     timeout+=$row ;;
       skip)        skipped+=$row ;;
       *)           failed+=$row ;;
     esac
@@ -108,6 +115,7 @@ shopt -s nocasematch
   nnon=$(sum "$noncefailed")
   nstr=$(sum "$storagefailed")
   nfail=$(sum "$failed")
+  ntime=$(sum "$timeout")
   nskip=$(sum "$skipped")
 
   echo >&2 "passed: $npass"
@@ -115,6 +123,7 @@ shopt -s nocasematch
   echo >&2 "bad-nonce: $nnon"
   echo >&2 "bad-storage: $nstr"
   echo >&2 "failed: $nfail"
+  echo >&2 "timeout: $ntime"
   echo >&2 "skipped: $nskip"
 
   if [[ $html == "True" ]]; then

--- a/src/hevm/run-blockchain-tests
+++ b/src/hevm/run-blockchain-tests
@@ -5,13 +5,15 @@ HEVM=${HEVM:-hevm}
 
 skip=''
 test=''
-usage() { echo "Usage: $(basename "$0") [--skip=<pattern>] [--test=<pattern>] <tests-dir>" 1>&2; exit 1; }
-OPTS=$(getopt --name="$0" --options=d --longoptions="skip:,test:" -- "$@") || usage
+timeout=10
+usage() { echo "Usage: $(basename "$0") [--skip=<pattern>] [--test=<pattern>] [--timeout=<seconds>] <tests-dir>" 1>&2; exit 1; }
+OPTS=$(getopt --name="$0" --options=d --longoptions="skip:,test:,timeout:" -- "$@") || usage
 eval set -- "$OPTS"
 while true; do
   case "$1" in
-    --skip) skip=$2; shift 2 ;;
-    --test) test=$2; shift 2 ;;
+    --skip)    skip=$2; shift 2 ;;
+    --test)    test=$2; shift 2 ;;
+    --timeout) timeout=$2; shift 2 ;;
     --) shift; break ;;
     *) usage ;;
   esac
@@ -31,7 +33,7 @@ shopt -s nocasematch
       done
     elif [[ $x =~ .*$test.* ]]; then
       set +e
-      echo -n "$x " ; "$HEVM" bc-test --file $x 2>&1
+      echo -n "$x " ; "$HEVM" bc-test --file $x --timeout $timeout 2>&1
       set -e
     fi
   done

--- a/src/hevm/run-consensus-tests
+++ b/src/hevm/run-consensus-tests
@@ -3,15 +3,14 @@ set -e
 
 HEVM=${HEVM:-hevm}
 
-if [[ $# != 1 ]]; then
+if [[ "$#" -lt 1 ]]; then
   echo >&2 "usage: $(basename "$0") <tests-dir>"
   exit 1
 fi
 
 tests=$1
-test=$2 # Not implemented
+timeout=${2:-10} # Not implemented
 skip=$3 # Not implemented
-timeout=${4:-10} # Not implemented
 
 {
   cd "$1"

--- a/src/hevm/run-consensus-tests
+++ b/src/hevm/run-consensus-tests
@@ -90,9 +90,11 @@ $(echo $passed)
     esac
   done
 
-  nfail=$(echo -ne "$failed" | wc -l | awk '{print $1}')
-  npass=$(echo -ne "$passed" | wc -l | awk '{print $1}')
-  nskip=$(echo -ne "$skipped" | wc -l | awk '{print $1}')
+  sum () { echo -ne "$1" | wc -l | awk '{print $1}'; }
+
+  nfail=$(sum "$failed")
+  npass=$(sum "$passed")
+  nskip=$(sum "$skipped")
 
   echo >&2 "failed: $nfail"
   echo >&2 "passed: $npass"

--- a/src/hevm/run-consensus-tests
+++ b/src/hevm/run-consensus-tests
@@ -13,21 +13,20 @@ fi
 
 tests=$1
 html=$2
-skip=$3
-timeout=$4 # Not implemented
+match=$3
+skip=$4
+timeout=${5:-10}
 
 _html() {
 cat <<.
 <!doctype html>
 <title>hevm test results</title>
 <style>
-* {
-  font-family:
-    "latin modern mono", "fantasque sans mono",
-    inconsolata, menlo, monospace;
-  font-size: 22px;
-  line-height: 26px;
-}
+* { font-family:
+"latin modern mono", "fantasque sans mono",
+inconsolata, menlo, monospace;
+font-size: 22px;
+line-height: 26px; }
 body { margin: 2rem; }
 header { text-align: center; margin: 4rem 0; }
 table { border-collapse: collapse; width: 100%; }
@@ -68,12 +67,12 @@ $(echo $passed)
 {
   cd "$tests"
   for x in VMTests/*/*; do
-    if [[ -n $skip && $x =~ .*$skip.* ]]; then
+    if [[ $x =~ .*$match.* ]] && [[ -n $skip && $x =~ .*$skip.* ]]; then
       for job in $(<$x jq '.|keys[]' -r); do
         echo "$x $job skip"
       done
-    else
-      echo -n "$x " ; "$HEVM" vm-test --file $x
+    elif [[ $x =~ .*$match.* ]]; then
+      echo -n "$x " ; "$HEVM" vm-test --file $x --timeout $timeout 2>&1
     fi
   done
 } | {

--- a/src/hevm/run-consensus-tests
+++ b/src/hevm/run-consensus-tests
@@ -8,6 +8,11 @@ if [[ $# != 1 ]]; then
   exit 1
 fi
 
+tests=$1
+test=$2 # Not implemented
+skip=$3 # Not implemented
+timeout=${4:-10} # Not implemented
+
 {
   cd "$1"
   for x in VMTests/*/*; do
@@ -25,7 +30,7 @@ fi
       *)  failed+=$row ;;
     esac
   done
-  
+
   cat <<.
 <!doctype html>
 <title>hevm test results</title>
@@ -61,7 +66,7 @@ $(date +%Y-%m-%d)
   echo "passed, "
   wc -l <<<"$failed"
   echo "failed"
-  
+
   cat <<.
 <p>
 (Test suite: <span class=VMTests</span>VMTests</span> for Homestead)

--- a/src/hevm/run-consensus-tests
+++ b/src/hevm/run-consensus-tests
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+# Invoke with hevm e.g.
+# hevm compliance --tests ~/ethereum-tests --group VM --skip quadratic --html
+
 HEVM=${HEVM:-hevm}
 
 if [[ "$#" -lt 1 ]]; then
@@ -9,28 +12,12 @@ if [[ "$#" -lt 1 ]]; then
 fi
 
 tests=$1
-timeout=${2:-10} # Not implemented
-skip=$3 # Not implemented
+html=$2
+skip=$3
+timeout=$4 # Not implemented
 
-{
-  cd "$1"
-  for x in VMTests/*/*; do
-    echo >&2 "$x"
-    echo -n "$x " ; "$HEVM" vm-test --file $x
-  done
-} | {
-  while read path test outcome; do
-    category=$(dirname "$path")
-    testcase=$(basename "${path%.json}")
-    row="<tr><td class=testcase>$testcase<td>$outcome<td class=category>$category"
-    row+=$'\n'
-    case $outcome in
-      ok) passed+=$row ;;
-      *)  failed+=$row ;;
-    esac
-  done
-
-  cat <<.
+_html() {
+cat <<.
 <!doctype html>
 <title>hevm test results</title>
 <style>
@@ -41,7 +28,6 @@ skip=$3 # Not implemented
   font-size: 22px;
   line-height: 26px;
 }
-
 body { margin: 2rem; }
 header { text-align: center; margin: 4rem 0; }
 table { border-collapse: collapse; width: 100%; }
@@ -53,36 +39,66 @@ h1, h2 { text-align: center; margin-top: 2rem  }
 .testcase { font-weight: bold }
 #failed .testcase { color: rgb(200, 0, 0) }
 #passed .testcase { color: rgb(0, 150, 0) }
+#skipped .testcase { color: rgb(0, 100, 250) }
 </style>
 <header>
 <h1>hevm consensus test report</h1>
-<p>
-$(date +%Y-%m-%d)
-<p>
-.
-
-  wc -l <<<"$passed"
-  echo "passed, "
-  wc -l <<<"$failed"
-  echo "failed"
-
-  cat <<.
-<p>
-(Test suite: <span class=VMTests</span>VMTests</span> for Homestead)
+<p>$(date +%Y-%m-%d)</p>
+<p>$(echo "$npass passed, $nfail failed, $nskip skipped")</p>
+(Test suite: <span class=VMTests</span>VMTests</span> for ConstantinopleFix)
 </header>
 <h2>Failed tests</h2>
 <table id=failed>
 <tbody>
-.
-  echo "$failed"
-  cat <<.
+$(echo $failed)
+</table>
+<h2>Skipped tests</h2>
+<table id=skipped>
+<tbody>
+$(echo $skipped)
 </table>
 <h2>Passed tests</h2>
 <table id=passed>
 <tbody>
-.
-  echo "$passed"
-  cat <<.
+$(echo $passed)
 </table>
 .
+}
+
+{
+  cd "$tests"
+  for x in VMTests/*/*; do
+    if [[ -n $skip && $x =~ .*$skip.* ]]; then
+      for job in $(<$x jq '.|keys[]' -r); do
+        echo "$x $job skip"
+      done
+    else
+      echo -n "$x " ; "$HEVM" vm-test --file $x
+    fi
+  done
+} | {
+  while read path test outcome; do
+    echo >&2 "$path $test $outcome"
+    category=$(dirname "$path")
+    testcase=$(basename "${path%.json}")
+    row="<tr><td class=testcase>$testcase<td>$outcome<td class=category>$category"
+    row+=$'\n'
+    case $outcome in
+      ok)   passed+=$row ;;
+      skip) skipped+=$row ;;
+      *)    failed+=$row ;;
+    esac
+  done
+
+  nfail=$(echo -ne "$failed" | wc -l | awk '{print $1}')
+  npass=$(echo -ne "$passed" | wc -l | awk '{print $1}')
+  nskip=$(echo -ne "$skipped" | wc -l | awk '{print $1}')
+
+  echo >&2 "failed: $nfail"
+  echo >&2 "passed: $npass"
+  echo >&2 "skipped: $nskip"
+
+  if [[ $html == "True" ]]; then
+    _html
+  fi
 }

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1732,6 +1732,7 @@ finishFrame how = do
             FrameReverted output -> do
               revertContracts
               assign (state . returndata) output
+              copyCallBytesToMemory output outSize 0 outOffset
               reclaimRemainingGasAllowance
               push 0
 

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1750,9 +1750,12 @@ finishFrame how = do
 
         -- Or were we creating?
         CreationContext _ reversion -> do
+          creator <- use (state . contract)
           let
             createe = view (state . contract) oldVm
-            revertContracts = assign (env . contracts) reversion
+            revertContracts = assign (env . contracts) reversion'
+            -- persist the nonce through the reversion
+            reversion' = (Map.adjust (over nonce (+ 1)) creator) reversion
 
           case how of
             -- Case 4: Returning during a creation?

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -2302,9 +2302,9 @@ costOfCreate
   :: FeeSchedule Word
   -> Word -> Word -> (Word, Word)
 costOfCreate (FeeSchedule {..}) availableGas hashSize =
-  (createCost + hashCost + initGas, initGas)
+  (createCost + initGas, initGas)
   where
-    createCost = g_create
+    createCost = g_create + hashCost
     hashCost   = g_sha3word * ceilDiv (hashSize) 32
     initGas    = allButOne64th (availableGas - createCost)
 

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1370,7 +1370,7 @@ costOfPrecompile (FeeSchedule {..}) precompileAddr input =
     -- ECMUL
     0x7 -> 40000
     -- ECPAIRING
-    0x8 -> num $ ((BS.length input) `div` 192) * 60000 + 40000
+    0x8 -> num $ ((BS.length input) `div` 192) * 80000 + 100000
     _ -> error ("unimplemented precompiled contract " ++ show precompileAddr)
 
 

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -26,7 +26,7 @@ import qualified EVM.Precompiled
 
 import Data.Binary.Get (runGetOrFail)
 import Data.Bits (bit, testBit, complement)
-import Data.Bits (xor, shiftL, shiftR, (.&.), (.|.), FiniteBits (..))
+import Data.Bits (xor, shiftR, (.&.), (.|.), FiniteBits (..))
 import Data.Text (Text)
 import Data.Word (Word8, Word32)
 
@@ -556,11 +556,11 @@ exec1 = do
             0xff .&. shiftR x (8 * (31 - num n))
 
         -- op: SHL
-        0x1b -> stackOp2 (const g_verylow) $ \(n, x) -> shiftL x (num n)
+        0x1b -> stackOp2 (const g_verylow) $ \(n, x) -> shl x n
         -- op: SHR
-        0x1c -> stackOp2 (const g_verylow) $ \(n, x) -> shiftR x (num n)
+        0x1c -> stackOp2 (const g_verylow) $ \(n, x) -> shr x n
         -- op: SAR
-        0x1d -> stackOp2 (const g_verylow) $ uncurry sar
+        0x1d -> stackOp2 (const g_verylow) $ \(n, x) -> sar x n
 
         -- op: SHA3
         0x20 ->

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -859,6 +859,8 @@ exec1 = do
                   then do
                     burn g_create $ do
                       assign (state . stack) (0 : xs)
+                      assign (state . returndata) mempty
+                      pushTrace $ ErrorTrace $ BalanceTooLow xValue (view balance this)
                       next
                   else do
                     availableGas <- use (state . gas)
@@ -1005,6 +1007,8 @@ exec1 = do
                   then do
                     burn g_create $ do
                       assign (state . stack) (0 : xs)
+                      assign (state . returndata) mempty
+                      pushTrace $ ErrorTrace $ BalanceTooLow xValue (view balance this)
                       next
                   else do
                     availableGas <- use (state . gas)

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1559,18 +1559,16 @@ finalize True = do
 
   -- deposit the code from a creation tx, or not, depending on success
   use (tx . isCreate) >>= \case
-    False -> return ()
     True  -> case res of
-      Just (VMFailure _) -> do
-        createe <- use (state . contract)
-        modifying (env . contracts)
-          (Map.delete createe)
       Just (VMSuccess output) -> do
         createe <- use (state . contract)
         createeExists <- (Map.member createe) <$> use (env . contracts)
         if createeExists then replaceCode createe (RuntimeCode output)
         else return ()
+      Just (VMFailure _) -> do
+        return ()
       Nothing -> error "Finalising an unfinished tx."
+    False -> return ()
 
   -- compute and pay the refund to the caller and the
   -- corresponding payment to the miner, including the

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -78,6 +78,7 @@ data Error
   | InvalidMemoryAccess
   | CallDepthLimitReached
   | MaxCodeSizeExceeded Word Word
+  | PrecompileFailure
 
 deriving instance Show Error
 
@@ -1283,8 +1284,10 @@ executePrecompile fees preCompileAddr gasCap inOffset inSize outOffset outSize x
         -- ECADD
         0x6 -> case EVM.Precompiled.execute 0x6 (truncpad 128 input) 64 of
           Nothing -> do
-            assign (state . stack) (0 : xs)
-            next
+            burn (gasCap - cost) $ do
+              assign (state . stack) (0 : xs)
+              pushTrace $ ErrorTrace $ PrecompileFailure
+              next
           Just output -> do
             let truncpaddedOutput = truncpad 64 output
             assign (state . stack) (1 : xs)
@@ -1295,8 +1298,10 @@ executePrecompile fees preCompileAddr gasCap inOffset inSize outOffset outSize x
         -- ECMUL
         0x7 -> case EVM.Precompiled.execute 0x7 (truncpad 96 input) 64 of
           Nothing -> do
-            assign (state . stack) (0 : xs)
-            next
+            burn (gasCap - cost) $ do
+              assign (state . stack) (0 : xs)
+              pushTrace $ ErrorTrace $ PrecompileFailure
+              next
           Just output -> do
             let truncpaddedOutput = truncpad 64 output
             assign (state . stack) (1 : xs)
@@ -1307,8 +1312,10 @@ executePrecompile fees preCompileAddr gasCap inOffset inSize outOffset outSize x
         -- ECPAIRING
         0x8 -> case EVM.Precompiled.execute 0x8 input 32 of
           Nothing -> do
-            assign (state . stack) (0 : xs)
-            next
+            burn (gasCap - cost) $ do
+              assign (state . stack) (0 : xs)
+              pushTrace $ ErrorTrace $ PrecompileFailure
+              next
           Just output -> do
             let truncpaddedOutput = truncpad 32 output
             assign (state . stack) (1 : xs)

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -877,44 +877,44 @@ exec1 = do
               : xs
              ) ->
               case xTo of
-                n | n > 0 && n <= 8 -> precompiledContract vm fees xGas xTo xTo xValue xInOffset xInSize xOutOffset xOutSize xs
+                n | n > 0 && n <= 8 ->
+                  precompiledContract vm fees xGas xTo xTo xValue xInOffset xInSize xOutOffset xOutSize xs
                 n | num n == cheatCode ->
                   do
                     assign (state . stack) xs
                     cheat (xInOffset, xInSize) (xOutOffset, xOutSize)
                 _ ->
-                 do
-                   accessMemoryRange fees xInOffset xInSize $ do
-                     accessMemoryRange fees xOutOffset xOutSize $ do
-                      availableGas <- use (state . gas)
-                      let
-                        recipientExists = accountExists xTo vm
-                        (cost, gas') = costOfCall fees recipientExists xValue availableGas xGas
-                      burn (cost - gas') $
-                        (if xValue > 0 then notStatic else id) $
-                        if xValue > view balance this
-                        then do
-                          assign (state . stack) (0 : xs)
-                          assign (state . returndata) mempty
-                          pushTrace $ ErrorTrace $ BalanceTooLow xValue (view balance this)
-                          -- todo: push to vm . result?
-                          next
-                        else
-                          case view execMode vm of
-                            ExecuteAsVMTest -> do
-                              assign (state . stack) (1 : xs)
-                              next
-                            _ -> do
-                              delegateCall gas' xTo xInOffset xInSize xOutOffset xOutSize xs $ do
-                                zoom state $ do
-                                  assign callvalue xValue
-                                  assign caller (the state contract)
-                                  assign contract xTo
-                                zoom (env . contracts) $ do
-                                  ix self . balance -= xValue
-                                  ix xTo  . balance += xValue
-                                modifying (tx . touchedAccounts) (self:)
-                                modifying (tx . touchedAccounts) (xTo:)
+                  (if xValue > 0 then notStatic else id) $
+                    accessMemoryRange fees xInOffset xInSize $
+                      accessMemoryRange fees xOutOffset xOutSize $ do
+                        availableGas <- use (state . gas)
+                        let
+                          recipientExists = accountExists xTo vm
+                          (cost, gas') = costOfCall fees recipientExists xValue availableGas xGas
+                        burn (cost - gas') $
+                          if xValue > view balance this
+                          then do
+                            assign (state . stack) (0 : xs)
+                            assign (state . returndata) mempty
+                            pushTrace $ ErrorTrace $ BalanceTooLow xValue (view balance this)
+                            -- todo: push to vm . result?
+                            next
+                          else
+                            case view execMode vm of
+                              ExecuteAsVMTest -> do
+                                assign (state . stack) (1 : xs)
+                                next
+                              _ -> do
+                                delegateCall gas' xTo xInOffset xInSize xOutOffset xOutSize xs $ do
+                                  zoom state $ do
+                                    assign callvalue xValue
+                                    assign caller (the state contract)
+                                    assign contract xTo
+                                  zoom (env . contracts) $ do
+                                    ix self . balance -= xValue
+                                    ix xTo  . balance += xValue
+                                  modifying (tx . touchedAccounts) (self:)
+                                  modifying (tx . touchedAccounts) (xTo:)
             _ ->
               underrun
 
@@ -931,16 +931,15 @@ exec1 = do
               : xs
               ) ->
               case xTo of
-                n | n > 0 && n <= 8 -> precompiledContract vm fees xGas xTo self xValue xInOffset xInSize xOutOffset xOutSize xs
+                n | n > 0 && n <= 8 ->
+                  precompiledContract vm fees xGas xTo self xValue xInOffset xInSize xOutOffset xOutSize xs
                 _ ->
-                 do
-                   accessMemoryRange fees xInOffset xInSize $ do
-                     accessMemoryRange fees xOutOffset xOutSize $ do
+                  accessMemoryRange fees xInOffset xInSize $
+                    accessMemoryRange fees xOutOffset xOutSize $ do
                       availableGas <- use (state . gas)
                       let
                         (cost, gas') = costOfCall fees True xValue availableGas xGas
                       burn (cost - gas') $
-                        (if xValue > 0 then notStatic else id) $
                         if xValue > view balance this
                         then do
                           assign (state . stack) (0 : xs)
@@ -975,20 +974,20 @@ exec1 = do
           case stk of
             (xGas:(num -> xTo):xInOffset:xInSize:xOutOffset:xOutSize:xs) ->
               case xTo of
-                n | n > 0 && n <= 8 -> precompiledContract vm fees xGas xTo self 0 xInOffset xInSize xOutOffset xOutSize xs
+                n | n > 0 && n <= 8 ->
+                  precompiledContract vm fees xGas xTo self 0 xInOffset xInSize xOutOffset xOutSize xs
                 n | num n == cheatCode -> do
                       assign (state . stack) xs
                       cheat (xInOffset, xInSize) (xOutOffset, xOutSize)
                 _ ->
-                  do
-                   accessMemoryRange fees xInOffset xInSize $ do
-                     accessMemoryRange fees xOutOffset xOutSize $ do
-                      availableGas <- use (state . gas)
-                      let
-                        (cost, gas') = costOfCall fees True 0 availableGas xGas
-                      burn (cost - gas') $
-                        delegateCall gas' xTo xInOffset xInSize xOutOffset xOutSize xs $ do
-                          modifying (tx . touchedAccounts) (self:)
+                  accessMemoryRange fees xInOffset xInSize $
+                    accessMemoryRange fees xOutOffset xOutSize $ do
+                    availableGas <- use (state . gas)
+                    let
+                      (cost, gas') = costOfCall fees True 0 availableGas xGas
+                    burn (cost - gas') $
+                      delegateCall gas' xTo xInOffset xInSize xOutOffset xOutSize xs $ do
+                        modifying (tx . touchedAccounts) (self:)
             _ -> underrun
 
         -- op: CREATE2
@@ -1017,11 +1016,11 @@ exec1 = do
           case stk of
             (xGas : (num -> xTo) : xInOffset : xInSize : xOutOffset : xOutSize : xs) ->
               case xTo of
-                n | n > 0 && n <= 8 -> precompiledContract vm fees xGas xTo xTo 0 xInOffset xInSize xOutOffset xOutSize xs
+                n | n > 0 && n <= 8 ->
+                  precompiledContract vm fees xGas xTo xTo 0 xInOffset xInSize xOutOffset xOutSize xs
                 _ ->
-                  do
-                   accessMemoryRange fees xInOffset xInSize $ do
-                     accessMemoryRange fees xOutOffset xOutSize $ do
+                  accessMemoryRange fees xInOffset xInSize $
+                    accessMemoryRange fees xOutOffset xOutSize $ do
                       availableGas <- use (state . gas)
                       let
                         recipientExists = accountExists xTo vm
@@ -1088,16 +1087,16 @@ precompiledContract
   -> [Word]
   -> EVM ()
 precompiledContract vm fees gasCap precompileAddr recipient xValue inOffset inSize outOffset outSize xs =
-  accessMemoryRange fees inOffset inSize $ do
-    accessMemoryRange fees outOffset outSize $ do
-      availableGas <- use (state . gas)
-      let
-        self = view (state . contract) vm
-        Just this = view (env . contracts . at self) vm
-        recipientExists = accountExists recipient vm
-        (cost, gas') = costOfCall fees recipientExists xValue availableGas gasCap
-      burn (cost - gas') $
-        (if xValue == 0 then notStatic else id) $
+  (if xValue == 0 then notStatic else id) $
+    accessMemoryRange fees inOffset inSize $
+      accessMemoryRange fees outOffset outSize $ do
+        availableGas <- use (state . gas)
+        let
+          self = view (state . contract) vm
+          Just this = view (env . contracts . at self) vm
+          recipientExists = accountExists recipient vm
+          (cost, gas') = costOfCall fees recipientExists xValue availableGas gasCap
+        burn (cost - gas') $
           if xValue > view balance this then do
             assign (state . stack) (0 : xs)
             next

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -421,8 +421,7 @@ exec1 = do
           calldatasize = num $ BS.length (the state calldata)
         copyBytesToMemory (the state calldata) calldatasize 0 0
         executePrecompile fees self (the state gas) 0 calldatasize 0 0 []
-        stk <- use (state . stack)
-        case stk of
+        use (state . stack) >>= \case
           (0:_) -> do
             touchAccount self $ \_ -> do
               modifying (tx . touchedAccounts) (self:)
@@ -1063,9 +1062,9 @@ exec1 = do
                         -- todo: push to vm . result?
                         next
                       else do
-                        caller <- use (state . caller)
+                        theCaller <- use (state . caller)
                         delegateCall gas' xTo xInOffset xInSize xOutOffset xOutSize xs $ do
-                          modifying (tx . touchedAccounts) (caller:)
+                          modifying (tx . touchedAccounts) (theCaller:)
                           modifying (tx . touchedAccounts) (self:)
             _ -> underrun
 

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -895,6 +895,9 @@ exec1 = do
                         if xValue > view balance this
                         then do
                           assign (state . stack) (0 : xs)
+                          assign (state . returndata) mempty
+                          pushTrace $ ErrorTrace $ BalanceTooLow xValue (view balance this)
+                          -- todo: push to vm . result?
                           next
                         else
                           case view execMode vm of
@@ -941,6 +944,9 @@ exec1 = do
                         if xValue > view balance this
                         then do
                           assign (state . stack) (0 : xs)
+                          assign (state . returndata) mempty
+                          pushTrace $ ErrorTrace $ BalanceTooLow xValue (view balance this)
+                          -- todo: push to vm . result?
                           next
                         else
                           case view execMode vm of

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1226,9 +1226,11 @@ executePrecompile fees preCompileAddr gasCap inOffset inSize outOffset outSize x
       case preCompileAddr of
         -- ECRECOVER
         0x1 ->
-          case EVM.Precompiled.execute 0x1 input (num outSize) of
+          case EVM.Precompiled.execute 0x1 (truncpad 128 input) 32 of
             Nothing -> do
-              assign (state . stack) (0 : xs)
+              -- return no output for invalid signature
+              assign (state . stack) (1 : xs)
+              assign (state . returndata) mempty
               next
             Just output -> do
               assign (state . stack) (1 : xs)

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1623,7 +1623,8 @@ finalize True = do
       touchedAddresses <- use (tx . touchedAccounts)
       modifying (env . contracts)
         (Map.filterWithKey
-          (\k a -> not ((elem k touchedAddresses) && accountEmpty a)))
+          (\k a -> k < 0xff && k > 0x0 && k/= 0x3 ||
+                    not ((elem k touchedAddresses) && accountEmpty a)))
     _ ->
       noop
 

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1360,18 +1360,18 @@ costOfPrecompile (FeeSchedule {..}) precompileAddr input =
     -- MODEXP
     0x5 -> num $ ((f $ max lenm lenb) * (max lene' 1)) `div` (num g_quaddivisor)
       where (lenb, lene, lenm, _, e, _) = parseModexpInput input
-            nextWord = word $ (BS.take 32) . (BS.drop (96 + lenb)) $ input
-            lene' = if e == 0 then 0
-                    else if lene <= 32
-                         then log2 lene
-                         else if nextWord == 0
-                              then 8 * (lene - 32)
-                              else 8 * (lene - 32) + log2 nextWord
+            input' = truncpad (96 + lenb + lene + lenm) input
+            e'     = w256 $ word $ (BS.take lene) . (BS.drop (96 + lenb)) $ input'
+            e32    = w256 $ word $ (BS.take 32)   . (BS.drop (96 + lenb)) $ input'
+            lene'  = if e <= 1 then 0
+                     else if lene <= 32
+                       then log2 e'
+                       else log2 e32 + 8 * (lene - 32)
             f :: Int -> Int
             f x = if x <= 64 then x * x
                   else if x <= 1024
-                       then (x * x) `div` 4 + 96 * x - 3072
-                       else (x * x) `div` 16 + 480 * x - 199680
+                   then (x * x) `div` 4 + 96 * x - 3072
+                   else (x * x) `div` 16 + 480 * x - 199680
     -- ECADD
     0x6 -> 500
     -- ECMUL

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1096,7 +1096,7 @@ precompiledContract vm fees gasCap precompileAddr recipient xValue inOffset inSi
             assign (state . stack) (0 : xs)
             next
           else do
-            executePrecompile fees precompileAddr gasCap inOffset inSize outOffset outSize xs
+            executePrecompile fees precompileAddr gas' inOffset inSize outOffset outSize xs
             stk <- use (state . stack)
             case stk of
               (0:_) ->

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -180,7 +180,7 @@ data FrameContext
     , creationContextReversion :: Map Addr Contract
     , creationContextSelfdestructs :: [Addr]
     , creationContextRefunds       :: [(Addr, Word)]
-
+    , creationContextTouched       :: [Addr]
     }
   | CallContext
     { callContextOffset   :: Word
@@ -191,6 +191,7 @@ data FrameContext
     , callContextReversion :: Map Addr Contract
     , callContextSelfdestructs :: [Addr]
     , callContextRefunds       :: [(Addr, Word)]
+    , callContextTouched       :: [Addr]
     }
 
 -- | The "registers" of the VM along with memory and data stack
@@ -326,7 +327,7 @@ makeVm o = VM
     , _toAddr = vmoptAddress o
     , _value = w256 $ vmoptValue o
     , _selfdestructs = mempty
-    , _touchedAccounts = [vmoptOrigin o, vmoptAddress o, vmoptCoinbase o]
+    , _touchedAccounts = mempty
     , _refunds = mempty
     , _isCreate = vmoptCreate o
     , _txReversion = Map.fromList
@@ -1013,6 +1014,7 @@ exec1 = do
                                 zoom state $ do
                                   assign callvalue xValue
                                   assign caller (the state contract)
+                                modifying (tx . touchedAccounts) (self:)
             _ ->
               underrun
 
@@ -1041,14 +1043,14 @@ exec1 = do
                     let
                       context = view frameContext frame
                     case context of
-                      CreationContext _ _ _ _ ->
+                      CreationContext _ _ _ _ _ ->
                         if codesize > maxsize
                         then do
                           finishFrame (FrameErrored (MaxCodeSizeExceeded maxsize codesize))
                         else
                           burn (g_codedeposit * num (BS.length output)) $
                             finishFrame (FrameReturned output)
-                      CallContext _ _ _ _ _ _ _ _ ->
+                      CallContext _ _ _ _ _ _ _ _ _ ->
                           finishFrame (FrameReturned output)
             _ -> underrun
 
@@ -1076,8 +1078,10 @@ exec1 = do
                         pushTrace $ ErrorTrace $ CallDepthLimitReached
                         -- todo: push to vm . result?
                         next
-                      else
+                      else do
+                        caller <- use (state . caller)
                         delegateCall gas' xTo xInOffset xInSize xOutOffset xOutSize xs $ do
+                          modifying (tx . touchedAccounts) (caller:)
                           modifying (tx . touchedAccounts) (self:)
             _ -> underrun
 
@@ -1171,6 +1175,7 @@ exec1 = do
                   modifying
                     (env . contracts . ix xTo . balance)
                     (+ (vm ^?! env . contracts . ix self . balance))
+                  modifying (tx . touchedAccounts) (self:)
                   modifying (tx . touchedAccounts) (xTo:)
                   doStop
 
@@ -1225,6 +1230,7 @@ precompiledContract vm fees gasCap precompileAddr recipient xValue inOffset inSi
                   ix recipient  . balance += xValue
                 modifying (tx . touchedAccounts) (self:)
                 modifying (tx . touchedAccounts) (recipient:)
+                modifying (tx . touchedAccounts) (precompileAddr:)
               _ ->
                 underrun
 
@@ -1510,7 +1516,7 @@ create self this xGas xValue xOffset xSize xs newAddr =
                               , creationContextReversion = view (env . contracts) vm0
                               , creationContextSelfdestructs = view (tx . selfdestructs) vm0
                               , creationContextRefunds = view (tx . refunds) vm0
-
+                              , creationContextTouched = view (tx . touchedAccounts) vm0
                               }
 
           zoom (env . contracts) $ do
@@ -1610,6 +1616,7 @@ finalize True = do
       assign (env . contracts) reversion
       assign (tx . selfdestructs) mempty
       assign (tx . refunds) mempty
+      assign (tx . touchedAccounts) mempty
     _ ->
       noop
 
@@ -1647,29 +1654,26 @@ finalize True = do
     (Map.adjust (over balance (+ originPay)) txOrigin)
   modifying (env . contracts)
     (Map.adjust (over balance (+ minerPay)) miner)
+  modifying (tx . touchedAccounts) (miner:)
 
-  -- state trie clearing (EIP 161) clears touched
-  -- accounts in the case of success only
+  -- finally, perform state trie clearing (EIP 161), of selfdestructs
+  -- and touched accounts. addresses are cleared if they have
+  --    a) selfdestructed, or
+  --    b) been touched and
+  --    c) are empty.
   -- (see Yellow Paper "Accrued Substate")
-  case res of
-    Just (VMSuccess _) -> do
-      -- addresses are cleared if they have
-      --    a) not already been cleared by selfdestruct,
-      --    b) been touched,
-      --    c) are empty.
-      --
-      -- first, remove any destructed addresses
-      destroyedAddresses <- use (tx . selfdestructs)
-      modifying (env . contracts)
-        (Map.filterWithKey (\k _ -> not (elem k destroyedAddresses)))
-      -- then, clear any remaining empty and touched addresses
-      touchedAddresses <- use (tx . touchedAccounts)
-      modifying (env . contracts)
-        (Map.filterWithKey
-          (\k a -> k < 0xff && k > 0x0 && k/= 0x3 ||
-                    not ((elem k touchedAddresses) && accountEmpty a)))
-    _ ->
-      noop
+  --
+  -- first, remove any destructed addresses
+  destroyedAddresses <- use (tx . selfdestructs)
+  modifying (env . contracts)
+    (Map.filterWithKey (\k _ -> not (elem k destroyedAddresses)))
+  --
+  -- then, clear any remaining empty and touched addresses
+  touchedAddresses <- use (tx . touchedAccounts)
+  modifying (env . contracts)
+    (Map.filterWithKey
+      (\k a -> not ((elem k touchedAddresses) && accountEmpty a)))
+
 
 loadContract :: Addr -> EVM ()
 loadContract target =
@@ -1791,6 +1795,7 @@ delegateCall xGas xTo xInOffset xInSize xOutOffset xOutSize xs continue =
                   , callContextReversion = view (env . contracts) vm0
                   , callContextSelfdestructs = view (tx . selfdestructs) vm0
                   , callContextRefunds = view (tx . refunds) vm0
+                  , callContextTouched = view (tx . touchedAccounts) vm0
                   , callContextAbi =
                       if xInSize >= 4
                       then
@@ -1889,13 +1894,13 @@ finishFrame how = do
       case view frameContext nextFrame of
 
         -- Were we calling?
-        CallContext (num -> outOffset) (num -> outSize) _ _ _ reversion destructs refundz -> do
+        CallContext (num -> outOffset) (num -> outSize) _ _ _ reversion destructs refundz touched -> do
 
           let
             revertContracts = assign (env . contracts) reversion
             revertDestructs = assign (tx . selfdestructs) destructs
             revertRefunds   = assign (tx . refunds) refundz
-
+            revertTouched   = assign (tx . touchedAccounts) touched
 
           case how of
             -- Case 1: Returning from a call?
@@ -1910,6 +1915,7 @@ finishFrame how = do
               revertContracts
               revertDestructs
               revertRefunds
+              revertTouched
               assign (state . returndata) output
               copyCallBytesToMemory output outSize 0 outOffset
               reclaimRemainingGasAllowance
@@ -1920,17 +1926,19 @@ finishFrame how = do
               revertContracts
               revertDestructs
               revertRefunds
+              revertTouched
               assign (state . returndata) mempty
               push 0
 
         -- Or were we creating?
-        CreationContext _ reversion destructs refundz -> do
+        CreationContext _ reversion destructs refundz touched -> do
           creator <- use (state . contract)
           let
             createe = view (state . contract) oldVm
             revertContracts = assign (env . contracts) reversion'
             revertDestructs = assign (tx . selfdestructs) destructs
             revertRefunds   = assign (tx . refunds) refundz
+            revertTouched   = assign (tx . touchedAccounts) touched
 
             -- persist the nonce through the reversion
             reversion' = (Map.adjust (over nonce (+ 1)) creator) reversion
@@ -1948,6 +1956,7 @@ finishFrame how = do
               revertContracts
               revertDestructs
               revertRefunds
+              revertTouched
               assign (state . returndata) output
               reclaimRemainingGasAllowance
               push 0
@@ -1957,6 +1966,7 @@ finishFrame how = do
               revertContracts
               revertDestructs
               revertRefunds
+              revertTouched
               assign (state . returndata) mempty
               push 0
 

--- a/src/hevm/src/EVM/Concrete.hs
+++ b/src/hevm/src/EVM/Concrete.hs
@@ -11,7 +11,7 @@ import EVM.Types (word, padRight)
 import EVM.Keccak (keccak, word256Bytes)
 
 import Control.Lens    ((^?), ix)
-import Data.Bits       (Bits (..), FiniteBits (..))
+import Data.Bits       (Bits (..), FiniteBits (..), shiftL, shiftR)
 import Data.ByteString (ByteString)
 import Data.DoubleWord (signedWord, unsignedWord)
 import Data.Maybe      (fromMaybe)
@@ -88,9 +88,24 @@ sgt :: Word -> Word -> Word
 sgt (C _ (W256 x)) (C _ (W256 y)) =
   if signedWord x > signedWord y then w256 1 else w256 0
 
+shr :: Word -> Word -> Word
+shr x n =
+  if n > 255 then 0
+  else shiftR x (num n)
+
+shl :: Word -> Word -> Word
+shl x n =
+  if n > 255 then 0
+  else shiftL x (num n)
+
 sar :: Word -> Word -> Word
-sar (C _ (W256 x)) (C _ (W256 y)) =
-  w256 (num (shiftR (signedWord y) (num x)))
+sar (C _ (W256 x)) (C _ (W256 n)) =
+  let
+    sx = signedWord x
+  in
+    if n > 255 && sx > 0 then 0
+    else if n > 255 && sx < 0 then -1
+    else w256 (num (unsignedWord (shiftR sx (num n))))
 
 wordValue :: Word -> W256
 wordValue (C _ x) = x

--- a/src/hevm/src/EVM/Exec.hs
+++ b/src/hevm/src/EVM/Exec.hs
@@ -34,6 +34,7 @@ vmForEthrunCreation creationCode =
     , vmoptDifficulty = 0
     , vmoptGas = 0xffffffffffffffff
     , vmoptGaslimit = 0xffffffffffffffff
+    , vmoptMaxCodeSize = 0xffffffff
     , vmoptSchedule = FeeSchedule.metropolis
     , vmoptCreate = False
     }) & set (env . contracts . at ethrunAddress)

--- a/src/hevm/src/EVM/FeeSchedule.hs
+++ b/src/hevm/src/EVM/FeeSchedule.hs
@@ -1,6 +1,6 @@
 module EVM.FeeSchedule where
 
-data Num n => FeeSchedule n = FeeSchedule
+data FeeSchedule n = FeeSchedule
   { g_zero :: n
   , g_base :: n
   , g_verylow :: n

--- a/src/hevm/src/EVM/FeeSchedule.hs
+++ b/src/hevm/src/EVM/FeeSchedule.hs
@@ -103,7 +103,7 @@ homestead = FeeSchedule
   , g_copy = 3
   , g_blockhash = 20
   , g_extcodehash = 400
-  , g_quaddivisor = 100
+  , g_quaddivisor = 20
   , r_block = 2000000000000000000
   }
 

--- a/src/hevm/src/EVM/Format.hs
+++ b/src/hevm/src/EVM/Format.hs
@@ -176,7 +176,7 @@ showTrace dapp trace =
         _ ->
           "\x1b[91merror\x1b[0m " <> pack (show e) <> pos
 
-    ReturnTrace output (CallContext _ _ hash (Just abi) _ _ _ _) ->
+    ReturnTrace output (CallContext _ _ hash (Just abi) _ _ _ _ _) ->
       case getAbiMethodOutput dapp hash abi of
         Nothing ->
           "← " <> formatBinary output
@@ -189,9 +189,9 @@ showTrace dapp trace =
 
     EntryTrace t ->
       t
-    FrameTrace (CreationContext hash _ _ _) ->
+    FrameTrace (CreationContext hash _ _ _ _) ->
       "create " <> maybeContractName (preview (dappSolcByHash . ix hash . _2) dapp) <> pos
-    FrameTrace (CallContext _ _ hash abi calldata _ _ _) ->
+    FrameTrace (CallContext _ _ hash abi calldata _ _ _ _) ->
       case preview (dappSolcByHash . ix hash . _2) dapp of
         Nothing ->
           "call [unknown]" <> pos

--- a/src/hevm/src/EVM/Format.hs
+++ b/src/hevm/src/EVM/Format.hs
@@ -176,7 +176,7 @@ showTrace dapp trace =
         _ ->
           "\x1b[91merror\x1b[0m " <> pack (show e) <> pos
 
-    ReturnTrace output (CallContext _ _ hash (Just abi) _ _ _ _ _) ->
+    ReturnTrace output (CallContext _ _ hash (Just abi) _ _ _) ->
       case getAbiMethodOutput dapp hash abi of
         Nothing ->
           "← " <> formatBinary output
@@ -189,9 +189,9 @@ showTrace dapp trace =
 
     EntryTrace t ->
       t
-    FrameTrace (CreationContext hash _ _ _ _) ->
+    FrameTrace (CreationContext hash _ _ ) ->
       "create " <> maybeContractName (preview (dappSolcByHash . ix hash . _2) dapp) <> pos
-    FrameTrace (CallContext _ _ hash abi calldata _ _ _ _) ->
+    FrameTrace (CallContext _ _ hash abi calldata _ _) ->
       case preview (dappSolcByHash . ix hash . _2) dapp of
         Nothing ->
           "call [unknown]" <> pos

--- a/src/hevm/src/EVM/Format.hs
+++ b/src/hevm/src/EVM/Format.hs
@@ -176,7 +176,7 @@ showTrace dapp trace =
         _ ->
           "\x1b[91merror\x1b[0m " <> pack (show e) <> pos
 
-    ReturnTrace output (CallContext _ _ hash (Just abi) _ _) ->
+    ReturnTrace output (CallContext _ _ hash (Just abi) _ _ _ _) ->
       case getAbiMethodOutput dapp hash abi of
         Nothing ->
           "← " <> formatBinary output
@@ -189,9 +189,9 @@ showTrace dapp trace =
 
     EntryTrace t ->
       t
-    FrameTrace (CreationContext hash _) ->
+    FrameTrace (CreationContext hash _ _ _) ->
       "create " <> maybeContractName (preview (dappSolcByHash . ix hash . _2) dapp) <> pos
-    FrameTrace (CallContext _ _ hash abi calldata _) ->
+    FrameTrace (CallContext _ _ hash abi calldata _ _ _) ->
       case preview (dappSolcByHash . ix hash . _2) dapp of
         Nothing ->
           "call [unknown]" <> pos

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -740,32 +740,32 @@ updateUiVmState ui vm =
              1)
       & set uiVmMessage message
   in
-    case view uiVmDapp ui of
-      Nothing ->
-        ui'
-          & set uiVmTraceList (list TracePane mempty 1)
-          & set uiVmSolidityList (list SolidityPane mempty 1)
-      Just dapp ->
-        ui'
-          & set uiVmTraceList
-              (list
-                TracePane
-                (Vec.fromList
-                 . Text.lines
-                 . showTraceTree dapp
-                 $ vm)
-                1)
-          & set uiVmSolidityList
-              (list SolidityPane
-                 (case currentSrcMap dapp vm of
-                    Nothing -> mempty
-                    Just x ->
-                      view (dappSources
-                            . sourceLines
-                            . ix (srcMapFile x)
-                            . to (Vec.imap (,)))
-                        dapp)
-                 1)
+    ui'
+      & set uiVmTraceList
+          (list
+            TracePane
+            (Vec.fromList
+              . Text.lines
+              . showTraceTree dapp
+              $ vm)
+            1)
+      & set uiVmSolidityList
+          (list SolidityPane
+              (case currentSrcMap dapp vm of
+                Nothing -> mempty
+                Just x ->
+                  view (dappSources
+                        . sourceLines
+                        . ix (srcMapFile x)
+                        . to (Vec.imap (,)))
+                    dapp)
+              1)
+      where
+        dapp =
+          case view uiVmDapp ui of
+            Just solcdapp -> solcdapp
+            Nothing ->
+              dappInfo "" mempty (SourceCache mempty mempty mempty mempty)
 
 drawStackPane :: UiVmState -> UiWidget
 drawStackPane ui =

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -262,7 +262,7 @@ runFromVM vm = do
            , _uiVmDapp = Nothing
            , _uiVmStepCount = 0
            , _uiVmFirstState = undefined
-           , _uiVmMessage = Just "Executing EVM code"
+           , _uiVmMessage = Just $ "Executing EVM code in " <> show (view (state . contract) vm)
            , _uiVmNotes = []
            , _uiVmShowMemory = False
            }
@@ -727,6 +727,8 @@ updateUiVmState ui vm =
           (move $ list BytecodePane
              (view codeOps (fromJust (currentContract vm)))
              1)
+      & set uiVmMessage
+          (Just $ "Executing EVM code in " <> show (view (state . contract) vm))
   in
     case view uiVmDapp ui of
       Nothing ->

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -78,6 +78,7 @@ data TestVMParams = TestVMParams
   , testTimestamp     :: W256
   , testGaslimit      :: W256
   , testGasprice      :: W256
+  , testMaxCodeSize   :: W256
   , testDifficulty    :: W256
   }
 
@@ -92,6 +93,9 @@ defaultBalanceForCreator = 0xffffffffffffffffffffffff
 
 defaultBalanceForCreated :: W256
 defaultBalanceForCreated = 0xffffffffffffffffffffffff
+
+defaultMaxCodeSize :: W256
+defaultMaxCodeSize = 0xffffffff
 
 type ABIMethod = Text
 
@@ -549,6 +553,7 @@ initialUnitTestVm (UnitTestOptions {..}) theContract _ =
            , vmoptTimestamp = testTimestamp
            , vmoptBlockGaslimit = testGaslimit
            , vmoptGasprice = testGasprice
+           , vmoptMaxCodeSize = testMaxCodeSize
            , vmoptDifficulty = testDifficulty
            , vmoptSchedule = FeeSchedule.metropolis
            , vmoptCreate = False
@@ -579,4 +584,5 @@ getParametersFromEnvironmentVariables = do
     <*> getWord "DAPP_TEST_TIMESTAMP" 1
     <*> getWord "DAPP_TEST_GAS_LIMIT" 0
     <*> getWord "DAPP_TEST_GAS_PRICE" 0
+    <*> getWord "DAPP_TEST_MAXCODESIZE" defaultMaxCodeSize
     <*> getWord "DAPP_TEST_DIFFICULTY" 1

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -127,11 +127,16 @@ checkExpectation diff execmode x vm =
             , ("bad-storage", not storage || money || nonce || code || state)
             , ("bad-code",    not code || money || nonce || storage || state)
             ])
+        initial = testContracts x
         expected = expectedContracts expectation
         actual = view (EVM.env . EVM.contracts . to (fmap clearZeroStorage)) vm
 
       putStr (intercalate " " reason)
       if diff && (not state) then do
+        putStrLn "\nInitial balance/state: "
+        printField (\v -> (show . toInteger  $ _nonce v) ++ " "
+                       ++ (show . toInteger  $ _balance v) ++ " "
+                       ++ (show . Map.toList $ _storage v)) initial
         putStrLn "\nExpected balance/state: "
         printField (\v -> (show . toInteger  $ _nonce v) ++ " "
                        ++ (show . toInteger  $ _balance v) ++ " "

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -52,12 +52,12 @@ import qualified Data.ByteString.Lazy  as Lazy
 data Which = Pre | Post
 
 data Block = Block
-  { blockCoinbase   :: Addr
-  , blockDifficulty :: W256
-  , blockGasLimit   :: W256
-  , blockNumber     :: W256
-  , blockTimestamp  :: W256
-  , blockTxs        :: [Transaction]
+  { blockCoinbase    :: Addr
+  , blockDifficulty  :: W256
+  , blockGasLimit    :: W256
+  , blockNumber      :: W256
+  , blockTimestamp   :: W256
+  , blockTxs         :: [Transaction]
   } deriving Show
 
 data Case = Case
@@ -271,6 +271,7 @@ parseVmOpts v =
            <*> wordField env  "currentTimestamp"
            <*> addrField env  "currentCoinbase"
            <*> wordField env  "currentDifficulty"
+           <*> pure 0xffffffff
            <*> wordField env  "currentGasLimit"
            <*> wordField exec "gasPrice"
            <*> pure (EVM.FeeSchedule.homestead)
@@ -378,6 +379,7 @@ fromCreateBlockchainCase block tx preState postState =
           , vmoptTimestamp     = blockTimestamp block
           , vmoptCoinbase      = blockCoinbase block
           , vmoptDifficulty    = blockDifficulty block
+          , vmoptMaxCodeSize   = 24576
           , vmoptBlockGaslimit = blockGasLimit block
           , vmoptGasprice      = txGasPrice tx
           , vmoptSchedule      = feeSchedule
@@ -416,6 +418,7 @@ fromNormalBlockchainCase block tx preState postState =
          , vmoptTimestamp     = blockTimestamp block
          , vmoptCoinbase      = blockCoinbase block
          , vmoptDifficulty    = blockDifficulty block
+         , vmoptMaxCodeSize   = 24576
          , vmoptBlockGaslimit = blockGasLimit block
          , vmoptGasprice      = txGasPrice tx
          , vmoptSchedule      = feeSchedule

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -483,6 +483,7 @@ initCreateTx tx block cs = do
    . (Map.adjust ((over balance (+ (txValue tx)))
                 . (set code (EVM.InitCode $ txData tx))
                 . (set nonce 1)
+                . (set storage mempty)
                 . (set create True)) createdAddr)
    . touchAccount origin
    . touchAccount createdAddr

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -535,7 +535,7 @@ vmForCase mode x =
     EVM.makeVm (testVmOpts x)
     & EVM.env . EVM.contracts .~ realizeContracts initState
     & EVM.tx . EVM.txReversion .~ realizeContracts checkState
-    & EVM.tx . EVM.touchedAccounts .~ touchedAccounts
+    & EVM.tx . EVM.substate . EVM.touchedAccounts .~ touchedAccounts
     & EVM.execMode .~ mode
 
 interpret :: Stepper a -> EVM a


### PR DESCRIPTION
`call` has different write semantics to other operations, which generally pad with zeros up to any excess of size + offset over the data length. With `call`, `writeMemory`was erroneously truncating memory in the case of calls where the bytes to write were shorter than the memory size given. We fix this with a special write method for `call`.

A number of other memory writing issues were fixed:

- correct zero padding of non-call memory operations
- `returndatacopy` is meant to fail if reading from beyond what has been written.
- memory offset calculations are not modulo-256 in some cases

Lastly, test failures due solely to incorrect nonce or storage were separated and counted.

Previously:

```
passed: 5868
bad-balance: 3948
bad-nonce: 0
bad-storage: 0
failed: 245
skipped: 1923
```

Now (up to 5e67834c798a813f2b987be6bf955080977208d5):

```
passed: 5887
bad-balance: 3944
bad-nonce: 16
bad-storage: 14
failed: 200
skipped: 1923
```

The `run-blockchain-test`was modified, with `--test` and `--skip` arguments implemented for finer control over tests that are run. This is used here for modexp, which typically goes out of memory. 

```patch
-BlockchainTests/GeneralStateTests/stCallCreateCallCodeTest/callcodeOutput3_d0g0v0.json callcodeOutput3_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stCallCreateCallCodeTest/callcodeOutput3_d0g0v0.json callcodeOutput3_d0g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stCallCreateCallCodeTest/callcodeOutput3partial_d0g0v0.json callcodeOutput3partial_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stCallCreateCallCodeTest/callcodeOutput3partial_d0g0v0.json callcodeOutput3partial_d0g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stCallCreateCallCodeTest/callOutput3_d0g0v0.json callOutput3_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stCallCreateCallCodeTest/callOutput3_d0g0v0.json callOutput3_d0g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stCallCreateCallCodeTest/callOutput3partial_d0g0v0.json callOutput3partial_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stCallCreateCallCodeTest/callOutput3partial_d0g0v0.json callOutput3partial_d0g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stCallCreateCallCodeTest/createNameRegistratorPreStore1NotEnoughGas_d0g0v0.json createNameRegistratorPreStore1NotEnoughGas_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stCallCreateCallCodeTest/createNameRegistratorPreStore1NotEnoughGas_d0g0v0.json createNameRegistratorPreStore1NotEnoughGas_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stCreate2/Create2OnDepth1024_d0g0v0.json Create2OnDepth1024_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stCreate2/Create2OnDepth1024_d0g0v0.json Create2OnDepth1024_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stCreate2/Create2OOGafterInitCodeReturndata_d0g1v0.json Create2OOGafterInitCodeReturndata_d0g1v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stCreate2/Create2OOGafterInitCodeReturndata_d0g1v0.json Create2OOGafterInitCodeReturndata_d0g1v0_ConstantinopleFix bad-balance

-BlockchainTests/GeneralStateTests/stCreate2/returndatacopy_afterFailing_create_d0g0v0.json returndatacopy_afterFailing_create_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stCreate2/returndatacopy_afterFailing_create_d0g0v0.json returndatacopy_afterFailing_create_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stCreate2/returndatacopy_following_create_d1g0v0.json returndatacopy_following_create_d1g0v0_ConstantinopleFix bad-balance
-BlockchainTests/GeneralStateTests/stCreate2/returndatacopy_following_revert_in_create_d0g0v0.json returndatacopy_following_revert_in_create_d0g0v0_ConstantinopleFix bad-state
-BlockchainTests/GeneralStateTests/stCreate2/returndatacopy_following_successful_create_d0g0v0.json returndatacopy_following_successful_create_d0g0v0_ConstantinopleFix bad-balance
+BlockchainTests/GeneralStateTests/stCreate2/returndatacopy_following_create_d1g0v0.json returndatacopy_following_create_d1g0v0_ConstantinopleFix ok
+BlockchainTests/GeneralStateTests/stCreate2/returndatacopy_following_revert_in_create_d0g0v0.json returndatacopy_following_revert_in_create_d0g0v0_ConstantinopleFix bad-nonce
+BlockchainTests/GeneralStateTests/stCreate2/returndatacopy_following_successful_create_d0g0v0.json returndatacopy_following_successful_create_d0g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stCreate2/RevertOpcodeCreate_d0g0v0.json RevertOpcodeCreate_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stCreate2/RevertOpcodeCreate_d0g0v0.json RevertOpcodeCreate_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stCreate2/RevertOpcodeInCreateReturnsCreate2_d0g0v0.json RevertOpcodeInCreateReturnsCreate2_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stCreate2/RevertOpcodeInCreateReturnsCreate2_d0g0v0.json RevertOpcodeInCreateReturnsCreate2_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stCreateTest/CreateOOGafterInitCodeReturndata_d0g1v0.json CreateOOGafterInitCodeReturndata_d0g1v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stCreateTest/CreateOOGafterInitCodeReturndata_d0g1v0.json CreateOOGafterInitCodeReturndata_d0g1v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stDelegatecallTestHomestead/callcodeOutput3_d0g0v0.json callcodeOutput3_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stDelegatecallTestHomestead/callcodeOutput3_d0g0v0.json callcodeOutput3_d0g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stDelegatecallTestHomestead/callOutput3_d0g0v0.json callOutput3_d0g0v0_ConstantinopleFix bad-state
-BlockchainTests/GeneralStateTests/stDelegatecallTestHomestead/callOutput3partial_d0g0v0.json callOutput3partial_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stDelegatecallTestHomestead/callOutput3_d0g0v0.json callOutput3_d0g0v0_ConstantinopleFix ok
+BlockchainTests/GeneralStateTests/stDelegatecallTestHomestead/callOutput3partial_d0g0v0.json callOutput3partial_d0g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stEIP150singleCodeGasPrices/RawCallCodeGasMemoryAsk_d0g0v0.json RawCallCodeGasMemoryAsk_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stEIP150singleCodeGasPrices/RawCallCodeGasMemoryAsk_d0g0v0.json RawCallCodeGasMemoryAsk_d0g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stEIP150singleCodeGasPrices/RawCallCodeGasValueTransferMemoryAsk_d0g0v0.json RawCallCodeGasValueTransferMemoryAsk_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stEIP150singleCodeGasPrices/RawCallCodeGasValueTransferMemoryAsk_d0g0v0.json RawCallCodeGasValueTransferMemoryAsk_d0g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stEIP150singleCodeGasPrices/RawCallGasValueTransferMemoryAsk_d0g0v0.json RawCallGasValueTransferMemoryAsk_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stEIP150singleCodeGasPrices/RawCallGasValueTransferMemoryAsk_d0g0v0.json RawCallGasValueTransferMemoryAsk_d0g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stEIP150singleCodeGasPrices/RawCallMemoryGasAsk_d0g0v0.json RawCallMemoryGasAsk_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stEIP150singleCodeGasPrices/RawCallMemoryGasAsk_d0g0v0.json RawCallMemoryGasAsk_d0g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stEIP150singleCodeGasPrices/RawDelegateCallGasMemoryAsk_d0g0v0.json RawDelegateCallGasMemoryAsk_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stEIP150singleCodeGasPrices/RawDelegateCallGasMemoryAsk_d0g0v0.json RawDelegateCallGasMemoryAsk_d0g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stHomesteadSpecific/contractCreationOOGdontLeaveEmptyContract_d0g0v0.json contractCreationOOGdontLeaveEmptyContract_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stHomesteadSpecific/contractCreationOOGdontLeaveEmptyContract_d0g0v0.json contractCreationOOGdontLeaveEmptyContract_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stHomesteadSpecific/createContractViaContractOOGInitCode_d0g0v0.json createContractViaContractOOGInitCode_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stHomesteadSpecific/createContractViaContractOOGInitCode_d0g0v0.json createContractViaContractOOGInitCode_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stInitCodeTest/CallRecursiveContract_d0g0v0.json CallRecursiveContract_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stInitCodeTest/CallRecursiveContract_d0g0v0.json CallRecursiveContract_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stInitCodeTest/OutOfGasPrefundedContractCreation_d0g3v0.json OutOfGasPrefundedContractCreation_d0g3v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stInitCodeTest/OutOfGasPrefundedContractCreation_d0g3v0.json OutOfGasPrefundedContractCreation_d0g3v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stMemExpandingEIP150Calls/CallAskMoreGasOnDepth2ThenTransactionHasWithMemExpandingCalls_d0g0v0.json CallAskMoreGasOnDepth2ThenTransactionHasWithMemExpandingCalls_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stMemExpandingEIP150Calls/CallAskMoreGasOnDepth2ThenTransactionHasWithMemExpandingCalls_d0g0v0.json CallAskMoreGasOnDepth2ThenTransactionHasWithMemExpandingCalls_d0g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stQuadraticComplexityTest/Return50000_2_d0g1v0.json Return50000_2_d0g1v0_ConstantinopleFix bad-balance
+BlockchainTests/GeneralStateTests/stQuadraticComplexityTest/Return50000_2_d0g1v0.json Return50000_2_d0g1v0_ConstantinopleFix timeout

-BlockchainTests/GeneralStateTests/stRandom/randomStatetest85_d0g0v0.json randomStatetest85_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stRandom/randomStatetest85_d0g0v0.json randomStatetest85_d0g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stRecursiveCreate/recursiveCreate_d0g0v0.json recursiveCreate_d0g0v0_ConstantinopleFix bad-state
-BlockchainTests/GeneralStateTests/stRecursiveCreate/recursiveCreateReturnValue_d0g0v0.json recursiveCreateReturnValue_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stRecursiveCreate/recursiveCreate_d0g0v0.json recursiveCreate_d0g0v0_ConstantinopleFix bad-nonce
+BlockchainTests/GeneralStateTests/stRecursiveCreate/recursiveCreateReturnValue_d0g0v0.json recursiveCreateReturnValue_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_after_failing_callcode_d0g0v0.json returndatacopy_after_failing_callcode_d0g0v0_ConstantinopleFix bad-state
-BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_afterFailing_create_d0g0v0.json returndatacopy_afterFailing_create_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_after_failing_callcode_d0g0v0.json returndatacopy_after_failing_callcode_d0g0v0_ConstantinopleFix ok
+BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_afterFailing_create_d0g0v0.json returndatacopy_afterFailing_create_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_after_failing_staticcall_d0g0v0.json returndatacopy_after_failing_staticcall_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_after_failing_staticcall_d0g0v0.json returndatacopy_after_failing_staticcall_d0g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_following_create_d0g0v0.json returndatacopy_following_create_d0g0v0_ConstantinopleFix bad-balance
-BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_following_failing_call_d0g0v0.json returndatacopy_following_failing_call_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_following_create_d0g0v0.json returndatacopy_following_create_d0g0v0_ConstantinopleFix ok
+BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_following_failing_call_d0g0v0.json returndatacopy_following_failing_call_d0g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_following_revert_in_create_d0g0v0.json returndatacopy_following_revert_in_create_d0g0v0_ConstantinopleFix bad-state
-BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_following_successful_create_d0g0v0.json returndatacopy_following_successful_create_d0g0v0_ConstantinopleFix bad-balance
-BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_following_too_big_transfer_d0g0v0.json returndatacopy_following_too_big_transfer_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_following_revert_in_create_d0g0v0.json returndatacopy_following_revert_in_create_d0g0v0_ConstantinopleFix bad-nonce
+BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_following_successful_create_d0g0v0.json returndatacopy_following_successful_create_d0g0v0_ConstantinopleFix ok
+BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_following_too_big_transfer_d0g0v0.json returndatacopy_following_too_big_transfer_d0g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_initial_256_d2g0v0.json returndatacopy_initial_256_d2g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_initial_256_d2g0v0.json returndatacopy_initial_256_d2g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_initial_d0g0v0.json returndatacopy_initial_d0g0v0_ConstantinopleFix bad-state
-BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_overrun_d0g0v0.json returndatacopy_overrun_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_initial_d0g0v0.json returndatacopy_initial_d0g0v0_ConstantinopleFix ok
+BlockchainTests/GeneralStateTests/stReturnDataTest/returndatacopy_overrun_d0g0v0.json returndatacopy_overrun_d0g0v0_ConstantinopleFix ok

-BlockchainTests/GeneralStateTests/stRevertTest/RevertOpcodeCreate_d0g0v0.json RevertOpcodeCreate_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stRevertTest/RevertOpcodeCreate_d0g0v0.json RevertOpcodeCreate_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stRevertTest/RevertOpcodeInCreateReturns_d0g0v0.json RevertOpcodeInCreateReturns_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stRevertTest/RevertOpcodeInCreateReturns_d0g0v0.json RevertOpcodeInCreateReturns_d0g0v0_ConstantinopleFix bad-nonce

-BlockchainTests/GeneralStateTests/stRevertTest/RevertPrecompiledTouch_storage_d0g0v0.json RevertPrecompiledTouch_storage_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stRevertTest/RevertPrecompiledTouch_storage_d0g0v0.json RevertPrecompiledTouch_storage_d0g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stRevertTest/RevertPrecompiledTouch_storage_d3g0v0.json RevertPrecompiledTouch_storage_d3g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stRevertTest/RevertPrecompiledTouch_storage_d3g0v0.json RevertPrecompiledTouch_storage_d3g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stSpecialTest/FailedCreateRevertsDeletion_d0g0v0.json FailedCreateRevertsDeletion_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stSpecialTest/FailedCreateRevertsDeletion_d0g0v0.json FailedCreateRevertsDeletion_d0g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stSStoreTest/InitCollision_d1g0v0.json InitCollision_d1g0v0_ConstantinopleFix bad-state
-BlockchainTests/GeneralStateTests/stSStoreTest/InitCollision_d2g0v0.json InitCollision_d2g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stSStoreTest/InitCollision_d1g0v0.json InitCollision_d1g0v0_ConstantinopleFix bad-storage
+BlockchainTests/GeneralStateTests/stSStoreTest/InitCollision_d2g0v0.json InitCollision_d2g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stZeroCallsTest/ZeroValue_TransactionCALL_ToOneStorageKey_d0g0v0.json ZeroValue_TransactionCALL_ToOneStorageKey_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stZeroCallsTest/ZeroValue_TransactionCALL_ToOneStorageKey_d0g0v0.json ZeroValue_TransactionCALL_ToOneStorageKey_d0g0v0_ConstantinopleFix bad-storage

-BlockchainTests/GeneralStateTests/stZeroCallsTest/ZeroValue_TransactionCALLwithData_ToOneStorageKey_d0g0v0.json ZeroValue_TransactionCALLwithData_ToOneStorageKey_d0g0v0_ConstantinopleFix bad-state
+BlockchainTests/GeneralStateTests/stZeroCallsTest/ZeroValue_TransactionCALLwithData_ToOneStorageKey_d0g0v0.json ZeroValue_TransactionCALLwithData_ToOneStorageKey_d0g0v0_ConstantinopleFix bad-storage

-passed: 5868
-bad-balance: 3948
-bad-nonce: 0
-bad-storage: 0
-failed: 245
+passed: 5887
+bad-balance: 3944
+bad-nonce: 16
+bad-storage: 14
+failed: 200
```