### PR TITLE
solc 0.5.15

### DIFF
--- a/nix/solc-updates.md
+++ b/nix/solc-updates.md
@@ -15,7 +15,7 @@
         1. add a new `solc_X.Y.Z` in the `unreleased` section
         1. update `rev` and `sha256` based on the output from `nix-prefetch-git
            git@github.com:dapphub/nixpkgs refs/heads/solc-X.Y.Z`
-    1. bump the version number in `dapp---version`, `default.nix` and the changelog
+    1. bump the version number in `dapp---version`, `src/dapp/default.nix` and the changelog
     1. commit the changes
 1. open a pr from `dapphub/dapptools:solc-X.Y.Z` to `dapphub/dapptools:master`
 1. once merged tag the commit with the new version number

--- a/nix/solc-versions.nix
+++ b/nix/solc-versions.nix
@@ -38,5 +38,7 @@ rec {
   x86_64-darwin = removeAttrs x86_64-linux [ "solc_0_4_6" "solc_0_4_8" "solc_0_4_11" "solc_0_4_12" "solc_0_4_24" ];
 
   # these versions have not been upstreamed on NixOS/nixpkgs yet, and come from our fork at dapptools/nixpkgs
-  unreleased = {};
+  unreleased = {
+    solc_0_5_15 = { rev = "4b456387e27ec440396646099cb8973fc3052e20"; sha256 = "16c4yn8fm1smm399bp4x3q4h1v96bvxy53407cgyl2hmy16k7qv9"; };
+  };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -114,7 +114,7 @@ in rec {
         fetchNixpkgs { owner = "NixOS";   attr = super.system; }
         //
         fetchNixpkgs { owner = "dapphub"; attr = "unreleased"; };
-  solc = solc-versions.solc_0_5_12;
+  solc = solc-versions.solc_0_5_15;
 
   hevm = self.pkgs.haskell.lib.justStaticExecutables self.haskellPackages.hevm;
 

--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -5,10 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Added
+- Support for solc 0.5.15
+
 ### Fixed
 - `dapp address` and `dapp create` now returns checksummed addresses
+
 ### Changed
 - `dapp address` returns address with `0x` prefix. 
+- Default to solc 0.5.15
 
 ## [0.25.0] - 2019-08-02
 ### Fixed

--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [0.26.0]
 ### Added
 - Support for solc 0.5.15
 
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `dapp address` returns address with `0x` prefix. 
 - Default to solc 0.5.15
+- Since solc 0.5.15, shared libraries are not built anymore, which might break
+  certain rare usecases
+
 
 ## [0.25.0] - 2019-08-02
 ### Fixed

--- a/src/dapp/default.nix
+++ b/src/dapp/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   name = "dapp-${version}";
-  version = "0.25.0";
+  version = "0.26.0";
   src = ./.;
 
   nativeBuildInputs = [makeWrapper shellcheck coreutils nodejs];

--- a/src/dapp/libexec/dapp/dapp---version
+++ b/src/dapp/libexec/dapp/dapp---version
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-echo dapp 0.25.0
+echo dapp 0.26.0
 solc --version
 echo "hevm $(hevm version)"


### PR DESCRIPTION
* Bumps solc to 0.5.15
* Disable the building of shared libs in Linux, which was difficult to maintain cause it required a patch that had to be kept in sync with upstream, for very little gain.
* bumps dapp to 0.26.0

## TODO

when this is merged, create a `dapp/0.26.0` tag.