### PR TITLE
[WIP] Hevm istanbul

### DIFF
--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -448,7 +448,7 @@ vmFromCommand cmd =
       , EVM.vmoptGasprice      = word gasprice 0
       , EVM.vmoptMaxCodeSize   = word maxcodesize 0xffffffff
       , EVM.vmoptDifficulty    = word difficulty 0
-      , EVM.vmoptSchedule      = FeeSchedule.metropolis
+      , EVM.vmoptSchedule      = FeeSchedule.istanbul
       , EVM.vmoptCreate        = create cmd
       }
     word f def = maybe def id (f cmd)

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -363,7 +363,7 @@ makeVm o = VM
     }
   , _env = Env
     { _sha3Crack = mempty
-    , _chainId = 42
+    , _chainId = 99
     , _contracts = Map.fromList
       [(vmoptAddress o, initialContract (InitCode (vmoptCode o)))]
     }

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -254,6 +254,7 @@ deriving instance Eq Contract
 -- | Various environmental data
 data Env = Env
   { _contracts :: Map Addr Contract
+  , _chainId   :: Word
   , _sha3Crack :: Map Word ByteString
   }
 
@@ -362,6 +363,7 @@ makeVm o = VM
     }
   , _env = Env
     { _sha3Crack = mempty
+    , _chainId = 42
     , _contracts = Map.fromList
       [(vmoptAddress o, initialContract (InitCode (vmoptCode o)))]
     }
@@ -754,9 +756,9 @@ exec1 = do
             next >> push (the block gaslimit)
 
         -- op: CHAINID
-        0x46 -> error "CHAINID not implemented"
-          -- limitStack 1 . burn g_base $
-          --  next >> push (the state chainid)
+        0x46 ->
+          limitStack 1 . burn g_base $ do
+           next >> push (the env chainId)
 
         -- op: SELFBALANCE
         0x47 ->

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -757,8 +757,8 @@ exec1 = do
 
         -- op: CHAINID
         0x46 ->
-          limitStack 1 . burn g_base $ do
-           next >> push (the env chainId)
+          limitStack 1 . burn g_base $
+            next >> push (the env chainId)
 
         -- op: SELFBALANCE
         0x47 ->

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -753,6 +753,11 @@ exec1 = do
           limitStack 1 . burn g_base $
             next >> push (the block gaslimit)
 
+        -- op: SELFBALANCE
+        0x47 ->
+          limitStack 1 . burn g_low $
+            next >> push (view balance this)
+
         -- op: POP
         0x50 ->
           case stk of
@@ -2184,6 +2189,7 @@ readOp x _ = case x of
   0x43 -> OpNumber
   0x44 -> OpDifficulty
   0x45 -> OpGaslimit
+  0x47 -> OpSelfbalance
   0x50 -> OpPop
   0x51 -> OpMload
   0x52 -> OpMstore

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -2296,11 +2296,11 @@ costOfPrecompile (FeeSchedule {..}) precompileAddr input =
                   then (x * x) `div` 4 + 96 * x - 3072
                   else (x * x) `div` 16 + 480 * x - 199680
     -- ECADD
-    0x6 -> 150
+    0x6 -> g_ecadd
     -- ECMUL
-    0x7 -> 6000
+    0x7 -> g_ecmul
     -- ECPAIRING
-    0x8 -> num $ ((BS.length input) `div` 192) * 34000 + 45000
+    0x8 -> num $ ((BS.length input) `div` 192) * (num g_pairing_point) + (num g_pairing_base)
     _ -> error ("unimplemented precompiled contract " ++ show precompileAddr)
 
 -- Gas cost of memory expansion

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -2290,11 +2290,11 @@ costOfPrecompile (FeeSchedule {..}) precompileAddr input =
                   then (x * x) `div` 4 + 96 * x - 3072
                   else (x * x) `div` 16 + 480 * x - 199680
     -- ECADD
-    0x6 -> 500
+    0x6 -> 150
     -- ECMUL
-    0x7 -> 40000
+    0x7 -> 6000
     -- ECPAIRING
-    0x8 -> num $ ((BS.length input) `div` 192) * 80000 + 100000
+    0x8 -> num $ ((BS.length input) `div` 192) * 34000 + 45000
     _ -> error ("unimplemented precompiled contract " ++ show precompileAddr)
 
 -- Gas cost of memory expansion

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -753,6 +753,11 @@ exec1 = do
           limitStack 1 . burn g_base $
             next >> push (the block gaslimit)
 
+        -- op: CHAINID
+        0x46 -> error "CHAINID not implemented"
+          -- limitStack 1 . burn g_base $
+          --  next >> push (the state chainid)
+
         -- op: SELFBALANCE
         0x47 ->
           limitStack 1 . burn g_low $
@@ -2189,6 +2194,7 @@ readOp x _ = case x of
   0x43 -> OpNumber
   0x44 -> OpDifficulty
   0x45 -> OpGaslimit
+  0x46 -> OpChainid
   0x47 -> OpSelfbalance
   0x50 -> OpPop
   0x51 -> OpMload

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -593,6 +593,8 @@ opString (i, o) = (showPc i <> " ") ++ case o of
   OpNumber -> "NUMBER"
   OpDifficulty -> "DIFFICULTY"
   OpGaslimit -> "GASLIMIT"
+  OpChainid -> "CHAINID"
+  OpSelfbalance -> "SELFBALANCE"
   OpPop -> "POP"
   OpMload -> "MLOAD"
   OpMstore -> "MSTORE"

--- a/src/hevm/src/EVM/Exec.hs
+++ b/src/hevm/src/EVM/Exec.hs
@@ -35,7 +35,7 @@ vmForEthrunCreation creationCode =
     , vmoptGas = 0xffffffffffffffff
     , vmoptGaslimit = 0xffffffffffffffff
     , vmoptMaxCodeSize = 0xffffffff
-    , vmoptSchedule = FeeSchedule.metropolis
+    , vmoptSchedule = FeeSchedule.istanbul
     , vmoptCreate = False
     }) & set (env . contracts . at ethrunAddress)
              (Just (initialContract (RuntimeCode mempty)))

--- a/src/hevm/src/EVM/FeeSchedule.hs
+++ b/src/hevm/src/EVM/FeeSchedule.hs
@@ -39,6 +39,10 @@ data FeeSchedule n = FeeSchedule
   , g_blockhash :: n
   , g_extcodehash :: n
   , g_quaddivisor :: n
+  , g_ecadd :: n
+  , g_ecmul :: n
+  , g_pairing_point :: n
+  , g_pairing_base :: n
   , r_block :: n
   } deriving Show
 
@@ -104,11 +108,25 @@ homestead = FeeSchedule
   , g_blockhash = 20
   , g_extcodehash = 400
   , g_quaddivisor = 20
+  , g_ecadd = 500
+  , g_ecmul = 40000
+  , g_pairing_point = 80000
+  , g_pairing_base = 100000
   , r_block = 2000000000000000000
   }
 
 metropolis :: Num n => FeeSchedule n
 metropolis = eip160 . eip150 $ homestead
+
+-- EIP1108: Reduce alt_bn128 precompile gas costs
+-- <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1108.md>
+eip1108 :: EIP n
+eip1108 fees = fees
+  { g_ecadd = 150
+  , g_ecmul = 6000
+  , g_pairing_point = 34000
+  , g_pairing_base = 45000
+  }
 
 -- EIP1884: Repricing for trie-size-dependent opcodes
 -- <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1884.md>
@@ -127,4 +145,4 @@ eip2028 fees = fees
   }
 
 istanbul :: Num n => FeeSchedule n
-istanbul = eip2028 . eip1884 $ metropolis
+istanbul = eip1108 . eip1884 . eip2028 $ metropolis

--- a/src/hevm/src/EVM/FeeSchedule.hs
+++ b/src/hevm/src/EVM/FeeSchedule.hs
@@ -109,3 +109,15 @@ homestead = FeeSchedule
 
 metropolis :: Num n => FeeSchedule n
 metropolis = eip160 . eip150 $ homestead
+
+-- EIP1884: Repricing for trie-size-dependent opcodes
+-- <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1884.md>
+eip1884 :: EIP n
+eip1884 fees = fees
+  { g_sload = 800
+  , g_balance = 700
+  , g_extcodehash = 700
+  }
+
+istanbul :: Num n => FeeSchedule n
+istanbul = eip1884 $ metropolis

--- a/src/hevm/src/EVM/FeeSchedule.hs
+++ b/src/hevm/src/EVM/FeeSchedule.hs
@@ -119,5 +119,12 @@ eip1884 fees = fees
   , g_extcodehash = 700
   }
 
+-- EIP2028: Transaction data gas cost reduction
+-- <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2028.md>
+eip2028 :: EIP n
+eip2028 fees = fees
+  { g_txdatanonzero = 16
+  }
+
 istanbul :: Num n => FeeSchedule n
-istanbul = eip1884 $ metropolis
+istanbul = eip2028 . eip1884 $ metropolis

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -28,6 +28,7 @@ data RpcQuery a where
   QueryBalance :: Addr         -> RpcQuery W256
   QueryNonce   :: Addr         -> RpcQuery W256
   QuerySlot    :: Addr -> W256 -> RpcQuery W256
+  QueryChainId ::                 RpcQuery W256
 
 data BlockNumber = Latest | BlockNumber W256
 
@@ -80,6 +81,9 @@ fetchQuery n f q = do
     QuerySlot addr slot ->
       fmap readText <$>
         f (rpc "eth_getStorageAt" [toRPC addr, toRPC slot, toRPC n])
+    QueryChainId ->
+      fmap readText <$>
+        f (rpc "eth_chainId" [toRPC n])
   return x
 
 fetchWithSession :: Text -> Session -> Value -> IO (Maybe Text)

--- a/src/hevm/src/EVM/Op.hs
+++ b/src/hevm/src/EVM/Op.hs
@@ -53,6 +53,7 @@ data Op
   | OpNumber
   | OpDifficulty
   | OpGaslimit
+  | OpSelfbalance
   | OpPop
   | OpMload
   | OpMstore

--- a/src/hevm/src/EVM/Op.hs
+++ b/src/hevm/src/EVM/Op.hs
@@ -53,6 +53,7 @@ data Op
   | OpNumber
   | OpDifficulty
   | OpGaslimit
+  | OpChainid
   | OpSelfbalance
   | OpPop
   | OpMload

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -1025,6 +1025,7 @@ opWidget (i, o) = str (showPc i <> " ") <+> case o of
   OpNumber -> txt "NUMBER"
   OpDifficulty -> txt "DIFFICULTY"
   OpGaslimit -> txt "GASLIMIT"
+  OpSelfbalance -> txt "SELFBALANCE"
   OpPop -> txt "POP"
   OpMload -> txt "MLOAD"
   OpMstore -> txt "MSTORE"

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -1025,6 +1025,7 @@ opWidget (i, o) = str (showPc i <> " ") <+> case o of
   OpNumber -> txt "NUMBER"
   OpDifficulty -> txt "DIFFICULTY"
   OpGaslimit -> txt "GASLIMIT"
+  OpChainid -> txt "CHAINID"
   OpSelfbalance -> txt "SELFBALANCE"
   OpPop -> txt "POP"
   OpMload -> txt "MLOAD"

--- a/src/hevm/src/EVM/Transaction.hs
+++ b/src/hevm/src/EVM/Transaction.hs
@@ -9,7 +9,6 @@ import EVM.Keccak (keccak)
 import EVM.Precompiled (execute)
 import EVM.RLP
 import EVM.Types
-import Test.QuickCheck
 
 import Data.Aeson (FromJSON (..))
 import Data.ByteString (ByteString)

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -81,6 +81,7 @@ data TestVMParams = TestVMParams
   , testGasprice      :: W256
   , testMaxCodeSize   :: W256
   , testDifficulty    :: W256
+  , testChainId       :: W256
   }
 
 defaultGasForCreating :: W256
@@ -567,6 +568,7 @@ initialUnitTestVm (UnitTestOptions {..}) theContract _ =
         & set balance (w256 testBalanceCreate)
   in vm
     & set (env . contracts . at ethrunAddress) (Just creator)
+    & set (env . chainId) (w256 testChainId)
 
 getParametersFromEnvironmentVariables :: IO TestVMParams
 getParametersFromEnvironmentVariables = do
@@ -589,3 +591,4 @@ getParametersFromEnvironmentVariables = do
     <*> getWord "DAPP_TEST_GAS_PRICE" 0
     <*> getWord "DAPP_TEST_MAXCODESIZE" defaultMaxCodeSize
     <*> getWord "DAPP_TEST_DIFFICULTY" 1
+    <*> getWord "DAPP_TEST_CHAINID" 99

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -558,7 +558,7 @@ initialUnitTestVm (UnitTestOptions {..}) theContract _ =
            , vmoptGasprice = testGasprice
            , vmoptMaxCodeSize = testMaxCodeSize
            , vmoptDifficulty = testDifficulty
-           , vmoptSchedule = FeeSchedule.metropolis
+           , vmoptSchedule = FeeSchedule.istanbul
            , vmoptCreate = False
            }
     creator =

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -402,7 +402,7 @@ fromCreateBlockchainCase block tx preState postState =
     (Nothing, _) -> Left SignatureUnverified
     (_, Nothing) -> Left FailedCreate
     (Just origin, Just (checkState, createdAddr)) -> let
-      feeSchedule = EVM.FeeSchedule.metropolis
+      feeSchedule = EVM.FeeSchedule.istanbul
       in Right $ Case
          (EVM.VMOpts
           { vmoptCode          = txData tx
@@ -432,7 +432,7 @@ fromNormalBlockchainCase :: Block -> Transaction
                        -> Either BlockchainError Case
 fromNormalBlockchainCase block tx preState postState =
   let Just toAddr = txToAddr tx
-      feeSchedule = EVM.FeeSchedule.metropolis
+      feeSchedule = EVM.FeeSchedule.istanbul
       toCode = Map.lookup toAddr preState
       theCode = case toCode of
           Nothing -> ""


### PR DESCRIPTION
Implements changes for Istanbul #258 

https://eips.ethereum.org/EIPS/eip-1679

- [ ] EIP-152: Add Blake2 compression function F precompile

- [x] EIP-1108: Reduce alt_bn128 precompile gas costs

- [x] EIP-1344: Add ChainID opcode

- [x] EIP-1884: Repricing for trie-size-dependent opcodes

- [x] EIP-2028: Calldata gas cost reduction

- [ ] EIP-2200: Rebalance net-metered SSTORE gas cost with consideration of SLOAD gas cost change

Still missing:

`CHAINID` should read from `--rpc` if one is passed

Is there a default `CHAINID` used in tests? Is the `Env` the right place for it?