### PR TITLE
verify-contract working when constrcutor args are absent

### DIFF
--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -31,9 +31,12 @@ esac
 path=${1?contractname}
 name=${path#*:}
 address=${2?contractaddress}
-constructorArguments=$(seth calldata "$4" "${@:5}")
-constructorArguments=${constructorArguments#0x}
-constructorArguments=${constructorArguments:8}
+
+if [[ $4 ]]; then
+    constructorArguments=$(seth calldata "$4" "${@:5}")
+    constructorArguments=${constructorArguments#0x}
+    constructorArguments=${constructorArguments:8}
+fi
 
 meta=$(<"$DAPP_JSON" jshon -e contracts -e "$path" -e metadata -u)
 version=$(jshon <<<"$meta" -e compiler -e version -u)
@@ -93,7 +96,8 @@ while [ $count -lt 5 ]; do
   response=$(curl -fsS "$ETHERSCAN_API_URL" -d "$query" \
   --data-urlencode "compilerversion=$version" \
   --data-urlencode "sourceCode@"<(echo "$source") \
-  --data-urlencode "constructorArguements=$constructorArguments" -X POST)
+  --data-urlencode "$constructorArguments && constructorArguements=$constructorArguments" \
+  -X POST)
 
   status=$(jshon <<<"$response" -e status -u)
   guid=$(jshon <<<"$response" -e result -u)

--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -95,7 +95,8 @@ while [ $count -lt 5 ]; do
   response=$(curl -fsS "$ETHERSCAN_API_URL" -d "$query" \
   --data-urlencode "compilerversion=$version" \
   --data-urlencode "sourceCode@"<(echo "$source") \
-  --data-urlencode "$constructorArguments && constructorArguements=$constructorArguments" \
+  # NOTE: the Arguements typo is in etherscan's API
+  --data-urlencode "constructorArguements=$constructorArguments" \
   -X POST)
 
   status=$(jshon <<<"$response" -e status -u)

--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -96,9 +96,8 @@ while [ $count -lt 5 ]; do
   response=$(curl -fsS "$ETHERSCAN_API_URL" -d "$query" \
   --data-urlencode "compilerversion=$version" \
   --data-urlencode "sourceCode@"<(echo "$source") \
+  --data-urlencode "constructorArguements=$constructorArguments" -X POST)
   # NOTE: the Arguements typo is in etherscan's API
-  --data-urlencode "constructorArguements=$constructorArguments" \
-  -X POST)
 
   status=$(jshon <<<"$response" -e status -u)
   guid=$(jshon <<<"$response" -e result -u)

--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 [[ $ETHERSCAN_API_KEY ]] || {
   cat >&2 <<.

--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -ex
 
 [[ $ETHERSCAN_API_KEY ]] || {
   cat >&2 <<.
@@ -49,7 +48,7 @@ version="v${version}"
 
 # Get the list of supported solc versions and compare
 # Etherscan uses the js solc, which is not guaranteed to match the C distribution signature
-set +x
+
 version_list=$(curl -fsS "https://raw.githubusercontent.com/ethereum/solc-bin/gh-pages/bin/list.txt")
 # There have been a couple of instances where the solc js release used by
 #   Etherscan does not match the tag of the C distributions.
@@ -63,7 +62,7 @@ if [[ $version_list != *"$version"* ]]; then
     echo "Attempting ${version}"
   fi
 fi
-set -x
+
 
 if [[ "$optimized" = "true" ]]; then
   optimized=1


### PR DESCRIPTION
I am a noob at bash, so maybe there is a superior way to do this

the problem appeared to be that the argument being passed to `seth calldata` was in fact an empty string, or something along those lines, so checking for the existence of the variable `$4` and opting out of that branch if it is absent allows the script to run as planned