### PR TITLE
seth: add --calldata-decode

### DIFF
--- a/src/seth/libexec/seth/seth---calldata-decode
+++ b/src/seth/libexec/seth/seth---calldata-decode
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+const usage = `Usage: seth --calldata-decode <name>(<in-types>)(<out-types) <hexdata>
+Decode <hexdata> according to <in-types> (<out-types> are ignored).`;
+if (process.argv.length == 4 &&
+    process.argv[2].indexOf('(') >= 0) {
+  // silence warnings we don't care about
+  const log = console.log
+  console.log = () => {};
+  const ethers = require("./ethers.min.js");
+  console.log = log;
+  const sig = process.argv[2];
+  const calldata = process.argv[3];
+  try {
+    const sighash = ethers.utils.hexDataSlice(calldata, 0, 4);
+    const data = ethers.utils.hexDataSlice(calldata, 4);
+    const funcs = new ethers.utils.Interface(["function " + sig.replace(')(', ') returns (')]).functions;
+    const func = Object.values(funcs).find(f => f.sighash == sighash);
+    const decoded = ethers.utils.defaultAbiCoder.decode(func.inputs, data);
+    console.log(decoded.map(e => e.toString()).join('\n'));
+  } catch (e) {
+    console.error(e.toString())
+    process.exit(1)
+  }
+} else {
+  console.error(usage)
+  process.exit(1)
+}


### PR DESCRIPTION
I would use this to debug tx made by someone else with complex inputs, especially where the contract is not verified on etherscan (but I knew the signature, or got it from 4byte.directory for example).

Simple example:

```sh
foodata=$(seth calldata 'foo(uint256)' 444)
seth --calldata-decode 'foo(uint256)' "$foodata"  # 444
```

Practical example ([this failing tx](https://etherscan.io/tx/0x3fe4ccad0cc8f25a2ea5e915c0d80c017c5107b5cc142c7ab71c3a6caa7d233e)):

```sh
txinput=$(seth tx 0x3fe4ccad0cc8f25a2ea5e915c0d80c017c5107b5cc142c7ab71c3a6caa7d233e | awk '$1 == "input" {print $2}')
seth --calldata-decode \
     'callOnExchange(uint,string,address[8],uint[8],bytes[4],bytes32,bytes)' "$txinput"

5
takeOrder(address,address[8],uint256[8],bytes[4],bytes32,bytes)
0x998497ffc64240D6a70C38e544521D09DcD23293,0x0000000000000000000000000000000000000000,0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2,0x6B175474E89094C44Da98b954EedeAC495271d0F,0xA258b39954ceF5cB142fd567A46cDdB31a670124,0x0000000000000000000000000000000000000000,0x0000000000000000000000000000000000000000,0x0000000000000000000000000000000000000000
8000000000000000000,2119357657600000000000,0,0,1582035574,1582035453432,10000000000000000,0
0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2,0xf47261b00000000000000000000000006b175474e89094c44da98b954eedeac495271d0f,0x,0x
0x0000000000000000000000000000000000000000000000000000000000000000
0x1bf681d1ee385fbccdc3a69c5ea7c1615df538ff97b1a582f459e99e2687edc61b3f15b6c71507a99d20a95431519a9de8f391d156ea5687e2252b3b841d29500d02
```