### PR TITLE
hevm: metadata: search for bzzr1 as well as bzzr0

### DIFF
--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -360,7 +360,9 @@ knownBzzrPrefixes = [
   -- a1 65 "bzzr0" 0x58 0x20 (solc <= 0.5.8)
   BS.pack [0xa1, 0x65, 98, 122, 122, 114, 48, 0x58, 0x20],
   -- a2 65 "bzzr0" 0x58 0x20 (solc >= 0.5.9)
-  BS.pack [0xa2, 0x65, 98, 122, 122, 114, 48, 0x58, 0x20]
+  BS.pack [0xa2, 0x65, 98, 122, 122, 114, 48, 0x58, 0x20],
+  -- a2 65 "bzzr1" 0x58 0x20 (solc >= 0.5.11)
+  BS.pack [0xa2, 0x65, 98, 122, 122, 114, 49, 0x58, 0x20]
   ]
 
 -- | Every node in the AST has an ID, and other nodes reference those


### PR DESCRIPTION
Just a little thing I noticed while investigating the embedded metadata hash. Solidity embeds `bzzr1` as part of the metadata identifier since solc 0.5.11 ([ref](https://github.com/ethereum/solidity/blob/385e1bf70a0389009af0da2f2f6054cd5b246619/Changelog.md#0511-2019-08-12))

Not sure what to test here, I ran: `nix build -f release.nix dapphub.linux.stable` and everything passes, but I guess there's something more I need to do?

