### PR TITLE
add solc 0.4.18

### DIFF
--- a/nix/solc-versions.nix
+++ b/nix/solc-versions.nix
@@ -40,6 +40,7 @@ rec {
 
   # these versions have not been upstreamed on NixOS/nixpkgs yet, and come from our fork at dapptools/nixpkgs
   unreleased = {
+    solc_0_4_18 = { rev = "f2e0cb5d72b70f3a874b133332fc92e7c170c710"; sha256 = "09f3mpa1f9gldxfrc96b2pqhrmq4disbi5bxqgmr4ag0mwn7qrnj"; };
     solc_0_5_16 = { rev = "725f92e016497dc351f84ff3d2c0c0538676f287"; sha256 = "1qwh0246piiwxxd80dzhya6x1fd2w2kj2rf80y83qa2v03zczqd1"; };
     solc_0_6_0  = { rev = "2342685388c0bad7163483c0b96c64f2dae817a3"; sha256 = "0ahqhw47y9xd3gwcxiazxj5ijiahgb4b69bvxja227rfpi9yvx60"; };
     solc_0_6_6  = { rev = "76d3d5826d9bff8b3952979514e0bc670bfbd8be"; sha256 = "0h3x3ldbv64li0aqajf2660gvzabgkkcjbbnq96l30llmxm5nrid"; };


### PR DESCRIPTION
Adding old version of solc not present in nixpkgs, as it is used by USDT.