### PR TITLE
hevm: fix STATICCALL for precompiles

### DIFF
--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -947,6 +947,7 @@ exec1 = do
               : xOutSize
               : xs
              ) ->
+              (if xValue > 0 then notStatic else id) $
               case xTo of
                 n | n > 0 && n <= 9 ->
                   precompiledContract vm fees xGas xTo xTo xValue xInOffset xInSize xOutOffset xOutSize xs
@@ -955,7 +956,6 @@ exec1 = do
                     assign (state . stack) xs
                     cheat (xInOffset, xInSize) (xOutOffset, xOutSize)
                 _ ->
-                  (if xValue > 0 then notStatic else id) $
                     accessMemoryRange fees xInOffset xInSize $
                       accessMemoryRange fees xOutOffset xOutSize $ do
                         availableGas <- use (state . gas)
@@ -1161,7 +1161,6 @@ precompiledContract
   -> [Word]
   -> EVM ()
 precompiledContract vm fees gasCap precompileAddr recipient xValue inOffset inSize outOffset outSize xs =
-  (if xValue == 0 then notStatic else id) $
     accessMemoryRange fees inOffset inSize $
       accessMemoryRange fees outOffset outSize $ do
         availableGas <- use (state . gas)


### PR DESCRIPTION
Current semantics does the opposite of what we want for precompiles – it causes a static mode violation iff the callvalue is zero.

Example bytecode for which hevm reverts and evm (geth) succeeds:
```
hevm exec --gas 0xffffff --code 0x600080541515601d576001815580818283305afa15601b578081fd5b005b80818283600160025af15050
evm --code 0x600080541515601d576001815580818283305afa15601b578081fd5b005b80818283600160025af15050 --gas 0xffffff --debug run
```

With this patch, `hevm exec` still fails because of an issue related to #273 (although the faulty semantics are still apparent in dapp tests), but in combination with #353 the behaviour of hevm exec matches that of geths