### PR TITLE
ethsign: add import command

### DIFF
--- a/src/ethsign/CHANGELOG
+++ b/src/ethsign/CHANGELOG
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2019-08-08
+
+### Changed
+
+- add command `import` to create and save an encrypted keyfile in the
+  keystore based on a private key and a passphrase
+
+[0.13.0]: https://github.com/dapphub/dapptools/tree/ethsign/0.13.0
+
 ## [0.12.0] - 2019-03-25
 
 ### Changed

--- a/src/ethsign/default.nix
+++ b/src/ethsign/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "ethsign-${version}";
-  version = "0.12.0";
+  version = "0.13.0";
 
   goPackagePath = "github.com/dapphub/ethsign";
   hardeningDisable = ["fortify"];


### PR DESCRIPTION
This command reads a hexadecimal private key and a desired passphrase
from stdin and saves a corresponding keyfile into the keystore using
Geth's standard options and file name scheme.