### PR TITLE
travis: use -A argument for nix-env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - cachix use dapp
 script:
   - |
-    nix-env -i ShellCheck
+    nix-env -iA nixpkgs.shellcheck
     grep -RHL --exclude-dir node_modules node src/*/libexec | xargs shellcheck --exclude=2001
   - |
     [[ -z "$TRAVIS_PULL_REQUEST_SLUG" || "$TRAVIS_PULL_REQUEST_SLUG" == "dapphub/dapptools" ]] && cachix push --watch-store dapp &


### PR DESCRIPTION
Avoids evaluating the whole package set, increasing performance.

This also, incidentally, solves a build failure we were having where the
version of nix used didn't have the `fromTOML` builtin used in a
recently introduced package.

Closes #322.