### PR TITLE
Add Etherscan API key to checkverifystatus

### DIFF
--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -106,7 +106,7 @@ done
 
 sleep 20
 response=$(curl -fsS "$ETHERSCAN_API_URL" \
--d "module=contract&action=checkverifystatus&guid=$guid")
+-d "module=contract&action=checkverifystatus&guid=$guid&apikey=$ETHERSCAN_API_KEY")
 
 status=$(jshon <<<"$response" -e status -u)
 result=$(jshon <<<"$response" -e result -u)


### PR DESCRIPTION
Etherscan API key is mandatory for all calls as of 2/15/2020. This adds the key to the checkverifystatus call.