### PR TITLE
Remove mcd-cli

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "submodules/terra"]
 	path = submodules/terra
 	url = https://github.com/makerdao/terra
-[submodule "submodules/mcd-cli"]
-	path = submodules/mcd-cli
-	url = https://github.com/makerdao/mcd-cli

--- a/overlay.nix
+++ b/overlay.nix
@@ -137,7 +137,6 @@ in rec {
 
   token = self.callPackage (import ./src/token) {};
   dai = self.callPackage (import ./submodules/dai-cli) {};
-  mcd = self.callPackage (import ./submodules/mcd-cli) {};
 
   setzer = self.callPackage (import ./submodules/setzer) {};
   terra = self.callPackage (import ./submodules/terra) {};


### PR DESCRIPTION
Recent updates to `seth` have broken much of the functionality in mcd-cli.

Current plan is to repair the functionality and build out `mcd-cli` as a distinct nix package so that we can better manage the dapptools version under the hood.

Since many of the features in the current distribution do not work with the current iteration of dapptools, we should remove it from the distribution to not encourage it's use.