### PR TITLE
travis: install cachix from upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ os:
   - linux
   - osx
 language: nix
+nix: 2.3.4
 sudo: required
 # workaround for a macOS specific issue with trusted users
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - echo "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= d121dybo9yhl5h.cloudfront.net-1:IOpHdUBT2b3fIRb/TBm+V8Y8eEj52fStcllzD6TFYyU=" | sudo tee -a /etc/nix/nix.conf
   - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
 install:
-  - nix-env -iA cachix -f .
+  - nix-env -iA cachix -f https://cachix.org/api/v1/install
   - cachix use dapp
 script:
   - |


### PR DESCRIPTION
So that our Haskell overrides don't interefere and cause an unnecessary
rebuild.