### PR TITLE
Hevmfixes

### DIFF
--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -679,7 +679,9 @@ exec1 = do
                 preuse (env . contracts . ix (num x)) >>=
                   \case
                     Nothing -> push (num (0 :: Int))
-                    Just c  -> push (num (keccak (view bytecode c)))
+                    Just c  -> if accountEmpty c
+                       then push (num (0 :: Int))
+                       else push (num (keccak (view bytecode c)))
             [] ->
               underrun
 

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1028,7 +1028,14 @@ exec1 = do
           notStatic $
           case stk of
             [] -> underrun
-            (x:_) -> do
+            (x:_) -> let
+              recipientExists = Map.member (num x) (view (env . contracts) vm)
+              c_new = if not recipientExists && view balance this /= 0
+                      then num g_selfdestruct_newaccount
+                      else 0
+              in burn (g_selfdestruct + c_new) $ do
+              destructs <- use (tx . selfdestructs)
+              if elem self destructs then noop else refund r_selfdestruct
               touchAccount (num x) $ \_ -> do
                 pushTo (tx . selfdestructs) self
                 assign (env . contracts . ix self . balance) 0

--- a/src/hevm/src/EVM/FeeSchedule.hs
+++ b/src/hevm/src/EVM/FeeSchedule.hs
@@ -14,8 +14,9 @@ data Num n => FeeSchedule n = FeeSchedule
   , g_sset :: n
   , g_sreset :: n
   , r_sclear :: n
+  , g_selfdestruct :: n
+  , g_selfdestruct_newaccount :: n
   , r_selfdestruct :: n
-  , r_selfdestruct_newaccount :: n
   , g_create :: n
   , g_codedeposit :: n
   , g_call :: n
@@ -53,8 +54,8 @@ eip150 fees = fees
   , g_balance = 400
   , g_sload = 200
   , g_call = 700
-  , r_selfdestruct = 5000
-  , r_selfdestruct_newaccount = 25000
+  , g_selfdestruct = 5000
+  , g_selfdestruct_newaccount = 25000
   }
 
 -- EIP160: EXP cost increase
@@ -78,8 +79,9 @@ homestead = FeeSchedule
   , g_sset = 20000
   , g_sreset = 5000
   , r_sclear = 15000
-  , r_selfdestruct = 0
-  , r_selfdestruct_newaccount = 0
+  , g_selfdestruct = 0
+  , g_selfdestruct_newaccount = 0
+  , r_selfdestruct = 24000
   , g_create = 32000
   , g_codedeposit = 200
   , g_call = 40


### PR DESCRIPTION
Increases coverage by a whole lot. If Mr. @rainbreak can tell me what `--skip` pattern will cause GeneralStateTests not to crash I could tell you the exact figures.