### PR TITLE
Vmtestsfix

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -12,14 +12,15 @@ let
     sha256 = "06h3hcsm09kp4hzq5sm9vqkmvx2nvgbh5i788qnqh5iiz9fpaa9k";
   };
 
-  # run all General State Tests, skipping modexp as it is
-  # problematic for darwin. todo: don't skip for linux
+  # run all General State Tests, skipping tests that deal with "anomalies on the main network"
+  # (see section K.1 of https://ethereum.github.io/yellowpaper/paper.pdf), and some performance
+  # heavy ones.
   hevmCompliance = x: x.runCommand "hevm-compliance" {} ''
     mkdir "$out"
     export PATH=${x.pkgs.hevm}/bin:${x.pkgs.jq}/bin:$PATH
     ${x.pkgs.hevm}/bin/hevm compliance \
       --tests ${ethereum-test-suite x} \
-      --skip "(modexp|RevertPrecompiledTouch_storage_d0g0v0|RevertPrecompiledTouch_storage_d3g0v0|Create1000Byzantium_d0g1v0)" \
+      --skip "(RevertPrecompiledTouch_storage_d0g0v0|RevertPrecompiledTouch_storage_d3g0v0|Create1000Byzantium_d0g1v0)" \
       --timeout 20 \
       --html > $out/index.html
     ${x.pkgs.hevm}/bin/hevm compliance \

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -1,6 +1,8 @@
 # hevm changelog
 
 ## [unreleased]
+ - Fix a bug introduced in [280](https://github.com/dapphub/dapptools/pull/280) of rlp encoding of transactions and sender address [320](https://github.com/dapphub/dapptools/pull/320/).
+ - Make InvalidTx a fatal error for vm tests and ci.
  - Correct gas readouts for unit tests
  - Prevent crash when trying to jump to next source code point if source code is missing
 

--- a/src/hevm/src/EVM/Concrete.hs
+++ b/src/hevm/src/EVM/Concrete.hs
@@ -245,7 +245,7 @@ x0 ^ y0 | y0 < 0    = errorWithoutStackTrace "Negative exponent"
                   | otherwise   = g (x * x) ((y - 1) `shiftR` 1) (x * z)
 
 createAddress :: Addr -> W256 -> Addr
-createAddress a n = num $ keccak $ rlpList [rlpencode $ BS $ word160Bytes a, rlpWord256 n]
+createAddress a n = num $ keccak $ rlpList [rlpWord160 a, rlpWord256 n]
 
 create2Address :: Addr -> W256 -> ByteString -> Addr
 create2Address a s b = num $ keccak $ mconcat $

--- a/src/hevm/src/EVM/Transaction.hs
+++ b/src/hevm/src/EVM/Transaction.hs
@@ -48,20 +48,20 @@ signingData chainId tx =
   else normalData
   where v          = fromIntegral (txV tx)
         to'        = case txToAddr tx of
-          Just a  -> rlpWord160 a
-          Nothing -> rlpencode $ BS mempty
+          Just a  -> BS $ word160Bytes a
+          Nothing -> BS mempty
         normalData = rlpList [rlpWord256 (txNonce tx),
                               rlpWord256 (txGasPrice tx),
                               rlpWord256 (txGasLimit tx),
                               to',
                               rlpWord256 (txValue tx),
-                              rlpencode (BS (txData tx))]
+                              BS (txData tx)]
         eip155Data = rlpList [rlpWord256 (txNonce tx),
                               rlpWord256 (txGasPrice tx),
                               rlpWord256 (txGasLimit tx),
                               to',
                               rlpWord256 (txValue tx),
-                              rlpencode (BS (txData tx)),
+                              BS (txData tx),
                               rlpWord256 (fromIntegral chainId),
                               rlpWord256 0x0,
                               rlpWord256 0x0]

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -379,6 +379,7 @@ errorFatal TooManyBlocks = True
 errorFatal TooManyTxs = True
 errorFatal TargetMissing = True
 errorFatal SignatureUnverified = True
+errorFatal InvalidTx = True
 errorFatal _ = False
 
 fromBlockchainCase :: BlockchainCase -> Either BlockchainError Case


### PR DESCRIPTION
Unfortunately, I introduced a bug in https://github.com/dapphub/dapptools/commit/f1b9b3485fa297a8ad5cd99c38e5ac6194970d11, wherein the rlp encoding of transactions wrapped some fields twice. I.e. a transaction:
```
(Transaction {txData = "", txGasLimit = 0x61a80, txGasPrice = 0x1, txNonce = 0x0, txR = 0xe94818d1f3b0c69eb37720145a5ead7fbf6f8d80139dd53953b4a782301050a3, txS = 0x1fcf46908c01576715411be0857e30027d6be3250a3653f049b3ff8d74d2540c, txToAddr = Just 0x95e7baea6a6c7c4c2dfeb977efac326af552d87, txV = 0x1c, txValue = 0x186a0})
```
was encoded as:
```
[0x80,0x01,0x83061a80,0x94095e7baea6a6c7c4c2dfeb977efac326af552d87,0x830186a0,0x80]
```
instead of:
```
[0x,0x01,0x061a80,0x095e7baea6a6c7c4c2dfeb977efac326af552d87,0x0186a0,0x]
```

This error caused blockchain-tests to not be able to decode any "valid tests", since all transactions were malformed. But because `InvalidTx` was not treated as a fatal error, no failures were reported and we happily ignored all tests. 

This fixes the tx encoding bug, and makes `InvalidTx` a fatal error. 
Let's see how the ci does on this one