### PR TITLE
Nix flatten solidity source

### DIFF
--- a/nix/solidity-package.nix
+++ b/nix/solidity-package.nix
@@ -26,7 +26,7 @@ in
     } @ attrs:
       pkgs.stdenv.mkDerivation (rec {
         inherit doCheck;
-        buildInputs = [ test-hevm solc ] ++ (if flatten then [hevm] else []);
+        buildInputs = [ test-hevm solc ] ++ pkgs.lib.optional flatten hevm;
         passthru = {
           remappings = remappings deps;
           libPaths = libPaths deps;

--- a/nix/solidity-package.nix
+++ b/nix/solidity-package.nix
@@ -19,12 +19,14 @@ in
     , deps ? []
     , solc ? pkgs.solc
     , test-hevm ? pkgs.dapp2.test-hevm
+    , hevm ? pkgs.hevm
     , solcFlags ? ""
+    , flatten ? false
     , ...
     } @ attrs:
       pkgs.stdenv.mkDerivation (rec {
         inherit doCheck;
-        buildInputs = [ test-hevm solc ];
+        buildInputs = [ test-hevm solc ] ++ (if flatten then [hevm] else []);
         passthru = {
           remappings = remappings deps;
           libPaths = libPaths deps;

--- a/nix/solidity-package.sh
+++ b/nix/solidity-package.sh
@@ -12,13 +12,14 @@ find "$DAPP_SRC" -name '*.sol' | while read -r x; do
   dir=${dir#/}
   json_file=$DAPP_OUT/$dir/${x##*/}.json
   mkdir -p "$DAPP_OUT/$dir"
-  (set -x; solc $REMAPPINGS --allow-paths $DAPP_SRC $solcFlags $jsonopts "$x" >"$json_file")
   if [[ $flatten == 1 && ! $x =~ \.t(\.[a-z0-9]+)*\.sol$ ]]; then
     flat_file="$DAPP_OUT/$dir/${x##*/}.flat"
+    (set -x; solc $REMAPPINGS --allow-paths $DAPP_SRC $solcFlags $jsonopts "$x" >"$json_file")
     (set -x; hevm flatten --source-file "$x" --json-file "$json_file" >"$flat_file")
     x="$flat_file"
   fi
   (set -x; solc --overwrite $REMAPPINGS --allow-paths $DAPP_SRC $solcFlags --abi --bin --bin-runtime -o "$DAPP_OUT/$dir" "$x")
+  (set -x; solc $REMAPPINGS --allow-paths $DAPP_SRC $solcFlags $jsonopts "$x" >"$json_file")
 done
 
 mkdir lib

--- a/nix/solidity-package.sh
+++ b/nix/solidity-package.sh
@@ -13,7 +13,7 @@ find "$DAPP_SRC" -name '*.sol' | while read -r x; do
   json_file=$DAPP_OUT/$dir/${x##*/}.json
   mkdir -p "$DAPP_OUT/$dir"
   (set -x; solc $REMAPPINGS --allow-paths $DAPP_SRC $solcFlags $jsonopts "$x" >"$json_file")
-  if [ "$flatten" == 1 ]; then
+  if [[ $flatten == 1 && ! $x =~ \.t(\.[a-z0-9]+)*\.sol$ ]]; then
     flat_file="$DAPP_OUT/$dir/${x##*/}.flat"
     (set -x; hevm flatten --source-file "$x" --json-file "$json_file" >"$flat_file")
     x="$flat_file"

--- a/nix/solidity-package.sh
+++ b/nix/solidity-package.sh
@@ -10,10 +10,15 @@ find "$DAPP_SRC" -name '*.sol' | while read -r x; do
   dir=${x%\/*}
   dir=${dir#$DAPP_SRC}
   dir=${dir#/}
-  mkdir -p "$DAPP_OUT/$dir"
-  (set -x; solc --overwrite $REMAPPINGS --allow-paths $DAPP_SRC $solcFlags --abi --bin --bin-runtime -o "$DAPP_OUT/$dir" "$x")
   json_file=$DAPP_OUT/$dir/${x##*/}.json
+  mkdir -p "$DAPP_OUT/$dir"
   (set -x; solc $REMAPPINGS --allow-paths $DAPP_SRC $solcFlags $jsonopts "$x" >"$json_file")
+  if [ "$flatten" == 1 ]; then
+    flat_file="$DAPP_OUT/$dir/${x##*/}.flat"
+    (set -x; hevm flatten --source-file "$x" --json-file "$json_file" >"$flat_file")
+    x="$flat_file"
+  fi
+  (set -x; solc --overwrite $REMAPPINGS --allow-paths $DAPP_SRC $solcFlags --abi --bin --bin-runtime -o "$DAPP_OUT/$dir" "$x")
 done
 
 mkdir lib


### PR DESCRIPTION
- Add `flatten` argument to `solidityPackage` to pass source through `hevm flatten`
- Fix to allow non-`solidity` `pragmas` being passed through `hevm flatten`
- Rename top scoped contracts and structs so not to cause naming conflicts on flatten