### PR TITLE
Property based testing for dapps

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 ### Added
- - Integrated `hevm`s new property based testing functionality. Any test with nonzero arguments will be interpreted as a property test whose arguments are randomly generated and run `--fuzz-runs` number of times.
+- Integration with `hevm`s new property based testing functionality. Any test with nonzero arguments will be interpreted as a property test whose arguments are randomly generated and run `--fuzz-runs` number of times.
 
 ## [0.26.0]
 ### Added

--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Added
+ - Integrated `hevm`s new property based testing functionality. Any test with nonzero arguments will be interpreted as a property test whose arguments are randomly generated and run `--fuzz-runs` number of times.
+
 ## [0.26.0]
 ### Added
 - Support for solc 0.5.15

--- a/src/dapp/libexec/dapp/dapp---hevm-opts
+++ b/src/dapp/libexec/dapp/dapp---hevm-opts
@@ -28,6 +28,10 @@ while [[ $1 ]]; do
       shift; [ -n "$1" ] || fail "--fuzz-runs requires an argument."
       opts+=(--fuzz-runs "$1"); shift
       ;;
+    --replay)
+      shift; [ -n "$1" ] || fail "--fuzz-runs requires an argument."
+      opts+=(--replay "$1"); shift
+      ;;
     --rpc-url)
       shift; [ -n "$1" ] || fail "--rpc-url requires an argument."
       HEVM_RPC=yes

--- a/src/dapp/libexec/dapp/dapp---hevm-opts
+++ b/src/dapp/libexec/dapp/dapp---hevm-opts
@@ -24,6 +24,10 @@ while [[ $1 ]]; do
     -v|--verbose)
       opts+=(--verbose 1); shift
       ;;
+    --fuzz-runs)
+      shift; [ -n "$1" ] || fail "--fuzz-runs requires an argument."
+      opts+=(--fuzz-runs "$1"); shift
+      ;;
     --rpc-url)
       shift; [ -n "$1" ] || fail "--rpc-url requires an argument."
       HEVM_RPC=yes

--- a/src/dapp/libexec/dapp/dapp-test
+++ b/src/dapp/libexec/dapp/dapp-test
@@ -5,6 +5,7 @@
 ### Options:
 ###   -v, --verbose         trace ouput for failing tests
 ###   -vv                   trace output for all tests including passes
+###   --fuzz-runs=<number>   number of times to run fuzzing tests
 ###   -m, --match=<string>  only run test methods matching regex
 ###
 ### RPC options:

--- a/src/dapp/libexec/dapp/dapp-test
+++ b/src/dapp/libexec/dapp/dapp-test
@@ -5,7 +5,8 @@
 ### Options:
 ###   -v, --verbose         trace ouput for failing tests
 ###   -vv                   trace output for all tests including passes
-###   --fuzz-runs=<number>   number of times to run fuzzing tests
+###   --fuzz-runs=<number>  number of times to run fuzzing tests
+###   --replay=<string>     rerun a particular test case
 ###   -m, --match=<string>  only run test methods matching regex
 ###
 ### RPC options:

--- a/src/dapp/libexec/dapp/dapp-test
+++ b/src/dapp/libexec/dapp/dapp-test
@@ -5,14 +5,14 @@
 ### Options:
 ###   -v, --verbose         trace ouput for failing tests
 ###   -vv                   trace output for all tests including passes
-###   --fuzz-runs=<number>  number of times to run fuzzing tests
-###   --replay=<string>     rerun a particular test case
-###   -m, --match=<string>  only run test methods matching regex
+###   --fuzz-runs <number>  number of times to run fuzzing tests
+###   --replay <string>     rerun a particular test case
+###   -m, --match <string>  only run test methods matching regex
 ###
 ### RPC options:
 ###   --rpc                 fetch remote state via ETH_RPC_URL
-###   --rpc-url=<url>       fetch remote state via <url>
-###   --rpc-block=<number>  block number (latest if not specified)
+###   --rpc-url <url>       fetch remote state via <url>
+###   --rpc-block <number>  block number (latest if not specified)
 set -e
 have() { command -v "$1" >/dev/null; }
 

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [unreleased]
  - Fix a bug introduced in [280](https://github.com/dapphub/dapptools/pull/280) of rlp encoding of transactions and sender address [320](https://github.com/dapphub/dapptools/pull/320/).
  - Make InvalidTx a fatal error for vm tests and ci.
+ - Suport property based testing in unit tests. Arguments to test functions are randomly generated based on the function abi. Fuzz tests are not present in the graphical debugger.
+ - Added flags `--replay` and `--fuzz-run` to `hevm dapp-test`, allowing for particular fuzz run cases to be rerun, or for configuration of how many fuzz tests are run.
  - Correct gas readouts for unit tests
  - Prevent crash when trying to jump to next source code point if source code is missing
 

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -106,6 +106,7 @@ data Command w
       { jsonFile    :: w ::: Maybe String <?> "Filename or path to dapp build output (default: out/*.solc.json)"
       , dappRoot    :: w ::: Maybe String <?> "Path to dapp project root directory (default: . )"
       , debug       :: w ::: Bool         <?> "Run interactively"
+      , fuzzRuns    :: w ::: Maybe Int    <?> "Number of times to run fuzz tests"
       , rpc         :: w ::: Maybe URL    <?> "Fetch state from a remote node"
       , verbose     :: w ::: Maybe Int    <?> "Append call trace: {1} failures {2} all"
       , coverage    :: w ::: Bool         <?> "Coverage analysis"
@@ -190,6 +191,7 @@ unitTestOptions cmd = do
          Nothing  -> EVM.Fetch.zero
     , EVM.UnitTest.verbose = verbose cmd
     , EVM.UnitTest.match   = pack $ fromMaybe "^test" (match cmd)
+    , EVM.UnitTest.fuzzRuns = fromMaybe 100 (fuzzRuns cmd)
     , EVM.UnitTest.vmModifier = vmModifier
     , EVM.UnitTest.testParams = params
     }

--- a/src/hevm/src/EVM/ABI.hs
+++ b/src/hevm/src/EVM/ABI.hs
@@ -38,9 +38,11 @@ module EVM.ABI
   , putAbi
   , getAbi
   , getAbiSeq
+  , genAbiValue
   , abiValueType
   , abiTypeSolidity
   , abiCalldata
+  , abiMethod
   , encodeAbiValue
   , parseTypeName
   ) where
@@ -300,6 +302,11 @@ putAbiSeq xs =
 
 encodeAbiValue :: AbiValue -> BS.ByteString
 encodeAbiValue = BSLazy.toStrict . runPut . putAbi
+
+abiMethod :: Text -> AbiValue -> BS.ByteString
+abiMethod s args = BSLazy.toStrict . runPut $ do
+  putWord32be (abiKeccak (encodeUtf8 s))
+  putAbi args
 
 abiCalldata :: Text -> Vector AbiValue -> BS.ByteString
 abiCalldata s xs = BSLazy.toStrict . runPut $ do

--- a/src/hevm/src/EVM/Dapp.hs
+++ b/src/hevm/src/EVM/Dapp.hs
@@ -75,17 +75,19 @@ findUnitTests matcher =
     case preview (abiMap . ix unitTestMarkerAbi) c of
       Nothing -> []
       Just _  ->
-        let testNames = (unitTestMethods matcher) c
+        let testNames = (unitTestMethodsFiltered matcher) c
         in if null testNames
            then []
            else [(view contractName c, testNames)]
 
-unitTestMethods :: (Text -> Bool) -> (SolcContract -> [(Text, [AbiType])])
-unitTestMethods matcher =
-  view abiMap
-    >>> Map.elems
-    >>> map (\f -> (view methodSignature f, fmap snd $ view methodInputs f))
-    >>> filter (matcher . fst)
+unitTestMethodsFiltered :: (Text -> Bool) -> (SolcContract -> [(Text, [AbiType])])
+unitTestMethodsFiltered matcher c = filter (matcher . fst) $ unitTestMethods c
+
+unitTestMethods :: SolcContract -> [(Text, [AbiType])]
+unitTestMethods = view abiMap
+                  >>> Map.elems
+                  >>> map (\f -> (view methodSignature f,
+                                  fmap snd $ view methodInputs f))
 
 traceSrcMap :: DappInfo -> Trace -> Maybe SrcMap
 traceSrcMap dapp trace =

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -49,6 +49,7 @@ ghciTest root path state =
         , verbose = Nothing
         , match = ""
         , fuzzRuns = 100
+        , replay = Nothing
         , vmModifier = loadFacts
         , testParams = params
         }
@@ -98,6 +99,7 @@ ghciTty root path state =
         , verbose = Nothing
         , match = ""
         , fuzzRuns = 100
+        , replay = Nothing
         , vmModifier = loadFacts
         , testParams = params
         }

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -48,6 +48,7 @@ ghciTest root path state =
         { oracle = EVM.Fetch.zero
         , verbose = Nothing
         , match = ""
+        , fuzzRuns = 100
         , vmModifier = loadFacts
         , testParams = params
         }
@@ -96,6 +97,7 @@ ghciTty root path state =
         { oracle = EVM.Fetch.zero
         , verbose = Nothing
         , match = ""
+        , fuzzRuns = 100
         , vmModifier = loadFacts
         , testParams = params
         }

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -507,6 +507,7 @@ defaultUnitTestOptions = do
     { oracle            = Fetch.zero
     , verbose           = Nothing
     , match             = ""
+    , fuzzRuns          = 100
     , vmModifier        = id
     , testParams        = params
     }

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -508,6 +508,7 @@ defaultUnitTestOptions = do
     , verbose           = Nothing
     , match             = ""
     , fuzzRuns          = 100
+    , replay            = Nothing
     , vmModifier        = id
     , testParams        = params
     }

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -18,6 +18,7 @@ import Data.SCargot.Repr.Basic
 import Data.Set (Set)
 import Data.Text (Text, pack, unpack)
 import EVM
+import EVM.ABI
 import EVM.Concrete
 import EVM.Dapp
 import EVM.Debug (srcMapCodePos)
@@ -522,7 +523,7 @@ initialStateForTest opts@(UnitTestOptions {..}) dapp (contractPath, testName) =
       Stepper.evm . pushTrace . EntryTrace $
         "test " <> testName <> " (" <> contractPath <> ")"
       initializeUnitTest opts
-      void (runUnitTest opts testName)
+      void (runUnitTest opts testName (AbiTuple mempty))
     ui0 =
       UiVmState
         { _uiVm             = vm0

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -11,7 +11,7 @@ import Brick.Widgets.Center
 import Brick.Widgets.List
 
 import EVM
-import EVM.ABI (abiTypeSolidity)
+import EVM.ABI (abiTypeSolidity, AbiValue(..))
 import EVM.Concrete (Word (C))
 import EVM.Dapp (DappInfo, dappInfo)
 import EVM.Dapp (dappUnitTests, dappSolcByName, dappSolcByHash, dappSources)
@@ -549,7 +549,7 @@ initialUiVmStateForTest opts dapp (theContractName, theTestName) =
       Stepper.evm . pushTrace . EntryTrace $
         "test " <> theTestName <> " (" <> theContractName <> ")"
       initializeUnitTest opts
-      void (runUnitTest opts theTestName)
+      void (runUnitTest opts theTestName (AbiTuple mempty))
     ui0 =
       UiVmState
         { _uiVm             = vm0

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -260,6 +260,7 @@ runFromVM vm = do
       { oracle            = Fetch.zero
       , verbose           = Nothing
       , match             = ""
+      , fuzzRuns          = 1
       , vmModifier        = id
       , testParams        = error "irrelevant"
       }
@@ -302,7 +303,7 @@ main opts root jsonFilePath = do
                   TestPickerPane
                   (Vec.fromList
                    (concatMap
-                    (\(a, xs) -> [(a, x) | x <- xs])
+                    (\(a, xs) -> [(a, fst x) | x <- xs])
                     (view dappUnitTests dapp)))
                   1
             , _testPickerDapp = dapp
@@ -389,7 +390,7 @@ appEvent st@(ViewVm s) (VtyEvent (V.EvKey V.KEsc [])) =
               TestPickerPane
               (Vec.fromList
                (concatMap
-                (\(a, xs) -> [(a, x) | x <- xs])
+                (\(a, xs) -> [(a, fst x) | x <- xs])
                 (view dappUnitTests dapp)))
               1
         , _testPickerDapp = dapp

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -17,6 +17,7 @@ import Data.ByteString (ByteString)
 import Data.ByteString.Base16 as BS16
 import Data.ByteString.Builder (byteStringHex, toLazyByteString)
 import Data.ByteString.Lazy (toStrict)
+import qualified Data.ByteString.Char8  as Char8
 import Data.DoubleWord
 import Data.DoubleWord.TH
 import Data.Word (Word8)
@@ -68,6 +69,9 @@ showAddrWith0x addr = "0x" ++ show addr
 
 showWordWith0x :: W256 -> String
 showWordWith0x addr = show addr
+
+strip0x :: ByteString -> ByteString
+strip0x bs = if "0x" `Char8.isPrefixOf` bs then Char8.drop 2 bs else bs
 
 newtype ByteStringS = ByteStringS ByteString
 

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -32,7 +32,7 @@ import Data.ByteString    (ByteString)
 import Data.ByteString.Base16 as BS16
 import Data.Foldable      (toList)
 import Data.Map           (Map)
-import Data.Maybe         (fromMaybe, catMaybes, fromJust, fromMaybe, mapMaybe)
+import Data.Maybe         (fromMaybe, catMaybes, fromJust, isJust, fromMaybe, mapMaybe)
 import Data.Monoid        ((<>))
 import Data.Text          (Text, pack, unpack)
 import Data.Text          (isPrefixOf, stripSuffix, intercalate)
@@ -468,7 +468,14 @@ runUnitTestContract
 
           -- Define the thread spawner for property based tests
           let fuzzRun (testName, types) = do
-                res <- quickCheckResult (withMaxSuccess fuzzRuns (fuzzTest opts testName types vm1))
+                let args = Args{ replay          = Nothing
+                               , maxSuccess      = fuzzRuns
+                               , maxDiscardRatio = 10
+                               , maxSize         = 100
+                               , chatty          = isJust verbose
+                               , maxShrinks      = maxBound
+                               }
+                res <- quickCheckWithResult args (fuzzTest opts testName types vm1)
                 case res of
                   Success numTests _ _ _ _ _ ->
                     pure ("\x1b[32m[PASS]\x1b[0m "

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -29,14 +29,12 @@ import Control.Monad.Par.IO (runParIO)
 
 import qualified Data.ByteString.Lazy as BSLazy
 import Data.ByteString    (ByteString)
-import Data.ByteString.Base16 as BS16
 import Data.Foldable      (toList)
 import Data.Map           (Map)
 import Data.Maybe         (fromMaybe, catMaybes, fromJust, isJust, fromMaybe, mapMaybe)
 import Data.Monoid        ((<>))
 import Data.Text          (Text, pack, unpack)
 import Data.Text          (isPrefixOf, stripSuffix, intercalate)
-import qualified Data.ByteString.Char8  as Char8
 import Data.Word          (Word32)
 import System.Environment (lookupEnv)
 import System.IO          (hFlush, stdout)
@@ -484,7 +482,7 @@ runUnitTestContract
                            -- but the vm we want is not accessible here anyway...
                            Right (passOutput vm1 dapp opts testName))
                   Failure _ _ _ _ _ _ _ _ _ _ failCase _ _ ->
-                    let abiValue = decodeAbiValue (AbiTupleType (Vector.fromList types)) $ BSLazy.fromStrict . snd . BS16.decode . Char8.pack $ concat failCase
+                    let abiValue = decodeAbiValue (AbiTupleType (Vector.fromList types)) $ BSLazy.fromStrict $ hexText (pack $ concat failCase)
                         ppOutput = pack $ show abiValue
                     in do
                     -- Run the failing test again to get a proper trace


### PR DESCRIPTION
Adds support for property based testing using `dapp`. By default, any test function which takes more than 0 arguments is interpreted as a property test, and it's arguments are randomly generated. 

The number of tests that are run can be modified with the `--fuzz-runs` flag, and defaults to `100`. 