### PR TITLE
travis: install cachix from latest nixpkgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - echo "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= d121dybo9yhl5h.cloudfront.net-1:IOpHdUBT2b3fIRb/TBm+V8Y8eEj52fStcllzD6TFYyU=" | sudo tee -a /etc/nix/nix.conf
   - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
 install:
-  - nix-env -if https://github.com/cachix/cachix/tarball/v0.2.0 --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+  - nix-env -if https://github.com/cachix/cachix/tarball/v0.3.5 --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
   - cachix use dapp
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - echo "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= d121dybo9yhl5h.cloudfront.net-1:IOpHdUBT2b3fIRb/TBm+V8Y8eEj52fStcllzD6TFYyU=" | sudo tee -a /etc/nix/nix.conf
   - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
 install:
-  - nix-env -if https://github.com/cachix/cachix/tarball/v0.3.5 --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+  - nix-env -iA nixpkgs.cachix
   - cachix use dapp
 script:
   - |


### PR DESCRIPTION
This could solve the CI issues we were having, cf. https://github.com/dapphub/dapptools/pull/330#issuecomment-578716213.

I think the problem was that the pinned version of nixpkgs we were using to build/fetch cachix is too old.

By using the version in the nixpkgs Travis is already using (which I think is the latest unstable) we lose some reproducibility, but we leverage Hydra tests.