### PR TITLE
dapp: 0.28.0

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -105,7 +105,7 @@ in rec {
         fetchSolcVersions { owner = "NixOS";   attr = super.system; }
         //
         fetchSolcVersions { owner = "dapphub"; attr = "unreleased"; };
-  solc = solc-versions.solc_0_5_15;
+  solc = solc-versions.solc_0_6_7;
 
   hevm = self.pkgs.haskell.lib.justStaticExecutables self.haskellPackages.hevm;
 

--- a/src/dapp-tests/src/constantinople.sol
+++ b/src/dapp-tests/src/constantinople.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity ^0.6.7;
 
 import "ds-test/test.sol";
 
@@ -102,7 +102,7 @@ contract ConstantinopleTests is DSTest {
           let top := mload(0x40)
           mstore(top, sload(deadcode_slot))
           let inithash := keccak256(top, 13)
-          mstore(sub(top, 11), address)
+          mstore(sub(top, 11), address())
           mstore8(top, 0xff)
           mstore(add(top, 21), salt)
           mstore(add(top, 53), inithash)

--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.28.0] - 2020-07-13
 ### Added
 - Support for solc 0.6.7
+
+### Changed
+- Default to solc 0.6.7
 
 ### Removed
 - Support for git submodules (setzer, dai-cli, chief, terra)

--- a/src/dapp/default.nix
+++ b/src/dapp/default.nix
@@ -4,7 +4,7 @@
 
 stdenv.mkDerivation rec {
   name = "dapp-${version}";
-  version = "0.27.0";
+  version = "0.28.0";
   src = ./.;
 
   nativeBuildInputs = [makeWrapper shellcheck coreutils nodejs];

--- a/src/dapp/libexec/dapp/dapp---version
+++ b/src/dapp/libexec/dapp/dapp---version
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-echo dapp 0.27.0
+echo dapp 0.28.0
 solc --version
 echo "hevm $(hevm version)"

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -340,11 +340,11 @@ toCode = fst . BS16.decode . encodeUtf8
 solidity' :: Text -> IO (Text, Text)
 solidity' src = withSystemTempFile "hevm.sol" $ \path handle -> do
   hClose handle
-  writeFile path ("pragma solidity ^0.5.2;\n" <> src)
+  writeFile path ("pragma solidity ^0.6.7;\n" <> src)
   x <- pack <$>
     readProcess
       "solc"
-      ["--combined-json=bin-runtime,bin,srcmap,srcmap-runtime,abi,ast", path]
+      ["--combined-json=bin-runtime,bin,srcmap,srcmap-runtime,abi,ast,storage-layout", path]
       ""
   return (x, pack path)
 


### PR DESCRIPTION
Updates default solc to 0.6.7.

Actually, I want this to see if stuff like [this](https://github.com/dapphub/dapp-tools/runs/849891626?check_suite_focus=true) is a fluke, due to missing caches.