### PR TITLE
Run `dapp-test` through nix-shell in ci

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "submodules/terra"]
 	path = submodules/terra
 	url = https://github.com/makerdao/terra
-[submodule "src/dapp-tests/lib/ds-test"]
-	path = src/dapp-tests/lib/ds-test
-	url = https://github.com/dapphub/ds-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
     [[ "$TRAVIS_OS_NAME" == "osx" ]] && PLATFORM=darwin || PLATFORM=linux
 
     nix-build -j auto release.nix -A dapphub.$PLATFORM.stable &&
+    cd src/dapp-test && nix-shell --command 'make' --pure && cd ../..
 
     # this is here to let cachix finish pushing the last artifact before the script is killed
     sleep 10

--- a/overlay.nix
+++ b/overlay.nix
@@ -46,24 +46,6 @@ in rec {
     ] dappsys);
   };
 
-  # Here we can make e.g. integration tests for Dappsys,
-  # or tests that verify Hevm correctness, etc.
-  dapp-tests = stdenv.mkDerivation {
-    name = "dapp-tests";
-    src = ./src/dapp-tests;
-    installPhase = "true";
-    buildInputs = [self.dapp];
-    buildPhase = ''
-      set -e
-      export DAPPSYS_PATH=${dappsys-merged}/dapp
-      ls "$DAPPSYS_PATH"
-      echo "$PATH"
-      patchShebangs .
-      make
-      mkdir "$out"
-    '';
-  };
-
   dapps = {
     maker-otc = import (self.pkgs.fetchFromGitHub {
       owner = "makerdao";

--- a/src/dapp-tests/Makefile
+++ b/src/dapp-tests/Makefile
@@ -1,3 +1,7 @@
-all:; ./run-tests
-
+all:;
+	dapp install ds-test
+	./run-tests
+	dapp uninstall ds-test
+	git reset HEAD^^
+	rm -rf lib
 .PHONY: all

--- a/src/dapp-tests/shell.nix
+++ b/src/dapp-tests/shell.nix
@@ -1,0 +1,8 @@
+let dapptools = import ../../. {};
+in dapptools.mkShell {
+  buildInputs = with dapptools; [
+  dapp
+  seth
+  git
+  ];
+}

--- a/src/seth/default.nix
+++ b/src/seth/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, glibcLocales
+{ lib, stdenv, fetchFromGitHub, makeWrapper, glibcLocales, jq
 , bc, coreutils, curl, ethsign, git, gnused, jshon, nodejs, perl, hevm, shellcheck }:
 
 stdenv.mkDerivation rec {
@@ -15,8 +15,7 @@ stdenv.mkDerivation rec {
   postInstall =
     let
       path = lib.makeBinPath [
-        bc coreutils curl ethsign git gnused jshon nodejs perl
-        bc coreutils curl ethsign git gnused hevm jshon nodejs perl
+        bc coreutils curl ethsign git gnused hevm jshon nodejs perl jq
       ];
     in
       ''


### PR DESCRIPTION
Ensures `dapp-tests` are run through travis, removes the ds-test submoule which should set the stage for #377 