### PR TITLE
Hevm gas

### DIFF
--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -734,11 +734,11 @@ stepOneOpcode ui =
 isNextSourcePosition
   :: UiVmState -> Pred VM
 isNextSourcePosition ui vm =
-  let
-    Just dapp       = view uiVmDapp ui
-    initialPosition = currentSrcMap dapp (view uiVm ui)
-  in
-    currentSrcMap dapp vm /= initialPosition
+  case view uiVmDapp ui of
+     Just dapp ->
+       let initialPosition = currentSrcMap dapp (view uiVm ui)
+       in currentSrcMap dapp vm /= initialPosition
+     Nothing -> True
 
 isNextSourcePositionWithoutEntering
   :: UiVmState -> Pred VM

--- a/src/hevm/src/EVM/Transaction.hs
+++ b/src/hevm/src/EVM/Transaction.hs
@@ -9,7 +9,6 @@ import EVM.Keccak (keccak)
 import EVM.Precompiled (execute)
 import EVM.RLP
 import EVM.Types
-import Test.QuickCheck
 
 import Data.Aeson (FromJSON (..))
 import Data.ByteString (ByteString)

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -461,8 +461,6 @@ runUnitTestContract
                pure ("\x1b[33m[OOPS]\x1b[0m "
                <> testName, Left ("VM error for " <> testName))
 
-
-
       let inform = \(x, y) -> Text.putStrLn x >> pure y
 
       -- Run all the test cases and print their status updates


### PR DESCRIPTION
Addresses https://github.com/dapphub/dapptools/issues/277.

Two changes were made to correct gas readouts for `dapp test`:
- The gas for the `failure()` call to check whether assertions were violated is now not included in the calculation
- Use `initialGas - usedGas` instead of `burned`. I'm not sure why this doesn't give the same result as `burned`, but it gives the right result.

Case splittings look a little ugly, but preserves the semantics.