### PR TITLE
backporting fix to ethsign from symbolic

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,8 +3,8 @@
 let
   nixpkgs = builtins.fetchGit {
     url = "https://github.com/nixos/nixpkgs";
-    ref = "release-19.03";
-    rev = "f1707d8875276cfa110139435a7e8998b4c2a4fd";
+    ref = "release-19.09";
+    rev = "54e89941c303687a6392a3264dbe1540fe3381d8";
   };
 in
   # Now return the Nixpkgs configured to use our overlay.

--- a/src/dapp/Makefile
+++ b/src/dapp/Makefile
@@ -16,6 +16,6 @@ test:
 	for x in libexec/*/*; do [[ -f $$x ]] && files+=($$x); done; \
 	! grep '^#!/bin/sh' "$${files[@]}"; \
 	grep '^#!/usr/bin/env bash' "$${files[@]}" | \
-	cut -d: -f1 | xargs shellcheck
+	cut -d: -f1 | xargs shellcheck --exclude=2001
 
 .PHONY: default dirs install link uninstall test

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -284,7 +284,8 @@ runFromVM oracle' vm = do
            }
     ui1 = updateUiVmState ui0 vm & set uiVmFirstState ui1
 
-  ui2 <- customMain mkVty Nothing (app opts) (ViewVm ui1)
+  v <- mkVty
+  ui2 <- customMain v mkVty Nothing (app opts) (ViewVm ui1)
   case ui2 of
     ViewVm ui -> return (view uiVm ui)
     _ -> error "internal error: customMain returned prematurely"
@@ -321,7 +322,8 @@ main opts root jsonFilePath = do
             , _testOpts = opts
             }
 
-        _ <- customMain mkVty Nothing (app opts) (ui :: UiState)
+        v <- mkVty
+        _ <- customMain v mkVty Nothing (app opts) (ui :: UiState)
         return ()
 
 -- ^ Specifies whether to do I/O blocking or VM halting while stepping.


### PR DESCRIPTION
Wholesale copy of default.nix and src/ethsign from the symbolic branch. 

Installed with following commands from a fresh clone after replacing default.nix and src/ethsign: 
```
git submodule init
git submodule update --recursive 
nix-env -i ethsign -f . 
```