### PR TITLE
Support ABIv2 in HEVM

### DIFF
--- a/src/hevm/src/EVM/ABI.hs
+++ b/src/hevm/src/EVM/ABI.hs
@@ -403,34 +403,22 @@ genAbiValue = \case
             if n == 256 then x else mod x (2 ^ n)
 
 instance Arbitrary AbiType where
-  arbitrary = sized arbitrary'
-    where arbitrary' 0 = oneof -- prevent empty tuples
-            [ (AbiUIntType . (* 8)) <$> choose (1, 32)
-            , (AbiIntType . (* 8)) <$> choose (1, 32)
-            , pure AbiAddressType
-            , pure AbiBoolType
-            , AbiBytesType . getPositive <$> arbitrary
-            , pure AbiBytesDynamicType
-            , pure AbiStringType
-            , AbiArrayDynamicType <$> scale (`div` 2) arbitrary
-            , AbiArrayType
-            <$> (getPositive <$> arbitrary)
-            <*> scale (`div` 2) arbitrary
-            ]
-          arbitrary' _ = oneof
-            [ (AbiUIntType . (* 8)) <$> choose (1, 32)
-            , (AbiIntType . (* 8)) <$> choose (1, 32)
-            , pure AbiAddressType
-            , pure AbiBoolType
-            , AbiBytesType . getPositive <$> arbitrary
-            , pure AbiBytesDynamicType
-            , pure AbiStringType
-            , AbiArrayDynamicType <$> scale (`div` 2) arbitrary
-            , AbiArrayType
-                <$> (getPositive <$> arbitrary)
-                <*> scale (`div` 2) arbitrary
-            , AbiTupleType <$> scale (`div` 2) (Vector.fromList <$> arbitrary)
-            ]
+  arbitrary = sized $ \n -> oneof $ -- prevent empty tuples
+    [ (AbiUIntType . (* 8)) <$> choose (1, 32)
+    , (AbiIntType . (* 8)) <$> choose (1, 32)
+    , pure AbiAddressType
+    , pure AbiBoolType
+    , AbiBytesType . getPositive <$> arbitrary
+    , pure AbiBytesDynamicType
+    , pure AbiStringType
+    , AbiArrayDynamicType <$> scale (`div` 2) arbitrary
+    , AbiArrayType
+    <$> (getPositive <$> arbitrary)
+    <*> scale (`div` 2) arbitrary
+    ] <>
+    if n == 0
+    then []
+    else [AbiTupleType <$> scale (`div` 2) (Vector.fromList <$> arbitrary)]
 
 instance Arbitrary AbiValue where
   arbitrary = arbitrary >>= genAbiValue

--- a/src/hevm/src/EVM/ABI.hs
+++ b/src/hevm/src/EVM/ABI.hs
@@ -444,5 +444,4 @@ instance Arbitrary AbiValue where
         map (\x -> AbiArray (length x) t (Vector.fromList x))
             (shrinkList shrink (Vector.toList v))
     AbiTuple v -> Vector.toList $ AbiTuple . Vector.fromList . shrink <$> v
-      --AbiTuple <$> (shrink <$> v)
     _ -> []

--- a/src/hevm/src/EVM/ABI.hs
+++ b/src/hevm/src/EVM/ABI.hs
@@ -303,8 +303,6 @@ abiCalldata s xs = BSLazy.toStrict . runPut $ do
   putWord32be (abiKeccak (encodeUtf8 s))
   putAbiSeq xs
 
---parseTypeName :: AsValue s => s -> Maybe AbiType
---parseTypeName s = parseTypeName' (s ^? key "components" . _Array) (s ^?! key "type" . _String)
 parseTypeName :: Vector AbiType -> Text -> Maybe AbiType
 parseTypeName = P.parseMaybe . typeWithArraySuffix
 

--- a/src/hevm/src/EVM/ABI.hs
+++ b/src/hevm/src/EVM/ABI.hs
@@ -413,8 +413,8 @@ instance Arbitrary AbiType where
     , pure AbiStringType
     , AbiArrayDynamicType <$> scale (`div` 2) arbitrary
     , AbiArrayType
-    <$> (getPositive <$> arbitrary)
-    <*> scale (`div` 2) arbitrary
+        <$> (getPositive <$> arbitrary)
+        <*> scale (`div` 2) arbitrary
     ] <>
     if n == 0
     then []

--- a/src/hevm/src/EVM/Format.hs
+++ b/src/hevm/src/EVM/Format.hs
@@ -93,6 +93,8 @@ showAbiValue (AbiArray _ _ xs) =
   showAbiArray xs
 showAbiValue (AbiArrayDynamic _ xs) =
   showAbiArray xs
+showAbiValue (AbiTuple v) =
+  showAbiValues v
 
 isPrintable :: ByteString -> Bool
 isPrintable =
@@ -221,7 +223,7 @@ getAbiMethodOutput dapp hash abi =
     dapp
 
 getAbiTypes :: Text -> [Maybe AbiType]
-getAbiTypes abi = map parseTypeName types
+getAbiTypes abi = map (parseTypeName mempty) types
   where
     types =
       filter (/= "") $

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -305,7 +305,7 @@ signature abi =
         ")"
       ]
 
--- Helper funcntion to convert the fields to the desired type
+-- Helper function to convert the fields to the desired type
 parseTypeName' :: AsValue s => s -> Maybe AbiType
 parseTypeName' x =
   parseTypeName

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -284,7 +284,7 @@ readJSON json = do
                   (case abi ^?! key "anonymous" . _Bool of
                      True -> Anonymous
                      False -> NotAnonymous)
-                  (map (\y -> ( force "internal error: type" (parseTypeName (y ^?! key "type" . _String))
+                  (map (\y -> ( force "internal error: type" (parseTypeName' y)
                               , if y ^?! key "indexed" . _Bool
                                 then Indexed
                                 else NotIndexed ))
@@ -305,11 +305,19 @@ signature abi =
         ")"
       ]
 
+-- Helper funcntion to convert the fields to the desired type
+parseTypeName' :: AsValue s => s -> Maybe AbiType
+parseTypeName' x =
+  parseTypeName
+    (fromMaybe mempty $ x ^? key "components" . _Array . to parseComponents)
+    (x ^?! key "type" . _String)
+  where parseComponents = fmap $ snd . parseMethodInput
+
 -- This actually can also parse a method output! :O
-parseMethodInput :: (Show s, AsValue s) => s -> (Text, AbiType)
+parseMethodInput :: AsValue s => s -> (Text, AbiType)
 parseMethodInput x =
   ( x ^?! key "name" . _String
-  , force "internal error: method type" (parseTypeName (x ^?! key "type" . _String))
+  , force "internal error: method type" (parseTypeName' x)
   )
 
 toCode :: Text -> ByteString

--- a/src/hevm/src/EVM/StorageLayout.hs
+++ b/src/hevm/src/EVM/StorageLayout.hs
@@ -165,7 +165,7 @@ grokValueType x =
        , preview (key "attributes" . key "type" . _String) x
        ) of
     (Just "ElementaryTypeName", _, Just typeName) ->
-      case parseTypeName (head (words typeName)) of
+      case parseTypeName mempty (head (words typeName)) of
         Just t -> t
         Nothing ->
           error ("ungrokked value type: " ++ show typeName)


### PR DESCRIPTION
I am porting over the code used to support ABIv2 from [echidna](https://github.com/crytic/echidna/blob/master/lib/Echidna/ABIv2.hs). If possible, I would like some guidance on how to better write `readJSON` without passing around an extra `Maybe` parameter in its subroutines.