### PR TITLE
dapp create without need of --extract

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for solc 0.5.16
 - Support for solc 0.6.0
 
+### Changed
+- `--extract` flag for `dapp build` no longer needed for using `dapp create`.
+- `dapp create` will fail if it finds multiple contracts with same name, requiring full path instead.
+
 ## [0.26.0]
 ### Added
 - Support for solc 0.5.15

--- a/src/dapp/libexec/dapp/dapp-create
+++ b/src/dapp/libexec/dapp/dapp-create
@@ -16,8 +16,31 @@ for i in "$@"; do
   esac
 done
 
-bin=$DAPP_OUT/${1?missing contract name}.bin
-type=$(seth --abi-constructor <"$DAPP_OUT/$1.abi")
+name=${1?missing contract name}
+
+mapfile -t contracts < <(<"$DAPP_JSON" jq '.contracts|keys[]' -r)
+
+name=()
+for path in "${contracts[@]}"; do
+  [[ "${path#*:}" = "$1" ]] && name+=("$path")
+done
+
+[[ "${#name[@]}" -eq 0 ]] && {
+  echo >&2 "${0##*/}: error: $1 not found"
+  exit 1
+}
+
+[[ "${#name[@]}" -ge 2 ]] && {
+  echo >&2 "${0##*/}: error: $1 found in multiple files"
+  printf '%s\n' "${name[@]}"
+  exit 1
+}
+
+data=$(<"$DAPP_JSON" jq '.contracts' -r)
+contract=$(echo "$data" | jq '.[''"'"$path"'"'']')
+abi=$(jq '.["abi"]' -r <<< "$contract")
+bin=$(jq '.["bin"]' -r <<< "$contract")
+type=$(seth --abi-constructor <<< "$abi")
 address=$(set -x; seth send --create "$bin" "${type/constructor/${1##*/}}" "${@:2}")
 
 [[ $DAPP_VERIFY_CONTRACT ]] && {

--- a/src/dapp/libexec/dapp/dapp-create
+++ b/src/dapp/libexec/dapp/dapp-create
@@ -42,7 +42,7 @@ done
 }
 
 data=$(<"$DAPP_JSON" jq '.contracts' -r)
-contract=$(echo "$data" | jq '.[''"'"$path"'"'']')
+contract=$(echo "$data" | jq '.[''"'"${name[0]}"'"'']')
 abi=$(jq '.["abi"]' -r <<< "$contract")
 bin=$(jq '.["bin"]' -r <<< "$contract")
 type=$(seth --abi-constructor <<< "$abi")

--- a/src/dapp/libexec/dapp/dapp-create
+++ b/src/dapp/libexec/dapp/dapp-create
@@ -26,8 +26,13 @@ name=${1?missing contract name}
 mapfile -t contracts < <(<"$DAPP_JSON" jq '.contracts|keys[]' -r)
 
 name=()
+
 for path in "${contracts[@]}"; do
-  [[ "${path#*:}" = "$1" ]] && name+=("$path")
+  if [ -z "${1##*:*}" ]; then
+    [[ "$path" = "$1" ]] && name+=("$path")
+  else
+    [[ "${path#*:}" = "$1" ]] && name+=("$path")
+  fi
 done
 
 [[ "${#name[@]}" -eq 0 ]] && {
@@ -36,8 +41,8 @@ done
 }
 
 [[ "${#name[@]}" -ge 2 ]] && {
-  echo >&2 "${0##*/}: error: $1 found in multiple files"
-  printf '%s\n' "${name[@]}"
+  echo >&2 "${0##*/}: error: $1 found in multiple files. Use full path:"
+  printf 'dapp create %s\n' "${name[@]}"
   exit 1
 }
 
@@ -46,7 +51,7 @@ contract=$(echo "$data" | jq '.[''"'"${name[0]}"'"'']')
 abi=$(jq '.["abi"]' -r <<< "$contract")
 bin=$(jq '.["bin"]' -r <<< "$contract")
 type=$(seth --abi-constructor <<< "$abi")
-address=$(set -x; seth send --create "$bin" "${type/constructor/${1##*/}}" "${@:2}")
+address=$(set -x; seth send --create "$bin" "${type/constructor/${1#*:}}" "${@:2}")
 
 [[ $DAPP_VERIFY_CONTRACT ]] && {
   echo >&2 "Verifying contract at $address"

--- a/src/dapp/libexec/dapp/dapp-create
+++ b/src/dapp/libexec/dapp/dapp-create
@@ -16,6 +16,11 @@ for i in "$@"; do
   esac
 done
 
+[[ -e "${DAPP_JSON}" ]] || {
+  echo >&2 "${0##*/}: error: ${DAPP_JSON} file not found. Did you run ``dapp build``?"
+  exit 1
+}
+
 name=${1?missing contract name}
 
 mapfile -t contracts < <(<"$DAPP_JSON" jq '.contracts|keys[]' -r)


### PR DESCRIPTION
Uses dapp.sol.json data for dapp create, without needing `--extract`

If there are multiple contracts with the same name (on different files) it fails. I believe this is the right thing to do, but wondering how to fix so that it's backwards compatible

```
$ dapp create MyContract
dapp-create: error: MyContract found in multiple files
src/MyContract.sol:MyContract
src/MyContract2.sol:MyContract
```