### PR TITLE
seth: set DAPPTOOLS in default.nix

### DIFF
--- a/src/seth/default.nix
+++ b/src/seth/default.nix
@@ -1,5 +1,7 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper, glibcLocales, solc, nix
-, bc, coreutils, curl, ethsign, git, gnused, jq, jshon, nodejs, perl, hevm, shellcheck }:
+, bc, coreutils, curl, ethsign, git, gnused, jq, jshon, nodejs, perl
+,  hevm, shellcheck, dapptoolsSrc }:
+
 stdenv.mkDerivation rec {
   name = "seth-${version}";
   version = "0.9.0";
@@ -20,6 +22,7 @@ stdenv.mkDerivation rec {
       ''
         wrapProgram "$out/bin/seth" \
           --prefix PATH : ${path} \
+          --set DAPPTOOLS ${dapptoolsSrc} \
         ${lib.optionalString (glibcLocales != null) ''
           --set LOCALE_ARCHIVE ${glibcLocales}/lib/locale/locale-archive
       ''}

--- a/src/seth/libexec/seth/seth---nix-run
+++ b/src/seth/libexec/seth/seth---nix-run
@@ -15,6 +15,5 @@ have() { command -v "$1" >/dev/null; }
 }
 
 expr="$1"; shift
-export DAPPTOOLS=${DAPPTOOLS-~/.dapp/dapptools} # TODO: fix purity
 
 nix run "(with import $DAPPTOOLS {}; $expr)" -c "$@"


### PR DESCRIPTION
Turns out `seth` also depends on `DAPPTOOLS`....