### PR TITLE
travis: pin nix to 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ os:
   - linux
   - osx
 language: nix
+nix: 2.3
 sudo: required
 # workaround for a macOS specific issue with trusted users
 before_install:


### PR DESCRIPTION
We were using the [default][0], which is 2.0.4, and among other things lacks
builtins that are used in nixpkgs, resulting in build failures like [this
one][1].

[0]: https://github.com/travis-ci/travis-build/blob/b897837a87a3210a78e89482c4d0ecdd02360504/lib/travis/build/script/nix.rb#L12
[1]: https://travis-ci.com/dapphub/dapptools/jobs/272356687