### PR TITLE
add cvc4 derivation and custom sbv_8_4

### DIFF
--- a/haskell.nix
+++ b/haskell.nix
@@ -13,9 +13,22 @@ in self-hs: super-hs:
       pkgs.haskell.lib.dontCheck
         (self-hs.callPackage x {});
     hevmBinPath = lib.makeBinPath (with pkgs; [bash coreutils git]);
+    sbv_8_4_prepatch = self-hs.callCabal2nix "sbv" (builtins.fetchGit {
+        url = "https://github.com/LeventErkok/sbv/";
+        rev = "b3facdfc959e0779fb8944743c0ec81e0d214ee3";
+    }) {inherit (pkgs) z3;};
+
   in {
     restless-git = dontCheck (import ./src/restless-git);
     wreq = pkgs.haskell.lib.doJailbreak super-hs.wreq;
+
+    # we use a pretty bleeding edge sbv version
+    sbv_8_4 = sbv_8_4_prepatch.overrideAttrs (attrs: {
+      postPatch = ''
+      sed -i -e 's|"z3"|"${pkgs.z3}/bin/z3"|' Data/SBV/Provers/Z3.hs
+      sed -i -e 's|"cvc4"|"${pkgs.cvc4}/bin/cvc4"|' Data/SBV/Provers/CVC4.hs'';
+    });
+
 
     # This package is somewhat unmaintained and doesn't compile with GHC 8.4,
     # so we have to use a GitHub fork that fixes it.

--- a/nix/cvc4.nix
+++ b/nix/cvc4.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, cmake, cln, gmp, git, swig, pkgconfig
+, readline, libantlr3c, boost, jdk, autoreconfHook
+, python3, antlr3_4
+}:
+
+stdenv.mkDerivation rec {
+  pname = "cvc4";
+  version = "1.8-prerelease";
+
+  src = fetchFromGitHub {
+    owner  = "cvc4";
+    repo   = "cvc4";
+    rev    = "fd60da4a22f02f6f5b82cef3585240c1b33595e9";
+    sha256 = "1bh0dvqskny3m95awlk237cdv0wds3qw1n89i3am1fqq0gs4ivyj";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake ];
+  buildInputs = [ gmp git python3.pkgs.toml cln readline swig libantlr3c antlr3_4 boost jdk python3 ];
+  configureFlags = [
+    "--enable-language-bindings=c,c++,java"
+    "--enable-gpl"
+    "--with-cln"
+    "--with-readline"
+    "--with-boost=${boost.dev}"
+  ];
+
+  prePatch = ''
+    patch -p1 -i ${./minisat-fenv.patch} -d src/prop/minisat
+    patch -p1 -i ${./minisat-fenv.patch} -d src/prop/bvminisat
+  '';
+
+  preConfigure = ''
+    patchShebangs ./src/
+  '';
+  cmakeFlags = ''
+  -DCMAKE_BUILD_TYPE=Production
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A high-performance theorem prover and SMT solver";
+    homepage    = http://cvc4.cs.stanford.edu/web/;
+    license     = licenses.gpl3;
+    platforms   = platforms.unix;
+    maintainers = with maintainers; [ vbgl thoughtpolice gebner ];
+  };
+}

--- a/nix/minisat-fenv.patch
+++ b/nix/minisat-fenv.patch
@@ -1,0 +1,65 @@
+From 7f1016ceab9b0f57a935bd51ca6df3d18439b472 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Tue, 17 Oct 2017 22:57:02 -0500
+Subject: [PATCH] use fenv instead of non-standard fpu_control
+
+---
+ core/Main.cc   | 8 ++++++--
+ simp/Main.cc   | 8 ++++++--
+ utils/System.h | 2 +-
+ 3 files changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/core/Main.cc b/core/Main.cc
+index 2b0d97b..8ad95fb 100644
+--- a/core/Main.cc
++++ b/core/Main.cc
+@@ -78,8 +78,12 @@ int main(int argc, char** argv)
+         // printf("This is MiniSat 2.0 beta\n");
+         
+ #if defined(__linux__)
+-        fpu_control_t oldcw, newcw;
+-        _FPU_GETCW(oldcw); newcw = (oldcw & ~_FPU_EXTENDED) | _FPU_DOUBLE; _FPU_SETCW(newcw);
++        fenv_t fenv;
++
++        fegetenv(&fenv);
++        fenv.__control_word &= ~0x300; /* _FPU_EXTENDED */
++        fenv.__control_word |= 0x200; /* _FPU_DOUBLE */
++        fesetenv(&fenv);
+         printf("WARNING: for repeatability, setting FPU to use double precision\n");
+ #endif
+         // Extra options:
+diff --git a/simp/Main.cc b/simp/Main.cc
+index 2804d7f..39bfb71 100644
+--- a/simp/Main.cc
++++ b/simp/Main.cc
+@@ -79,8 +79,12 @@ int main(int argc, char** argv)
+         // printf("This is MiniSat 2.0 beta\n");
+         
+ #if defined(__linux__)
+-        fpu_control_t oldcw, newcw;
+-        _FPU_GETCW(oldcw); newcw = (oldcw & ~_FPU_EXTENDED) | _FPU_DOUBLE; _FPU_SETCW(newcw);
++        fenv_t fenv;
++
++        fegetenv(&fenv);
++        fenv.__control_word &= ~0x300; /* _FPU_EXTENDED */
++        fenv.__control_word |= 0x200; /* _FPU_DOUBLE */
++        fesetenv(&fenv);
+         printf("WARNING: for repeatability, setting FPU to use double precision\n");
+ #endif
+         // Extra options:
+diff --git a/utils/System.h b/utils/System.h
+index 1758192..c0ad13a 100644
+--- a/utils/System.h
++++ b/utils/System.h
+@@ -22,7 +22,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
+ #define Minisat_System_h
+ 
+ #if defined(__linux__)
+-#include <fpu_control.h>
++#include <fenv.h>
+ #endif
+ 
+ #include "mtl/IntTypes.h"
+-- 
+2.14.2
+

--- a/overlay.nix
+++ b/overlay.nix
@@ -120,6 +120,8 @@ in rec {
 
   libff = self.callPackage (import ./nix/libff.nix) {};
 
+  cvc4 = self.callPackage (import ./nix/cvc4.nix) {};
+
   jays = (
     self.pkgs.haskell.lib.justStaticExecutables
       (self.haskellPackages.callPackage (import ./src/jays) {})


### PR DESCRIPTION
factored out from #353, as it keeps timing out. Could also be useful on its own if someone is curious to try cvc4 out. It's pretty good on large bitvectors. Not suitable for nixpkgs upstream as it is a nightly version