### PR TITLE
fix for big numbers

### DIFF
--- a/src/seth/libexec/seth/seth-calldata
+++ b/src/seth/libexec/seth/seth-calldata
@@ -14,7 +14,12 @@ if (process.argv.length >= 3 &&
     const funcs = new ethers.utils.Interface(["function " + sig.replace(')(', ') returns (')]).functions;
     const args = process.argv.slice(3).map(s => {
       try {
-        return JSON.parse(s)
+        const parsed = JSON.parse(s)
+        if (typeof(parsed) == "number") {
+          return s
+        } else {
+          return parsed
+        }
       }
       catch (e) {
         return s


### PR DESCRIPTION
javascript parses large integers to integers in scientific notation, losing precision. We want to keep ints as strings.

We should set up some proper tests for this repo before merging