### PR TITLE
hevm: Solidity.hs: strip using old and new bzzr prefixes

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -19,7 +19,7 @@ let
     export PATH=${x.pkgs.hevm}/bin:${x.pkgs.jq}/bin:$PATH
     ${x.pkgs.hevm}/bin/hevm compliance \
       --tests ${ethereum-test-suite x} \
-      --skip "(modexp|RevertPrecompiledTouch_storage_d0g0v0|RevertPrecompiledTouch_storage_d3g0v0)" \
+      --skip "(modexp|RevertPrecompiledTouch_storage_d0g0v0|RevertPrecompiledTouch_storage_d3g0v0|Create1000Byzantium_d0g1v0)" \
       --timeout 20 \
       --html > $out/index.html
     ${x.pkgs.hevm}/bin/hevm compliance \


### PR DESCRIPTION
This version just iterates over the two known bzzr prefixes, and correctly displays source maps for both new and old  `solc` versions, unlike #261. See commit message for details.