### PR TITLE
hevm: Remove `ExecMode`, always execute as blockchaintest

### DIFF
--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.39 - unreleased
  - Exposes abi encoding to cli
  - Added cheat code `hevm.store(address a, bytes32 location, bytes32 value)`
+ - Removes `ExecMode`, always running as `ExecuteAsBlockchainTest`. This means that `hevm exec` now finalizes transactions as well.
+ - `--code` is now entirely optional. Not supplying it returns an empty contract, or whatever is stored in `--state`.
 
 ## 0.38 - 2020-04-23
  - Exposes metadata stripping of bytecode to the cli: `hevm strip-metadata --code X`. [357](https://github.com/dapphub/dapptools/pull/357).

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -6,7 +6,6 @@ import EVM.Dapp
 import EVM.Solidity
 import EVM.UnitTest
 
-import qualified EVM
 import qualified EVM.Fetch
 import qualified EVM.TTY
 import qualified EVM.Emacs
@@ -63,12 +62,12 @@ ghciTest root path state =
 
 runBCTest :: (String, VMTest.Case) -> IO Bool
 runBCTest (name, x) = do
-  let vm0 = VMTest.vmForCase EVM.ExecuteAsBlockchainTest x
+  let vm0 = VMTest.vmForCase x
   putStr (name ++ " ")
   result <-
     evaluate $
       execState (VMTest.interpret EVM.Stepper.execFully) vm0
-  ok <- VMTest.checkExpectation False EVM.ExecuteAsBlockchainTest x result
+  ok <- VMTest.checkExpectation False x result
   putStrLn (if ok then "ok" else "")
   return ok
 


### PR DESCRIPTION
This makes `hevm exec` (and other commands) finalize transactions, which ensures that bytecode is replaced at creations, coinbase is paid and so on. 

`VMTest` cli endpoint is removed. I do not believe they have been run in quite some time, and what's being tested in VMTests is a proper subset of what's being done in `Blockchaintests` anyway.

