### PR TITLE
Missing dependency in stack.yaml to build hevm

### DIFF
--- a/src/hevm/stack.yaml
+++ b/src/hevm/stack.yaml
@@ -5,6 +5,7 @@ extra-deps:
 - config-ini-0.2.4.0
 - brick-0.46
 - data-clist-0.1.2.2
+- free-5.1.2
 - ghci-pretty-0.0.2
 - HSH-2.1.3
 - ipprint-0.6


### PR DESCRIPTION
This small PR adds a missing dependency to build hevm using stack.