### PR TITLE
dapp verify-contract updates/fixes

### DIFF
--- a/src/dapp/libexec/dapp/dapp-create
+++ b/src/dapp/libexec/dapp/dapp-create
@@ -19,13 +19,12 @@ done
 bin=$DAPP_OUT/${1?missing contract name}.bin
 type=$(seth --abi-constructor <"$DAPP_OUT/$1.abi")
 address=$(set -x; seth send --create "$bin" "${type/constructor/${1##*/}}" "${@:2}")
-# TODO(cmooney): parse this out of $DAPP_JSON file
-path="src/value.sol"
 
 [[ $DAPP_VERIFY_CONTRACT ]] && {
   echo >&2 "Verifying contract at $address"
+  path=$(sed 's|\/|/|g' $DAPP_JSON | sed "s/.*\"\(.*:${1}\)\".*/\1/g")
   sleep 5
-  dapp verify-contract "${path}:${1}" "$address" || true
+  dapp verify-contract "$path" "$address" || true
 }
 
 echo "$address"

--- a/src/dapp/libexec/dapp/dapp-create
+++ b/src/dapp/libexec/dapp/dapp-create
@@ -19,11 +19,13 @@ done
 bin=$DAPP_OUT/${1?missing contract name}.bin
 type=$(seth --abi-constructor <"$DAPP_OUT/$1.abi")
 address=$(set -x; seth send --create "$bin" "${type/constructor/${1##*/}}" "${@:2}")
+# TODO(cmooney): parse this out of $DAPP_JSON file
+path="src/value.sol"
 
 [[ $DAPP_VERIFY_CONTRACT ]] && {
   echo >&2 "Verifying contract at $address"
   sleep 5
-  dapp verify-contract "$1" "$address" || true
+  dapp verify-contract "${path}:${1}" "$address" || true
 }
 
 echo "$address"

--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -38,7 +38,10 @@ file=$(jshon <<<"$meta" -e settings -e compilationTarget -k)
 optimized=$(jshon <<<"$meta" -e settings -e optimizer -e enabled -u)
 runs=$(jshon <<<"$meta" -e settings -e optimizer -e runs -u)
 
-version=v"$version"
+# TODO(cmooney): allow this to be changed in case solc version isn't supported
+# by etherscan.
+# version=v"$version"
+version="v0.5.11+commit.c082d0b4"
 if [[ "$optimized" = "true" ]]; then
   optimized=1
 else
@@ -47,7 +50,7 @@ fi
 
 params=(
   "module=contract" "action=verifysourcecode"
-  "contractname=$name" "contractaddress=$address}"
+  "contractname=$name" "contractaddress=$address"
   "optimizationUsed=$optimized" "runs=$runs"
   "apikey=$ETHERSCAN_API_KEY"
 )
@@ -65,44 +68,35 @@ query=$(printf "&%s" "${params[@]}")
 
 count=0
 while [ $count -lt 5 ]; do
+  sleep 10
+
   response=$(curl -fsS "$ETHERSCAN_API_URL" -d "$query" \
   --data-urlencode "compilerversion=$version" \
   --data-urlencode "sourceCode@"<(echo "$source") -X POST)
 
   status=$(jshon <<<"$response" -e status -u)
-  #message=$(jshon <<<"$response" -e message -u)
   guid=$(jshon <<<"$response" -e result -u)
+  message=$(jshon <<<"$response" -e message -u)
   count=$((count + 1))
 
-  [[ $guid = "Contract source code already verified" ]] && {
-    echo >&2 "$guid"
-    echo >&2 "Go to $ETHERSCAN_URL/$2#code"
-    exit 1
-  }
   [[ $status = 1 ]] && break;
-  sleep 5
 done
 
 [[ $status = 0 ]] && {
   echo >&2 "There was an error verifying this contract."
-  echo >&2 "Response: $guid"
+  echo >&2 "Response: $message"
   exit 1
 }
 
-count=0
-while [ $count -lt 5 ]; do
-  sleep 10
-  response=$(curl -fsS "$ETHERSCAN_API_URL" \
-  -d "module=contract&action=checkverifystatus&guid=$guid")
+sleep 20
+response=$(curl -fsS "$ETHERSCAN_API_URL" \
+-d "module=contract&action=checkverifystatus&guid=$guid")
 
-  status=$(jshon <<<"$response" -e status -u)
-  # message=$(jshon <<<"$response" -e message -u)
-  result=$(jshon <<<"$response" -e result -u)
+status=$(jshon <<<"$response" -e status -u)
+result=$(jshon <<<"$response" -e result -u)
 
-  [[ $status = 1 ]] && {
-    echo >&2 "$result"
-    echo >&2 "Go to $ETHERSCAN_URL/$2#code"
-    exit 0
-  }
-  count=$((count + 1))
-done
+[[ $status = 1 ]] && {
+  echo >&2 "$result"
+  echo >&2 "Go to $ETHERSCAN_URL/$2#code"
+  exit 0
+}


### PR DESCRIPTION
Etherscan verification with dapptools does not appear to be working at the moment. This PR updates the `dapp-create` and `dapp-verify` scripts to successfully verify a contract at etherscan.

Notable Changes:

* In `dapp-create`, pass the path of the code, instead of the class name, to `dapp-verify`
* Add leading `v` to version string to match etherscan list
* Get the list of available compilers from etherscan and compare with the build compiler, due to [occasional discrepancies](https://github.com/ethereum/solidity/issues/7512) between the C solc release and the JS solc release, we add a block of code to select the best option from the list of available etherscan-compatible compilers.
* fixes bug in contract address string
* cleans up some of the loops related to checking results, since there is always a delay between when the transaction is confirmed and when it is available for verification at etherscan, sleep timeout is moved to the beginning of retry loop so that it should succeed on the first try.
* Similar handling of checkverify status. Loop was removed here as a design decision to keep the script moving, we can replace it if necessary.