### PR TITLE
hevm: remove (arbitrary?) memory bound

### DIFF
--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -2303,9 +2303,7 @@ memoryCost FeeSchedule{..} byteCount =
     linearCost = g_memory * wordCount
     quadraticCost = div (wordCount * wordCount) 512
   in
-    if byteCount > exponentiate 2 32
-    then maxBound
-    else linearCost + quadraticCost
+    linearCost + quadraticCost
 
 -- * Arithmetic
 

--- a/src/hevm/src/EVM/Concrete.hs
+++ b/src/hevm/src/EVM/Concrete.hs
@@ -197,10 +197,6 @@ instance FiniteBits Word where
   countLeadingZeros (C _ x) = countLeadingZeros x
   countTrailingZeros (C _ x) = countTrailingZeros x
 
-instance Bounded Word where
-  minBound = w256 minBound
-  maxBound = w256 maxBound
-
 instance Eq Word where
   (C _ x) == (C _ y) = x == y
 

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -40,7 +40,7 @@ mkUnpackedDoubleWord "Word512" ''Word256 "Int512" ''Int256 ''Word256
 newtype W256 = W256 Word256
   deriving
     ( Num, Integral, Real, Ord, Enum, Eq
-    , Bits, FiniteBits, Bounded, Generic
+    , Bits, FiniteBits, Generic
     )
 
 newtype Addr = Addr { addressWord160 :: Word160 }


### PR DESCRIPTION
Not sure what the reasoning behind this memory bound was in the first place, but it causes hevm to have incorrect behaviour. Here's an example execution where `hevm` behaves differently to geth:
```
hevm exec --code 600063ffffffff52 --gas 351847752663100
OutOfGas 0x14000f0500033 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
```
```
evm --code 600063ffffffff52 --gas 351847752663100 --prestate customgenesis.json  --debug --nomemory run
0x
```

where `customgenesis.json` makes sure that the geth evm operates according to the Petersburg fork:

```
{
  "alloc": {
  },
  "nonce": "0x000000000000002a",
  "difficulty": "0x020000",
  "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "coinbase": "0x0000000000000000000000000000000000000000",
  "timestamp": "0x00",
  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "extraData": "0x",
  "gasLimit": "0x2fefd8",
  "config" : { "chainId": 56312,
               "homesteadBlock": 0,
               "EIP150Block": 0,
               "byzantiumBlock": 0,
               "constantinopleBlock": 0,
               "petersburgBlock": 0
             }
}
```