### PR TITLE
Max iterations in `--debug`

### DIFF
--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Changed
 
 - z3 updated to 4.8.7
+- default `--smttimeout` changed from unlimited to 20 seconds
+- `hevm symbolic --debug` now respects `--max-iterations`
+
 
 ### Added
 

--- a/src/hevm/README.md
+++ b/src/hevm/README.md
@@ -190,7 +190,7 @@ Usage: hevm equivalence --code-a TEXT --code-b TEXT [--sig TEXT]
 Symbolically execute both the code given in `--code-a` and `--code-b` and try to prove equivalence between their outputs and storages.
 
 If `--sig` is given, calldata is assumed to take the form of the function given.
-If left out, calldata is a fully abstract buffer of at most 1024 bytes.
+If left out, calldata is a fully abstract buffer of at most 256 bytes.
 
 ### `hevm dapp-test`
 

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -695,9 +695,9 @@ symvmFromCommand cmd = do
   (calldata', cdlen, pathCond) <- case (calldata cmd, sig cmd) of
     -- fully abstract calldata (up to 1024 bytes)
     (Nothing, Nothing) -> do
-      cd <- sbytes1024
+      cd <- sbytes256
       len <- freshVar_
-      return (SymbolicBuffer cd, len, len .<= 1024)
+      return (SymbolicBuffer cd, len, len .<= 256)
     -- fully concrete calldata
     (Just c, Nothing) ->
       let cd = ConcreteBuffer $ decipher c

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -695,7 +695,7 @@ symvmFromCommand cmd = do
   (calldata', cdlen, pathCond) <- case (calldata cmd, sig cmd) of
     -- fully abstract calldata (up to 1024 bytes)
     (Nothing, Nothing) -> do
-      cd <- sbytes256
+      cd <- sbytes1024
       len <- freshVar_
       return (SymbolicBuffer cd, len, len .<= 1024)
     -- fully concrete calldata

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -440,7 +440,7 @@ assert cmd = do
     runSMTWithTimeOut (solver cmd) (smttimeout cmd) $ query $ do
       preState <- symvmFromCommand cmd
       smtState <- queryState
-      io $ void $ EVM.TTY.runFromVM srcinfo (EVM.Fetch.oracle smtState rpcinfo) preState
+      io $ void $ EVM.TTY.runFromVM (maxIterations cmd) srcinfo (EVM.Fetch.oracle smtState rpcinfo) preState
 
   else
     runSMTWithTimeOut (solver cmd) (smttimeout cmd) $ query $ do
@@ -460,7 +460,7 @@ assert cmd = do
               <> show (length vmErrs)
               <> " branch(es) errored while exploring:"
             print vmErrs
-          -- When `--get-model` is passed, we print example vm info for each path
+          -- When `--get-models` is passed, we print example vm info for each path
           when (getModels cmd) $
             forM_ (zip [1..] posts) $ \(i, postVM) -> do
               resetAssertions
@@ -468,8 +468,10 @@ assert cmd = do
               io $ putStrLn $
                 "-- Branch (" <> show i <> "/" <> show (length posts) <> ") --"
               checkSat >>= \case
-                Unk -> io $ putStrLn "Timed out"
-                Unsat -> io $ putStrLn "Inconsistent path conditions: dead path"
+                Unk -> io $ do putStrLn "Timed out"
+                               print $ view EVM.result postVM
+                Unsat -> io $ do putStrLn "Inconsistent path conditions: dead path"
+                                 print $ view EVM.result postVM
                 Sat -> do
                   showCounterexample pre maybesig
                   case view EVM.result postVM of
@@ -566,7 +568,7 @@ launchExec cmd = do
             Nothing -> pure ()
             Just path ->
               Git.saveFacts (Git.RepoAt path) (Facts.vmFacts vm')
-    Debug -> void $ EVM.TTY.runFromVM srcinfo fetcher vm1
+    Debug -> void $ EVM.TTY.runFromVM Nothing srcinfo fetcher vm1
    where fetcher = maybe EVM.Fetch.zero (EVM.Fetch.http block') (rpc cmd)
          block'  = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber (block cmd)
 
@@ -811,7 +813,7 @@ runVMTest diffmode mode timelimit (name, x) = do
           Timeout.timeout (1e6 * (fromMaybe 10 timelimit)) $
             execStateT (EVM.Stepper.interpret EVM.Fetch.zero . void $ EVM.Stepper.execFully) vm0
         Debug ->
-          Just <$> EVM.TTY.runFromVM Nothing EVM.Fetch.zero vm0
+          Just <$> EVM.TTY.runFromVM Nothing Nothing EVM.Fetch.zero vm0
     waitCatch action
   case result of
     Right (Just vm1) -> do

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -2006,12 +2006,10 @@ finishFrame how = do
   case view frames oldVm of
     -- Is the current frame the only one?
     [] -> do
-      assign result . Just $
-        case how of
-          FrameReturned output -> VMSuccess output
-          FrameReverted (ConcreteBuffer output) -> VMFailure (Revert output)
-          FrameReverted (SymbolicBuffer output) -> VMFailure (Revert (forceLitBytes output))
-          FrameErrored e       -> VMFailure e
+      case how of
+          FrameReturned output -> assign result . Just $ VMSuccess output
+          FrameReverted buffer -> forceConcreteBuffer buffer $ \out -> assign result . Just $ VMFailure (Revert out)
+          FrameErrored e       -> assign result . Just $ VMFailure e
       finalize
 
     -- Are there some remaining frames?

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -962,7 +962,7 @@ exec1 = do
                   in case maybeLitWord y of
                       Just y' -> jump y'
                       -- if the jump condition is symbolic, an smt query has to be made.
-                      Nothing -> askSMT self (the state pc) y jump
+                      Nothing -> askSMT (self, the state pc) y jump
             _ -> underrun
 
         -- op: PC
@@ -1471,15 +1471,18 @@ pushTo f x = f %= (x :)
 pushToSequence :: MonadState s m => ASetter s s (Seq a) (Seq a) -> a -> m ()
 pushToSequence f x = f %= (Seq.|> x)
 
-askSMT :: Addr -> Int -> SymWord -> (Word -> EVM ()) -> EVM ()
-askSMT addr pcval jumpcondition continue = do
+getCodeLocation :: VM -> CodeLocation
+getCodeLocation vm = (view (state . contract) vm, view (state . pc) vm)
+
+askSMT :: CodeLocation -> SymWord -> (Word -> EVM ()) -> EVM ()
+askSMT codeloc jumpcondition continue = do
   -- We keep track of how many times we have come across this particular
   -- (contract, pc) combination in the `iteration` mapping.
-  iteration <- use (iterations . at (addr, pcval) . non 0)
+  iteration <- use (iterations . at codeloc . non 0)
 
   -- If we are backstepping, the result of this query should be cached
   -- already. So we first check the cache to see if the result is known
-  use (cache . path . at ((addr, pcval), iteration)) >>= \case
+  use (cache . path . at (codeloc, iteration)) >>= \case
      -- If the query has been done already, select path or select the only available
      Just w -> choosePath w
      -- If this is a new query, run the query, cache the result
@@ -1490,18 +1493,18 @@ askSMT addr pcval jumpcondition continue = do
 
    where -- Only one path is possible
          choosePath (Known w) = do assign result Nothing
-                                   iteration <- use (iterations . at (addr, pcval) . non 0)
-                                   assign (cache . path . at ((addr, pcval), iteration)) (Just (Known w))
-                                   assign (iterations . at (addr, pcval)) (Just (iteration + 1))
+                                   iteration <- use (iterations . at codeloc . non 0)
+                                   assign (cache . path . at (codeloc, iteration)) (Just (Known w))
+                                   assign (iterations . at codeloc) (Just (iteration + 1))
                                    continue w
          -- Both paths are possible; we ask for more input
          choosePath Unknown = assign result . Just . VMFailure . Choose $ PleaseChoosePath
            (\selected -> do
                pathConditions <>= [litWord selected .== jumpcondition]
-               iteration <- use (iterations . at (addr, pcval) . non 0)
-               assign (cache . path . at ((addr, pcval), iteration)) (Just (Known selected))
+               iteration <- use (iterations . at codeloc . non 0)
+               assign (cache . path . at (codeloc, iteration)) (Just (Known selected))
                assign result Nothing
-               assign (iterations . at (addr, pcval)) (Just (iteration + 1))
+               assign (iterations . at codeloc) (Just (iteration + 1))
                continue selected)
 
 

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -45,6 +45,7 @@ ghciTest root path state =
       opts = UnitTestOptions
         { oracle = EVM.Fetch.zero
         , verbose = Nothing
+        , maxIter = Nothing
         , match = ""
         , fuzzRuns = 100
         , replay = Nothing

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -529,6 +529,7 @@ defaultUnitTestOptions = do
   pure UnitTestOptions
     { oracle            = Fetch.zero
     , verbose           = Nothing
+    , maxIter           = Nothing
     , match             = ""
     , fuzzRuns          = 100
     , replay            = Nothing

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -264,7 +264,7 @@ equivalenceCheck bytecodeA bytecodeB maxiter signature' = do
                              differingResults = case (aResult, bResult) of
                                (Just (VMSuccess aOut), Just (VMSuccess bOut)) -> aOut ./= bOut .|| aStorage ./= bStorage .|| fromBool (aSelf /= bSelf)
                                (Just (VMFailure UnexpectedSymbolicArg), _) -> error $ "Unexpected symbolic argument at opcode: " <> maybe "??" show (vmOp a) <> ". Not supported (yet!)"
-                               (_, Just (VMFailure UnexpectedSymbolicArg)) -> error $ "Unexpected symbolic argument at opcode: " <> maybe "??" show (vmOp a) <> ". Not supported (yet!)"
+                               (_, Just (VMFailure UnexpectedSymbolicArg)) -> error $ "Unexpected symbolic argument at opcode: " <> maybe "??" show (vmOp b) <> ". Not supported (yet!)"
                                (Just (VMFailure _), Just (VMFailure _)) -> sFalse
                                (Just _, Just _) -> sTrue
                                _ -> error "Internal error during symbolic execution (should not be possible)"

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -128,9 +128,9 @@ loadSymVM x initStore addr callvalue' calldata' =
     }) & set (env . contracts . at (createAddress ethrunAddress 1))
              (Just (contractWithStore x initStore))
 
--- Interpreter which explores all paths at
--- branching points.
--- returns a list of possible final evm states
+-- | Interpreter which explores all paths at
+-- | branching points.
+-- | returns a list of possible final evm states
 interpret
   :: Fetch.Fetcher
   -> Maybe Integer --max iterations
@@ -157,11 +157,10 @@ interpret fetcher maxIter =
           do vm <- get
              case maxIter of
                Just maxiter ->
-                 let pc' = view (state . pc) vm
-                     addr = view (state . contract) vm
-                     iters = view (iterations . at (addr, pc') . non 0) vm
+                 let codelocation = getCodeLocation vm
+                     iters = view (iterations . at codelocation . non 0) vm
                  in if num maxiter <= iters then
-                      vm ^?! (cache . path . ix ((addr, pc'), iters - 1)) & \case
+                      vm ^?! (cache . path . ix (codelocation, iters - 1)) & \case
                         -- When we have reached maxIterations, we take the choice that will hopefully
                         -- lead us out of here.
                         Known 0 -> State.state (runState (continue 1)) >> interpret fetcher maxIter (k ())

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -231,8 +231,8 @@ interpret mode =
                 case view (cache . path . at (codelocation, iters - 1)) vm of
                   -- When we have reached maxIterations, we take the choice that will hopefully
                   -- lead us out of here.
-                  Just (Known 0) -> pure . Stepped $ Stepper.evm (cont 1) >>= k
-                  Just (Known 1) -> pure . Stepped $ Stepper.evm (cont 0) >>= k
+                  Just (Known 0) -> interpret mode (Stepper.evm (cont 1) >>= k)
+                  Just (Known 1) -> interpret mode (Stepper.evm (cont 1) >>= k)
                   n -> error ("I don't see how this could have happened: " <> show n)
               else
                 pure $ Stepped (k ())

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -144,8 +144,7 @@ interpret mode =
       :: Operational.ProgramView Stepper.Action a
       -> State UiVmState (StepOutcome a)
 
-    eval (Operational.Return x) = do
-      traceM $ "returning"
+    eval (Operational.Return x) =
       pure (Returned x)
 
     eval (action Operational.:>>= k) =

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -396,6 +396,7 @@ takeStep ui policy mode =
   where
     vmResult Nothing = False
     vmResult (Just (VMFailure (Query _))) = False
+    vmResult (Just (VMFailure (Choose _))) = False
     vmResult (Just _) = True
     m = interpret mode (view uiVmNextStep ui)
     nxt = runState (m <* modify renderVm) ui

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -61,6 +61,7 @@ data UnitTestOptions = UnitTestOptions
   {
     oracle     :: Query -> IO (EVM ())
   , verbose    :: Maybe Int
+  , maxIter    :: Maybe Integer
   , match      :: Text
   , fuzzRuns   :: Int
   , replay     :: Maybe (Text, BSLazy.ByteString)


### PR DESCRIPTION
Makes `hevm symbolic --debug` respect `--max-iterations` and fixes two issues discussed in #457 