### PR TITLE
hevm: handle rpc fetch in tty - fixes #257

### DIFF
--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -160,10 +160,16 @@ unitTestOptions cmd = do
 
   params <- getParametersFromEnvironmentVariables
 
+  let
+    testn = testNumber params
+    block = if (0 ==) testn
+       then EVM.Fetch.Latest
+       else EVM.Fetch.BlockNumber testn
+
   pure EVM.UnitTest.UnitTestOptions
     { EVM.UnitTest.oracle =
         case rpc cmd of
-         Just url -> EVM.Fetch.http (EVM.Fetch.BlockNumber (testNumber params)) url
+         Just url -> EVM.Fetch.http block url
          Nothing  -> EVM.Fetch.zero
     , EVM.UnitTest.verbose = verbose cmd
     , EVM.UnitTest.match   = pack $ fromMaybe "^test" (match cmd)

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -321,10 +321,12 @@ launchExec cmd = do
       in case view EVM.result vm' of
         Nothing ->
           error "internal error; no EVM result"
+        Just (EVM.VMFailure (EVM.Revert msg)) -> do
+          die . show . ByteStringS $ msg
         Just (EVM.VMFailure err) -> do
-          die (show err)
+          die . show $ err
         Just (EVM.VMSuccess msg) -> do
-          putStrLn $ showByteStringWith0x msg
+          putStrLn . show . ByteStringS $ msg
           case state cmd of
             Nothing -> pure ()
             Just path ->

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -491,7 +491,7 @@ instance SDisplay Word where
     L [A "hash", A (txt x), sexp bs]
 
 instance SDisplay ByteString where
-  sexp = A . txt . pack . showByteStringWith0x
+  sexp = A . txt . pack . show . ByteStringS
 
 sexpMemory :: ByteString -> SExpr Text
 sexpMemory bs =

--- a/src/hevm/src/EVM/Stepper.hs
+++ b/src/hevm/src/EVM/Stepper.hs
@@ -45,10 +45,10 @@ data Action a where
 
   -- | Keep executing until an intermediate result is reached
   Exec ::            Action VMResult
-  
+
   -- | Short-circuit with a failure
   Fail :: Failure -> Action a
-  
+
   -- | Wait for a query to be resolved
   Wait :: Query   -> Action ()
 

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -805,7 +805,9 @@ updateUiVmState ui vm =
     message =
       case view result vm of
         Just (VMSuccess msg) ->
-          Just ("VMSuccess: " <> showByteStringWith0x msg)
+          Just ("VMSuccess: " <> (show . ByteStringS $ msg))
+        Just (VMFailure (Revert msg)) ->
+          Just ("VMFailure: " <> (show . ByteStringS $ msg))
         Just (VMFailure err) ->
           Just ("VMFailure: " <> show (err))
         Nothing ->

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -14,6 +14,8 @@ import Data.Monoid ((<>))
 import Data.Bits
 import Data.ByteString (ByteString)
 import Data.ByteString.Base16 as BS16
+import Data.ByteString.Builder (byteStringHex, toLazyByteString)
+import Data.ByteString.Lazy (toStrict)
 import Data.DoubleWord
 import Data.DoubleWord.TH
 import Data.Word (Word8)
@@ -66,8 +68,13 @@ showAddrWith0x addr = "0x" ++ show addr
 showWordWith0x :: W256 -> String
 showWordWith0x addr = show addr
 
-showByteStringWith0x :: ByteString -> String
-showByteStringWith0x bs = "0x" ++ Text.unpack (Text.decodeUtf8 (BS16.encode bs))
+newtype ByteStringS = ByteStringS ByteString
+
+instance Show ByteStringS where
+  show (ByteStringS x) = ("0x" ++) . Text.unpack . fromBinary $ x
+    where
+      fromBinary =
+        Text.decodeUtf8 . toStrict . toLazyByteString . byteStringHex
 
 instance FromJSON W256 where
   parseJSON v = do

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -580,7 +580,7 @@ getParametersFromEnvironmentVariables = do
     <*> getWord "DAPP_TEST_BALANCE_CREATE" defaultBalanceForCreator
     <*> getWord "DAPP_TEST_BALANCE_CALL" defaultBalanceForCreated
     <*> getAddr "DAPP_TEST_COINBASE" 0
-    <*> getWord "DAPP_TEST_NUMBER" 512
+    <*> getWord "DAPP_TEST_NUMBER" 0
     <*> getWord "DAPP_TEST_TIMESTAMP" 1
     <*> getWord "DAPP_TEST_GAS_LIMIT" 0
     <*> getWord "DAPP_TEST_GAS_PRICE" 0


### PR DESCRIPTION
A minimal fix for #257 where remote contracts are now correctly
fetched when running with the --rpc flag. Attempts to fetch
non-existant contracts will result in a VMFailure.

The fix is somewhat unsatisfactory because the tty interpreter
is not suited to gracefully handling operational failures without a
more extensive refactor of the stepper and other interpreters.

In the meantime rpc fetch is functional, with more robust and
informative error handling to follow.