### PR TITLE
travis: use cachix from pinned nixpkgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - echo "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= d121dybo9yhl5h.cloudfront.net-1:IOpHdUBT2b3fIRb/TBm+V8Y8eEj52fStcllzD6TFYyU=" | sudo tee -a /etc/nix/nix.conf
   - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
 install:
-  - nix-env -if https://github.com/cachix/cachix/tarball/v0.2.0 --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+  - nix-env -iA cachix -f .
   - cachix use dapp
 script:
   - |


### PR DESCRIPTION
Instead of using any nixpkgs, we use the one this repo pins anyway. Currently, this means using [cachix 0.2.0](https://github.com/NixOS/nixpkgs/blob/f1707d8875276cfa110139435a7e8998b4c2a4fd/pkgs/development/tools/cachix/cachix.nix).

For some reason that has to do with issues with Cachix, this seems to be the only way to currently get pushes to work.

We can revisit this (e.g. by using [latest cachix](https://github.com/dapphub/dapptools/pull/331)) after [this migration](https://twitter.com/cachix_org/status/1222045505842073601) has completed.

Closes #331.
