### PR TITLE
src/seth/default.nix: add jq dependency to path, fix merge artifact

### DIFF
--- a/src/seth/default.nix
+++ b/src/seth/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper, glibcLocales
-, bc, coreutils, curl, ethsign, git, gnused, jshon, nodejs, perl, hevm, shellcheck }:
+, bc, coreutils, curl, ethsign, git, gnused, jq, jshon, nodejs, perl, hevm, shellcheck }:
 
 stdenv.mkDerivation rec {
   name = "seth-${version}";
@@ -15,8 +15,7 @@ stdenv.mkDerivation rec {
   postInstall =
     let
       path = lib.makeBinPath [
-        bc coreutils curl ethsign git gnused jshon nodejs perl
-        bc coreutils curl ethsign git gnused hevm jshon nodejs perl
+        bc coreutils curl ethsign git gnused hevm jq jshon nodejs perl
       ];
     in
       ''


### PR DESCRIPTION
Currently `seth-calldata` is broken because of missing `jq`:
```
$ seth calldata "foo()"
/nix/store/ws5xsfv3p64000r0pjcv1fhkp5p7jagw-seth-0.9.0/libexec/seth/seth-calldata: line 14: jq: command not found
```

There is also some weird mergin conflict artifact in the dependencies, fixed here.