### PR TITLE
fix `stripBytecodeMetadata`

### DIFF
--- a/src/hevm/default.nix
+++ b/src/hevm/default.nix
@@ -1,6 +1,6 @@
 { mkDerivation, abstract-par, aeson, ansi-wl-pprint, async, base
 , base16-bytestring, base64-bytestring, binary, brick, bytestring
-, cereal, containers, cryptonite, data-dword, deepseq, directory
+, cborg, cereal, containers, cryptonite, data-dword, deepseq, directory
 , ff, fgl, filepath, free, ghci-pretty, haskeline, here, HUnit
 , lens, lens-aeson, megaparsec, memory, monad-par, mtl, multiset
 , operational, optparse-generic, process, QuickCheck
@@ -19,7 +19,7 @@ mkDerivation {
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [
     abstract-par aeson ansi-wl-pprint base base16-bytestring
-    base64-bytestring binary brick bytestring cereal containers
+    base64-bytestring binary brick bytestring cborg cereal containers
     cryptonite data-dword deepseq directory fgl filepath free
     ghci-pretty haskeline lens lens-aeson megaparsec memory monad-par
     mtl multiset operational optparse-generic process QuickCheck

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -87,6 +87,7 @@ library
     binary                            >= 0.8,
     brick                             >= 0.18,
     bytestring                        >= 0.10,
+    cborg                             >= 0.2,
     cereal                            >= 0.5,
     containers                        >= 0.5,
     cryptonite                        >= 0.21,


### PR DESCRIPTION
This introduces the fix suggested in #333. `solc-0.6.2` also uses `ipfs` instead of `bzzr` so this works a bit better.