### PR TITLE
fix loadContract

### DIFF
--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1505,11 +1505,15 @@ finalize = do
 
 loadContract :: Addr -> EVM ()
 loadContract target =
-  preuse (env . contracts . ix target . bytecode) >>=
+  preuse (env . contracts . ix target . contractcode) >>=
     \case
       Nothing ->
         error "Call target doesn't exist"
-      Just targetCode -> do
+      Just (InitCode targetCode) -> do
+        assign (state . contract) target
+        assign (state . code)     targetCode
+        assign (state . codeContract) target
+      Just (RuntimeCode targetCode) -> do
         assign (state . contract) target
         assign (state . code)     targetCode
         assign (state . codeContract) target


### PR DESCRIPTION
so that contracts with `InitCode` may be ran normally without changing it to `RuntimeCode`

before, we initialized a contract was by

1. creating a contract with `RuntimeCode constructorCode`
2. exec'ing the constructor
3. replacing the contract with `InitCode ""`
4. call `replaceCode` on the target contract with the constructor result

this change lets us change 1 to `InitCode constructorCode` and omitting step 3.