### PR TITLE
Return the checksummed address after contract creation

### DIFF
--- a/src/dapp/libexec/dapp/dapp-address
+++ b/src/dapp/libexec/dapp/dapp-address
@@ -29,4 +29,5 @@ else
   exit 1
 fi
 
-seth keccak "$rlp" | cut -b 27-66
+raw_address=$(seth keccak "$rlp" | cut -b 27-66)
+seth --to-checksum-address "$raw_address" | cut -b 3-

--- a/src/dapp/libexec/dapp/dapp-address
+++ b/src/dapp/libexec/dapp/dapp-address
@@ -30,4 +30,4 @@ else
 fi
 
 raw_address=$(seth keccak "$rlp" | cut -b 27-66)
-seth --to-checksum-address "$raw_address" | cut -b 3-
+seth --to-checksum-address "$raw_address"

--- a/src/dapp/libexec/dapp/dapp-create
+++ b/src/dapp/libexec/dapp/dapp-create
@@ -27,4 +27,4 @@ address=$(set -x; seth send --create "$bin" "${type/constructor/${1##*/}}" "${@:
   dapp verify-contract "$path" "$address" || true
 }
 
-echo "$address"
+echo $(seth --to-checksum-address $address)

--- a/src/dapp/libexec/dapp/dapp-create
+++ b/src/dapp/libexec/dapp/dapp-create
@@ -27,4 +27,4 @@ address=$(set -x; seth send --create "$bin" "${type/constructor/${1##*/}}" "${@:
   dapp verify-contract "$path" "$address" || true
 }
 
-echo $(seth --to-checksum-address $address)
+seth --to-checksum-address "$address"


### PR DESCRIPTION
On dapp create, checksum and return the contract address.

Checksummed addressed are increasingly required by consuming services, and in the way that our scripts are using the dapp output it probably makes sense to put this here prior to handing it back to the user.