### PR TITLE
Integrate solc test suite for hevm-symbolic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           name: dapp
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-      - name: run integration tests
+      - name: run dapp tests
         run: nix-env -iA nixpkgs.bashInteractive && nix-shell --pure src/dapp-tests/shell.nix --command 'make --directory src/dapp-tests'
+      - name: run hevm symbolic tests
+        run: nix-build -A hevm-tests
       - run: nix-build release.nix -A dapphub.${{ matrix.os_attr }}.stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,5 +31,5 @@ jobs:
       - name: run dapp tests
         run: nix-env -iA nixpkgs.bashInteractive && nix-shell --pure src/dapp-tests/shell.nix --command 'make --directory src/dapp-tests'
       - name: run hevm symbolic tests
-        run: nix-build -A hevm-tests
+        run: nix-build -j 0 -A hevm-tests
       - run: nix-build release.nix -A dapphub.${{ matrix.os_attr }}.stable

--- a/nix/hevm-tests/default.nix
+++ b/nix/hevm-tests/default.nix
@@ -1,5 +1,5 @@
-{ pkgs, lib }:
-rec {
+{ pkgs }:
+let
   solc = "${pkgs.solc-versions.solc_0_6_7}/bin/solc";
   solidity = pkgs.fetchFromGitHub {
     owner = "ethereum";
@@ -7,7 +7,13 @@ rec {
     rev = "b8d736ae0c506b1b3cf5d2456af67e8dc2c0ca8e"; # v0.6.7
     sha256 = "1zqfcfgy70hmckxb3l59rabdpzj7gf1vzg6kkw4xz0c6lzy7mrpz";
   };
+  runWithSolver = file : solver : (import file) { inherit pkgs solc solidity solver; };
+in
+{
+  yulEquivalence-z3 = runWithSolver ./yul-equivalence.nix "z3";
+  yulEquivalence-cvc4 = runWithSolver ./yul-equivalence.nix "cvc4";
 
-  yulEquivalence = (import ./yul-equivalence.nix) { inherit pkgs solc solidity; };
-  smtChecker = (import ./smt-checker.nix) { inherit pkgs solc solidity; };
+  # z3 takes 3hrs to run these tests on a fast machine, and even then ~180 timeout
+  #smtChecker-z3 = runWithSolver ./smt-checker.nix "z3";
+  smtChecker-cvc4 = runWithSolver ./smt-checker.nix "cvc4";
 }

--- a/nix/hevm-tests/default.nix
+++ b/nix/hevm-tests/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, lib }:
+rec {
+  solidity = pkgs.fetchFromGitHub {
+    owner = "ethereum";
+    repo = "solidity";
+    rev = "b8d736ae0c506b1b3cf5d2456af67e8dc2c0ca8e"; # v0.6.7
+    sha256 = "1zqfcfgy70hmckxb3l59rabdpzj7gf1vzg6kkw4xz0c6lzy7mrpz";
+  };
+
+  yulEquivalence = (import ./yul-equivalence.nix) { inherit pkgs lib solidity; };
+}

--- a/nix/hevm-tests/default.nix
+++ b/nix/hevm-tests/default.nix
@@ -1,5 +1,6 @@
 { pkgs, lib }:
 rec {
+  solc = "${pkgs.solc-versions.solc_0_6_7}/bin/solc";
   solidity = pkgs.fetchFromGitHub {
     owner = "ethereum";
     repo = "solidity";
@@ -7,5 +8,6 @@ rec {
     sha256 = "1zqfcfgy70hmckxb3l59rabdpzj7gf1vzg6kkw4xz0c6lzy7mrpz";
   };
 
-  yulEquivalence = (import ./yul-equivalence.nix) { inherit pkgs lib solidity; };
+  yulEquivalence = (import ./yul-equivalence.nix) { inherit pkgs solc solidity; };
+  smtChecker = (import ./smt-checker.nix) { inherit pkgs solc solidity; };
 }

--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -398,9 +398,9 @@ pkgs.runCommand "smtCheckerTests-${solver}" {} ''
      [ $smt_reports != 0 ]  || \
      [ $hevm_reports != 0 ]
   then
-    exit 0
-  else
     exit 1
+  else
+    exit 0
   fi
 ''
 

--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -186,7 +186,7 @@ let
   # --- test scripts ---
 
   strings = {
-    exeucting = "Executing test:";
+    executing = "Executing test:";
     pass = "PASS: hevm and SMTChecker agree!";
     ignore = "SKIP: test ignored";
     smtReports = "FAIL: SMTChecker reports assertion violation whereas HEVM reports safe.";
@@ -281,7 +281,7 @@ let
     testName=$(${testName} $1)
 
     ${divider}
-    ${echo} "${strings.exeucting} $(${testName} $1)"
+    ${echo} "${strings.executing} $(${testName} $1)"
 
     ignoredTests=(${toString ignored})
     if [[ " ''${ignoredTests[@]} " =~ " ''${testName} " ]]; then
@@ -353,7 +353,7 @@ pkgs.runCommand "smtCheckerTests-${solver}" {} ''
   time ${runAllTests} | ${tee} $results
 
   set +e
-  total="$(${grep} -c '${strings.exeucting}' $results)"
+  total="$(${grep} -c '${strings.executing}' $results)"
   passed="$(${grep} -c '${strings.pass}' $results)"
   ignored="$(${grep} -c '${strings.ignore}' $results)"
   smt_failed="$(${grep} -c '${strings.smtCheckerFailed}' $results)"

--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -45,6 +45,9 @@ let
     "functions/constructor_simple.sol"
     "functions/constructor_state_value_inherited.sol"
     "functions/constructor_state_value.sol"
+    "inheritance/constructor_hierarchy_mixed_chain_with_params.sol"
+    "inheritance/constructor_state_variable_init_chain_run_all.sol"
+    "inheritance/constructor_state_variable_init_chain_run_all_2.sol"
 
     # unbounded looping
 
@@ -55,6 +58,29 @@ let
     "functions/functions_trivial_condition_for_only_call.sol"
     "functions/functions_trivial_condition_while.sol"
     "functions/functions_trivial_condition_while_only_call.sol"
+    "invariants/loop_basic.sol"
+    "invariants/loop_basic_for.sol"
+    "loops/do_while_1_fail.sol"
+    "loops/do_while_continue.sol"
+    "loops/for_loop_1.sol"
+    "loops/for_loop_2.sol"
+    "loops/for_loop_3.sol"
+    "loops/for_loop_5.sol"
+    "loops/for_loop_6.sol"
+    "loops/for_loop_trivial_condition_1.sol"
+    "loops/for_loop_trivial_condition_2.sol"
+    "loops/for_loop_trivial_condition_3.sol"
+    "loops/for_loop_array_assignment_storage_memory.sol"
+    "loops/for_loop_array_assignment_storage_storage.sol"
+    "loops/while_1_infinite.sol"
+    "loops/while_2_fail.sol"
+    "loops/while_1.sol"
+    "loops/while_loop_simple_2.sol"
+    "loops/while_loop_simple_3.sol"
+    "loops/while_loop_simple_4.sol"
+    "loops/while_loop_simple_5.sol"
+    "loops/do_while_1_false_positives.sol"
+    "loops/while_loop_array_assignment_storage_storage.sol"
 
     # --- unsupported opcodes ---
 
@@ -66,10 +92,25 @@ let
     "functions/functions_external_3.sol"
     "functions/functions_external_4.sol"
 
+    # OpJump
+
+    "complex/slither/external_function.sol"
+
+    # OpCalldatacopy
+
+    "loops/for_loop_array_assignment_memory_memory.sol"
+    "loops/for_loop_array_assignment_memory_storage.sol"
+    "loops/while_loop_array_assignment_memory_memory.sol"
+    "loops/while_loop_array_assignment_memory_storage.sol"
+
     # --- contract level knowledge required ---
 
     "functions/internal_call_with_assertion_1.sol"
     "functions/internal_multiple_calls_with_assertion_1.sol"
+    "inheritance/constructor_state_variable_init_chain_run_all.sol"
+    "inheritance/implicit_only_constructor_hierarchy.sol"
+    "inheritance/implicit_constructor_hierarchy.sol"
+    "invariants/state_machine_1.sol"
 
   ];
 
@@ -237,10 +278,11 @@ pkgs.runCommand "smtCheckerTests" {} ''
   ${echo}
   ${echo} ran: $total
   ${echo} passed: $passed
-  ${echo} ignored: $ignored
+  ${echo} skipped: $(${bc} <<< "$ignored + $smt_failed")
   ${echo} 'failed (smt reports assertion, hevm reports safe):' $smt_reports
   ${echo} 'failed (hevm reports assertion, smt reports safe):' $hevm_reports
   ${echo} hevm timeout: $hevm_timeout
+  ${echo} hevm failure: $hevm_failed
   ${echo}
 
   if [ $hevm_timeout != 0 ] || \

--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -334,17 +334,24 @@ let
     ${echo} ${strings.pass}
   '';
 
-  runAllTests = pkgs.runCommand "runAllSmtCheckerTests-${solver}" {} ''
-    mkdir $out
-    results=$out/results
-
+  runAllTests = pkgs.writeShellScript "runAllTests-${solver}" ''
     for filename in ${smtCheckerTests}/**/*.sol; do
-      ${runSingleTest} $filename ${solver} | ${tee} -a $results
+      ${runSingleTest} $filename ${solver}
     done
+
+    ${divider}
+    ${echo} "Time Taken (${solver}):"
+    ${echo} ---------------------------------
+    ${echo}
+
+    exit 0
   '';
 in
 pkgs.runCommand "smtCheckerTests-${solver}" {} ''
-  results=${runAllTests}/results
+  mkdir $out
+  results=$out/results
+
+  time ${runAllTests} | ${tee} $results
 
   set +e
   total="$(${grep} -c '${strings.exeucting}' $results)"
@@ -357,8 +364,7 @@ pkgs.runCommand "smtCheckerTests-${solver}" {} ''
   hevm_timeout="$(${grep} -c '${strings.timeout}' $results)"
   set -e
 
-
-  ${divider}
+  ${echo}
   ${echo} "Summary (${solver}):"
   ${echo} ---------------------------------
   ${echo}

--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -1,0 +1,128 @@
+{ pkgs, solidity, solc }:
+
+let
+
+  # --- binaries ---
+
+  awk = "${pkgs.gawk}/bin/awk";
+  cat = "${pkgs.coreutils}/bin/cat";
+  echo = "${pkgs.coreutils}/bin/echo";
+  grep = "${pkgs.gnugrep}/bin/grep";
+  hevm = "${pkgs.hevm}/bin/hevm";
+  jq = "${pkgs.jq}/bin/jq";
+  mkdir = "${pkgs.coreutils}/bin/mkdir";
+  mktemp = "${pkgs.coreutils}/bin/mktemp";
+  nix = "${pkgs.nix}/bin/nix";
+  rev = "${pkgs.utillinux}/bin/rev";
+  rm = "${pkgs.coreutils}/bin/rm";
+  sed = "${pkgs.gnused}/bin/sed";
+  tee = "${pkgs.coreutils}/bin/tee";
+  tr = "${pkgs.coreutils}/bin/tr";
+  timeout = "${pkgs.coreutils}/bin/timeout";
+
+  # --- test scripts ---
+
+  smtCheckerTests = "${solidity}/test/libsolidity/smtCheckerTests";
+
+  # Takes one Solidity file, compiles it to bytecode and explores `hevm
+  # symbolic` on all contracts within.
+  # $1 == input file
+  # $2 == hevm smt backend
+  checkWithHevm = pkgs.writeShellScript "checkWithHevm" ''
+    # write json file to store for later debugging
+    testName=$(${echo} "$1" | ${grep} -oP "^${smtCheckerTests}/\K.*")
+    json=$out/jsonFiles/$testName.json
+    ${mkdir} -p $(${echo} "''${json%/*}/")
+
+    ${solc} --combined-json=srcmap,srcmap-runtime,bin,bin-runtime,ast,metadata,storage-layout,abi $1 2> /dev/null > $json
+
+    contracts=($(${cat} $json | ${jq} .contracts | ${jq} keys | ${jq} -r '. | @sh' | ${tr} -d \'))
+
+    for contract in "''${contracts[@]}"; do
+      bytecode=$(${jq} -r --arg c $contract -c '.contracts[$c]."bin-runtime"' $json)
+      set +e
+      set -x
+      ${timeout} 10s ${hevm} symbolic --code "$bytecode" --solver $2 --json-file "$json"
+      status=$?
+      set +x
+      set -e
+
+      if [[ $status == 124 ]]; then echo "FAIL: hevm timeout"; fi
+    done
+
+    exit 0
+  '';
+
+  # Takes one Solidity file in the format of an SMTChecker test,
+  # runs `hevm symbolic` on it and compares results against the SMTChecker expectations.
+  # $1 == input file
+  # $2 == hevm smt backend
+  runSingleTest = pkgs.writeShellScript "runSingleTest" ''
+    #!/usr/bin/sh
+
+    ${echo}
+    ${echo} ----------------------------------------
+    ${echo} "Executing test at: $1"
+
+    hevm_output=$(${checkWithHevm} $1 $2)
+    echo "$hevm_output"
+
+    ${grep} -q 'FAIL:' <<< "$hevm_output"
+    hevm_failure=$?
+    if [ $hevm_failure == 0 ]; then exit; fi
+
+    ${grep} -q 'Assertion violation found' <<< "$hevm_output"
+    hevm_violation=$?
+    ${grep} -q 'Assertion violation happens' $1
+    smtchecker_violation=$?
+
+    if [ $hevm_violation -ne 0 ] && [ $smtchecker_violation -eq 0 ]; then
+      ${echo} "SMTChecker reports assertion violation whereas HEVM reports safe."
+      exit
+    elif [ $hevm_violation -eq 0 ] && [ $smtchecker_violation -ne 0 ]; then
+      ${echo} "SMTChecker reports safe whereas HEVM reports assertion violation."
+      exit
+    fi
+
+    ${echo} hevm and SMTChecker agree!
+  '';
+in
+pkgs.runCommand "smtCheckerTests" {} ''
+  ${mkdir} $out
+
+  for filename in ${smtCheckerTests}/control_flow/*.sol; do
+    ${runSingleTest} $filename z3 | ${tee} $out/z3
+  done
+
+  set +e
+  total="$(${grep} -c 'executing test:' $results)"
+  passed="$(${grep} -c 'No discrepancies found' $results)"
+  ignored="$(${grep} -c 'is ignored, skipping' $results)"
+  same_bytecode="$(${grep} -c 'Bytecodes are the same' $results)"
+  no_compile_first="$(${grep} -c 'Could not compile first Yul source' $results)"
+  no_compile_second="$(${grep} -c 'Could not compile second Yul source' $results)"
+  hevm_timeout="$(${grep} -c 'hevm timeout' $results)"
+  hevm_failed="$(${grep} -c 'hevm execution failed' $results)"
+  set -e
+
+  ${echo} ran: $total
+  ${echo} same bytecode: $same_bytecode
+  ${echo} ignored: $ignored
+  ${echo} passed: $passed
+  ${echo} could not compile first program: $no_compile_first
+  ${echo} could not compile second program: $no_compile_second
+  ${echo} hevm timeout: $hevm_timeout
+  ${echo} hevm execution failed: $hevm_failed
+  ${echo}
+
+  if [ $no_compile_first != 0 ]  || \
+     [ $no_compile_second != 0 ] || \
+     [ $hevm_timeout != 0 ]      || \
+     [ $hevm_failed != 0 ]
+  then
+    return 1
+  else
+    return 0
+  fi
+''
+

--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -48,6 +48,10 @@ let
 
   ignored = [
 
+    # --- hevm soundness bug ---
+    # TODO: enable me once https://github.com/dapphub/dapptools/issues/466 is fixed
+    "types/mapping_aliasing_2.sol"
+
     # --- constructor arguments ---
 
     "functions/constructor_hierarchy_3.sol"

--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -8,7 +8,6 @@ let
 
   # --- binaries ---
 
-  awk = "${pkgs.gawk}/bin/awk";
   bc = "${pkgs.bc}/bin/bc";
   basename = "${pkgs.coreutils}/bin/basename";
   cat = "${pkgs.coreutils}/bin/cat";
@@ -18,9 +17,6 @@ let
   jq = "${pkgs.jq}/bin/jq";
   mkdir = "${pkgs.coreutils}/bin/mkdir";
   mktemp = "${pkgs.coreutils}/bin/mktemp";
-  nix = "${pkgs.nix}/bin/nix";
-  rev = "${pkgs.utillinux}/bin/rev";
-  rm = "${pkgs.coreutils}/bin/rm";
   sed = "${pkgs.gnused}/bin/sed";
   tee = "${pkgs.coreutils}/bin/tee";
   tr = "${pkgs.coreutils}/bin/tr";

--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -38,7 +38,7 @@ let
     "functions/constructor_hierarchy_empty_middle.sol"
     "functions/constructor_hierarchy_mixed_chain_empty_base.sol"
     "functions/constructor_hierarchy_mixed_chain.sol"
-    "constructor_hierarchy_mixed_chain_local_vars.sol"
+    "functions/constructor_hierarchy_mixed_chain_local_vars.sol"
     "functions/constructor_hierarchy_mixed_chain_with_params.sol"
     "functions/constructor_hierarchy_mixed_chain_with_params_2.sol"
     "functions/constructor_simple.sol"
@@ -54,6 +54,21 @@ let
     "functions/functions_trivial_condition_for_only_call.sol"
     "functions/functions_trivial_condition_while.sol"
     "functions/functions_trivial_condition_while_only_call.sol"
+
+    # --- unsupported opcodes ---
+
+    # OpExtcodesize
+
+    "functions/this_fake.sol"
+    "functions/functions_external_1.sol"
+    "functions/functions_external_2.sol"
+    "functions/functions_external_3.sol"
+    "functions/functions_external_4.sol"
+
+    # --- contract level knowledge required ---
+
+    "functions/internal_call_with_assertion_1.sol"
+    "functions/internal_multiple_calls_with_assertion_1.sol"
 
   ];
 

--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -179,6 +179,7 @@ let
     "typecast/cast_smaller_2.sol"
     "typecast/cast_smaller_3.sol"
     "types/mapping_as_parameter_1.sol"
+    "types/mapping_as_local_var_1.sol"
 
   ];
 
@@ -293,8 +294,6 @@ let
     ${grep} -q 'Assertion checker does not yet implement' $1
     if [ $? == 0 ]; then ${echo} ${strings.smtCheckerFailed} && exit; fi
     ${grep} -q 'Assertion checker does not yet support' $1
-    if [ $? == 0 ]; then ${echo} ${strings.smtCheckerFailed} && exit; fi
-    ${grep} -q 'Internal error: Expression undefined for SMT solver.' $1
     if [ $? == 0 ]; then ${echo} ${strings.smtCheckerFailed} && exit; fi
 
     hevm_output=$(${checkWithHevm} $1 $2 2>&1)

--- a/nix/hevm-tests/yul-equivalence.nix
+++ b/nix/hevm-tests/yul-equivalence.nix
@@ -3,7 +3,7 @@
   This is a corpus of ~400 tests used to ensure that the yul optimizer produces equivalent code.
 */
 
-{ pkgs, solidity, solc }:
+{ pkgs, solidity, solc, solver }:
 
 let
 
@@ -21,6 +21,180 @@ let
   sed = "${pkgs.gnused}/bin/sed";
   tee = "${pkgs.coreutils}/bin/tee";
   timeout = "${pkgs.coreutils}/bin/timeout";
+
+  # --- test classification ----
+
+  ignored = [
+
+    # --- timeout (investigate) ----
+
+    "controlFlowSimplifier/terminating_for_nested.yul"
+    "controlFlowSimplifier/terminating_for_nested_reversed.yul"
+
+    # --- unbounded loop ---
+
+    "commonSubexpressionEliminator/branches_for.yul"
+    "commonSubexpressionEliminator/loop.yul"
+    "conditionalSimplifier/clear_after_if_continue.yul"
+    "conditionalSimplifier/no_opt_if_break_is_not_last.yul"
+    "conditionalUnsimplifier/clear_after_if_continue.yul"
+    "conditionalUnsimplifier/no_opt_if_break_is_not_last.yul"
+    "expressionSimplifier/inside_for.yul"
+    "forLoopConditionIntoBody/cond_types.yul"
+    "forLoopConditionIntoBody/simple.yul"
+    "fullSimplify/inside_for.yul"
+    "fullSuite/devcon_example.yul"
+    "fullSuite/loopInvariantCodeMotion.yul"
+    "fullSuite/no_move_loop_orig.yul"
+    "loadResolver/loop.yul"
+    "loopInvariantCodeMotion/multi.yul"
+    "loopInvariantCodeMotion/recursive.yul"
+    "loopInvariantCodeMotion/simple.yul"
+    "redundantAssignEliminator/for_branch.yul"
+    "redundantAssignEliminator/for_break.yul"
+    "redundantAssignEliminator/for_continue.yul"
+    "redundantAssignEliminator/for_decl_inside_break_continue.yul"
+    "redundantAssignEliminator/for_deep_noremove.yul"
+    "redundantAssignEliminator/for_deep_simple.yul"
+    "redundantAssignEliminator/for_multi_break.yul"
+    "redundantAssignEliminator/for_nested.yul"
+    "redundantAssignEliminator/for_rerun.yul"
+    "redundantAssignEliminator/for_stmnts_after_break_continue.yul"
+    "rematerialiser/branches_for1.yul"
+    "rematerialiser/branches_for2.yul"
+    "rematerialiser/for_break.yul"
+    "rematerialiser/for_continue.yul"
+    "rematerialiser/for_continue_2.yul"
+    "rematerialiser/for_continue_with_assignment_in_post.yul"
+    "rematerialiser/no_remat_in_loop.yul"
+    "ssaTransform/for_reassign_body.yul"
+    "ssaTransform/for_reassign_init.yul"
+    "ssaTransform/for_reassign_post.yul"
+    "ssaTransform/for_simple.yul"
+
+    # --- unexpected symbolic arg ---
+
+    # OpCreate2
+    "expressionSimplifier/create2_and_mask.yul"
+
+    # OpCreate
+    "expressionSimplifier/create_and_mask.yul"
+    "expressionSimplifier/large_byte_access.yul"
+
+    # OpMload
+    "yulOptimizerTests/expressionSplitter/inside_function.yul"
+    "fullInliner/double_inline.yul"
+    "fullInliner/inside_condition.yul"
+    "fullInliner/large_function_multi_use.yul"
+    "fullInliner/large_function_single_use.yul"
+    "fullInliner/no_inline_into_big_global_context.yul"
+    "fullSimplify/invariant.yul"
+    "fullSuite/abi_example1.yul"
+    "ssaAndBack/for_loop.yul"
+    "ssaAndBack/multi_assign_multi_var_if.yul"
+    "ssaAndBack/multi_assign_multi_var_switch.yul"
+    "ssaAndBack/two_vars.yul"
+    "ssaTransform/multi_assign.yul"
+    "ssaTransform/multi_decl.yul"
+    "expressionSplitter/inside_function.yul"
+    "fullSuite/ssaReverseComplex.yul"
+
+    # OpMstore
+    "commonSubexpressionEliminator/function_scopes.yul"
+    "commonSubexpressionEliminator/variable_for_variable.yul"
+    "expressionSplitter/trivial.yul"
+    "fullInliner/multi_return.yul"
+    "fullSimplify/constant_propagation.yul"
+    "fullSimplify/identity_rules_complex.yul"
+    "fullSuite/medium.yul"
+    "loadResolver/memory_with_msize.yul"
+    "loadResolver/merge_known_write.yul"
+    "loadResolver/merge_known_write_with_distance.yul"
+    "loadResolver/merge_unknown_write.yul"
+    "loadResolver/reassign_value_expression.yul"
+    "loadResolver/second_mstore_with_delta.yul"
+    "loadResolver/second_store_with_delta.yul"
+    "loadResolver/simple.yul"
+    "loadResolver/simple_memory.yul"
+    "fullSuite/ssaReverse.yul"
+    "rematerialiser/cheap_caller.yul"
+    "rematerialiser/non_movable_instruction.yul"
+    "ssaAndBack/multi_assign.yul"
+    "ssaAndBack/multi_assign_if.yul"
+    "ssaAndBack/multi_assign_switch.yul"
+    "ssaAndBack/simple.yul"
+    "ssaReverser/simple.yul"
+
+    # OpMstore8
+    "loadResolver/memory_with_different_kinds_of_invalidation.yul"
+
+    # OpRevert
+    "ssaAndBack/ssaReverse.yul"
+    "redundantAssignEliminator/for_continue_3.yul"
+    "controlFlowSimplifier/terminating_for_revert.yul"
+
+    # --- invalid test ---
+    # https://github.com/ethereum/solidity/issues/9500
+
+    "commonSubexpressionEliminator/object_access.yul"
+    "expressionSplitter/object_access.yul"
+    "fullSuite/stack_compressor_msize.yul"
+    "varNameCleaner/function_names.yul"
+
+    # --- stack too deep ---
+
+    "fullSuite/abi2.yul"
+    "fullSuite/aztec.yul"
+    "stackCompressor/inlineInBlock.yul"
+    "stackCompressor/inlineInFunction.yul"
+    "stackCompressor/unusedPrunerWithMSize.yul"
+    "wordSizeTransform/function_call.yul"
+    "fullInliner/no_inline_into_big_function.yul"
+
+    # --- wrong number of args ---
+
+    "wordSizeTransform/functional_instruction.yul"
+    "wordSizeTransform/if.yul"
+    "wordSizeTransform/or_bool_renamed.yul"
+    "wordSizeTransform/switch_1.yul"
+    "wordSizeTransform/switch_2.yul"
+    "wordSizeTransform/switch_3.yul"
+    "wordSizeTransform/switch_4.yul"
+    "wordSizeTransform/switch_5.yul"
+
+    # --- typed yul ---
+
+    "expressionSplitter/typed.yul"
+    "expressionInliner/simple.yul"
+    "expressionInliner/with_args.yul"
+    "disambiguator/variables_inside_functions.yul"
+    "disambiguator/switch_statement.yul"
+    "disambiguator/if_statement.yul"
+    "disambiguator/for_statement.yul"
+    "disambiguator/funtion_call.yul"
+    "disambiguator/long_names.yul"
+    "disambiguator/variables.yul"
+    "disambiguator/variables_clash.yul"
+    "conditionalSimplifier/add_correct_type.yul"
+    "conditionalSimplifier/add_correct_type_wasm.yul"
+    "fullInliner/multi_return_typed.yul"
+    "functionGrouper/empty_block.yul"
+    "functionGrouper/multi_fun_mixed.yul"
+    "functionGrouper/nested_fun.yul"
+    "functionGrouper/single_fun.yul"
+    "functionHoister/empty_block.yul"
+    "functionHoister/multi_mixed.yul"
+    "functionHoister/nested.yul"
+    "functionHoister/single.yul"
+    "mainFunction/empty_block.yul"
+    "mainFunction/multi_fun_mixed.yul"
+    "mainFunction/nested_fun.yul"
+    "mainFunction/single_fun.yul"
+    "ssaTransform/typed.yul"
+    "ssaTransform/typed_for.yul"
+    "ssaTransform/typed_switch.yul"
+    "varDeclInitializer/typed.yul"
+  ];
 
   # --- test scripts ---
 
@@ -160,237 +334,41 @@ let
     done
   '';
 
-  # --- ignored tests ----
-
-  ignored = [
-    # --- hevm bug ---
-
-    # https://github.com/dapphub/dapptools/issues/457
-    "controlFlowSimplifier/terminating_for_revert.yul"
-
-    # --- timeout (investigate) ----
-
-    "controlFlowSimplifier/terminating_for_nested.yul"
-    "controlFlowSimplifier/terminating_for_nested_reversed.yul"
-
-    # --- unbounded loop ---
-
-    "commonSubexpressionEliminator/branches_for.yul"
-    "commonSubexpressionEliminator/loop.yul"
-    "conditionalSimplifier/clear_after_if_continue.yul"
-    "conditionalSimplifier/no_opt_if_break_is_not_last.yul"
-    "conditionalUnsimplifier/clear_after_if_continue.yul"
-    "conditionalUnsimplifier/no_opt_if_break_is_not_last.yul"
-    "expressionSimplifier/inside_for.yul"
-    "forLoopConditionIntoBody/cond_types.yul"
-    "forLoopConditionIntoBody/simple.yul"
-    "fullSimplify/inside_for.yul"
-    "fullSuite/devcon_example.yul"
-    "fullSuite/loopInvariantCodeMotion.yul"
-    "fullSuite/no_move_loop_orig.yul"
-    "loadResolver/loop.yul"
-    "loopInvariantCodeMotion/multi.yul"
-    "loopInvariantCodeMotion/recursive.yul"
-    "loopInvariantCodeMotion/simple.yul"
-    "redundantAssignEliminator/for_branch.yul"
-    "redundantAssignEliminator/for_break.yul"
-    "redundantAssignEliminator/for_continue.yul"
-    "redundantAssignEliminator/for_continue_3.yul"
-    "redundantAssignEliminator/for_decl_inside_break_continue.yul"
-    "redundantAssignEliminator/for_deep_noremove.yul"
-    "redundantAssignEliminator/for_deep_simple.yul"
-    "redundantAssignEliminator/for_multi_break.yul"
-    "redundantAssignEliminator/for_nested.yul"
-    "redundantAssignEliminator/for_rerun.yul"
-    "redundantAssignEliminator/for_stmnts_after_break_continue.yul"
-    "rematerialiser/branches_for1.yul"
-    "rematerialiser/branches_for2.yul"
-    "rematerialiser/for_break.yul"
-    "rematerialiser/for_continue.yul"
-    "rematerialiser/for_continue_2.yul"
-    "rematerialiser/for_continue_with_assignment_in_post.yul"
-    "rematerialiser/no_remat_in_loop.yul"
-    "ssaTransform/for_reassign_body.yul"
-    "ssaTransform/for_reassign_init.yul"
-    "ssaTransform/for_reassign_post.yul"
-    "ssaTransform/for_simple.yul"
-
-    # --- unexpected symbolic arg ---
-
-    # OpCreate2
-    "expressionSimplifier/create2_and_mask.yul"
-
-    # OpCreate
-    "expressionSimplifier/create_and_mask.yul"
-    "expressionSimplifier/large_byte_access.yul"
-
-    # OpMload
-    "yulOptimizerTests/expressionSplitter/inside_function.yul"
-    "fullInliner/double_inline.yul"
-    "fullInliner/inside_condition.yul"
-    "fullInliner/large_function_multi_use.yul"
-    "fullInliner/large_function_single_use.yul"
-    "fullInliner/no_inline_into_big_global_context.yul"
-    "fullSimplify/invariant.yul"
-    "fullSuite/abi_example1.yul"
-    "ssaAndBack/for_loop.yul"
-    "ssaAndBack/multi_assign_multi_var_if.yul"
-    "ssaAndBack/multi_assign_multi_var_switch.yul"
-    "ssaAndBack/two_vars.yul"
-    "ssaTransform/multi_assign.yul"
-    "ssaTransform/multi_decl.yul"
-    "expressionSplitter/inside_function.yul"
-    "fullSuite/ssaReverseComplex.yul"
-
-    # OpMstore
-    "commonSubexpressionEliminator/function_scopes.yul"
-    "commonSubexpressionEliminator/variable_for_variable.yul"
-    "expressionSplitter/trivial.yul"
-    "fullInliner/multi_return.yul"
-    "fullSimplify/constant_propagation.yul"
-    "fullSimplify/identity_rules_complex.yul"
-    "fullSuite/medium.yul"
-    "loadResolver/memory_with_msize.yul"
-    "loadResolver/merge_known_write.yul"
-    "loadResolver/merge_known_write_with_distance.yul"
-    "loadResolver/merge_unknown_write.yul"
-    "loadResolver/reassign_value_expression.yul"
-    "loadResolver/second_mstore_with_delta.yul"
-    "loadResolver/second_store_with_delta.yul"
-    "loadResolver/simple.yul"
-    "loadResolver/simple_memory.yul"
-    "fullSuite/ssaReverse.yul"
-    "rematerialiser/cheap_caller.yul"
-    "rematerialiser/non_movable_instruction.yul"
-    "ssaAndBack/multi_assign.yul"
-    "ssaAndBack/multi_assign_if.yul"
-    "ssaAndBack/multi_assign_switch.yul"
-    "ssaAndBack/simple.yul"
-    "ssaReverser/simple.yul"
-
-    # OpMstore8
-    "loadResolver/memory_with_different_kinds_of_invalidation.yul"
-
-    # OpRevert
-    "ssaAndBack/ssaReverse.yul"
-
-    # --- invalid test ---
-    # https://github.com/ethereum/solidity/issues/9500
-
-    "commonSubexpressionEliminator/object_access.yul"
-    "expressionSplitter/object_access.yul"
-    "fullSuite/stack_compressor_msize.yul"
-    "varNameCleaner/function_names.yul"
-
-    # --- stack too deep ---
-
-    "fullSuite/abi2.yul"
-    "fullSuite/aztec.yul"
-    "stackCompressor/inlineInBlock.yul"
-    "stackCompressor/inlineInFunction.yul"
-    "stackCompressor/unusedPrunerWithMSize.yul"
-    "wordSizeTransform/function_call.yul"
-    "fullInliner/no_inline_into_big_function.yul"
-
-    # --- wrong number of args ---
-
-    "wordSizeTransform/functional_instruction.yul"
-    "wordSizeTransform/if.yul"
-    "wordSizeTransform/or_bool_renamed.yul"
-    "wordSizeTransform/switch_1.yul"
-    "wordSizeTransform/switch_2.yul"
-    "wordSizeTransform/switch_3.yul"
-    "wordSizeTransform/switch_4.yul"
-    "wordSizeTransform/switch_5.yul"
-
-    # --- typed yul ---
-
-    "expressionSplitter/typed.yul"
-    "expressionInliner/simple.yul"
-    "expressionInliner/with_args.yul"
-    "disambiguator/variables_inside_functions.yul"
-    "disambiguator/switch_statement.yul"
-    "disambiguator/if_statement.yul"
-    "disambiguator/for_statement.yul"
-    "disambiguator/funtion_call.yul"
-    "disambiguator/long_names.yul"
-    "disambiguator/variables.yul"
-    "disambiguator/variables_clash.yul"
-    "conditionalSimplifier/add_correct_type.yul"
-    "conditionalSimplifier/add_correct_type_wasm.yul"
-    "fullInliner/multi_return_typed.yul"
-    "functionGrouper/empty_block.yul"
-    "functionGrouper/multi_fun_mixed.yul"
-    "functionGrouper/nested_fun.yul"
-    "functionGrouper/single_fun.yul"
-    "functionHoister/empty_block.yul"
-    "functionHoister/multi_mixed.yul"
-    "functionHoister/nested.yul"
-    "functionHoister/single.yul"
-    "mainFunction/empty_block.yul"
-    "mainFunction/multi_fun_mixed.yul"
-    "mainFunction/nested_fun.yul"
-    "mainFunction/single_fun.yul"
-    "ssaTransform/typed.yul"
-    "ssaTransform/typed_for.yul"
-    "ssaTransform/typed_switch.yul"
-    "varDeclInitializer/typed.yul"
-  ];
 in
-pkgs.runCommand "yulEquivalence" {} ''
-  parse_results() {
-    local results=$1
-
-    set +e
-    total="$(${grep} -c 'executing test:' $results)"
-    passed="$(${grep} -c 'No discrepancies found' $results)"
-    ignored="$(${grep} -c 'is ignored, skipping' $results)"
-    same_bytecode="$(${grep} -c 'Bytecodes are the same' $results)"
-    no_compile_first="$(${grep} -c 'Could not compile first Yul source' $results)"
-    no_compile_second="$(${grep} -c 'Could not compile second Yul source' $results)"
-    hevm_timeout="$(${grep} -c 'hevm timeout' $results)"
-    hevm_failed="$(${grep} -c 'hevm execution failed' $results)"
-    set -e
-
-    ${echo} ran: $total
-    ${echo} same bytecode: $same_bytecode
-    ${echo} ignored: $ignored
-    ${echo} passed: $passed
-    ${echo} could not compile first program: $no_compile_first
-    ${echo} could not compile second program: $no_compile_second
-    ${echo} hevm timeout: $hevm_timeout
-    ${echo} hevm execution failed: $hevm_failed
-    ${echo}
-
-    if [ $no_compile_first != 0 ]  || \
-       [ $no_compile_second != 0 ] || \
-       [ $hevm_timeout != 0 ]      || \
-       [ $hevm_failed != 0 ]
-    then
-      return 1
-    else
-      return 0
-    fi
-  }
-
-  ${mkdir} $out
-
-  ${runAllTests} z3 | ${tee} $out/z3
-  ${runAllTests} cvc4 | ${tee} $out/cvc4
+pkgs.runCommand "yulEquivalence-${solver}" {} ''
+  results=$out
+  ${runAllTests} ${solver} | ${tee} $out
 
   ${echo}
-  ${echo} "Summary (z3):"
+  ${echo} "Summary (${solver}):"
   ${echo} -------------------------------------------
-  parse_results $out/z3
-  z3_status=$?
 
+  set +e
+  total="$(${grep} -c 'executing test:' $results)"
+  passed="$(${grep} -c 'No discrepancies found' $results)"
+  ignored="$(${grep} -c 'is ignored, skipping' $results)"
+  same_bytecode="$(${grep} -c 'Bytecodes are the same' $results)"
+  no_compile_first="$(${grep} -c 'Could not compile first Yul source' $results)"
+  no_compile_second="$(${grep} -c 'Could not compile second Yul source' $results)"
+  hevm_timeout="$(${grep} -c 'hevm timeout' $results)"
+  hevm_failed="$(${grep} -c 'hevm execution failed' $results)"
+  set -e
+
+  ${echo} ran: $total
+  ${echo} same bytecode: $same_bytecode
+  ${echo} ignored: $ignored
+  ${echo} passed: $passed
+  ${echo} could not compile first program: $no_compile_first
+  ${echo} could not compile second program: $no_compile_second
+  ${echo} hevm timeout: $hevm_timeout
+  ${echo} hevm execution failed: $hevm_failed
   ${echo}
-  ${echo} "Summary (cvc4):"
-  ${echo} -------------------------------------------
-  parse_results $out/cvc4
-  cvc4_status=$?
 
-  if [ $z3_status!= 0 ] || [ $cvc4_status != 0 ]; then
+  if [ $no_compile_first != 0 ]  || \
+     [ $no_compile_second != 0 ] || \
+     [ $hevm_timeout != 0 ]      || \
+     [ $hevm_failed != 0 ]
+  then
     exit 1
   else
     exit 0

--- a/nix/hevm-tests/yul-equivalence.nix
+++ b/nix/hevm-tests/yul-equivalence.nix
@@ -332,12 +332,16 @@ let
     for filename in ${prefix}/**/*.yul; do
       check_equiv $filename $solver
     done
+
+    ${echo}
+    ${echo} "Time taken (${solver}):"
+    ${echo} -------------------------------------------
   '';
 
 in
 pkgs.runCommand "yulEquivalence-${solver}" {} ''
   results=$out
-  ${runAllTests} ${solver} | ${tee} $out
+  time ${runAllTests} ${solver} | ${tee} $out
 
   ${echo}
   ${echo} "Summary (${solver}):"
@@ -355,9 +359,9 @@ pkgs.runCommand "yulEquivalence-${solver}" {} ''
   set -e
 
   ${echo} ran: $total
-  ${echo} same bytecode: $same_bytecode
-  ${echo} ignored: $ignored
   ${echo} passed: $passed
+  ${echo} ignored: $ignored
+  ${echo} same bytecode: $same_bytecode
   ${echo} could not compile first program: $no_compile_first
   ${echo} could not compile second program: $no_compile_second
   ${echo} hevm timeout: $hevm_timeout

--- a/nix/hevm-tests/yul-equivalence.nix
+++ b/nix/hevm-tests/yul-equivalence.nix
@@ -16,7 +16,7 @@ let
   hevm = "${pkgs.hevm}/bin/hevm";
   mkdir = "${pkgs.coreutils}/bin/mkdir";
   mktemp = "${pkgs.coreutils}/bin/mktemp";
-  rev = "${pkgs.utillinux}/bin/rev";
+  rev = "${pkgs.busybox}/bin/rev";
   rm = "${pkgs.coreutils}/bin/rm";
   sed = "${pkgs.gnused}/bin/sed";
   tee = "${pkgs.coreutils}/bin/tee";

--- a/nix/hevm-tests/yul-equivalence.nix
+++ b/nix/hevm-tests/yul-equivalence.nix
@@ -3,7 +3,7 @@
   This is a corpus of ~400 tests used to ensure that the yul optimizer produces equivalent code.
 */
 
-{ pkgs, lib, solidity }:
+{ pkgs, solidity, solc }:
 
 let
 
@@ -16,12 +16,11 @@ let
   hevm = "${pkgs.hevm}/bin/hevm";
   mkdir = "${pkgs.coreutils}/bin/mkdir";
   mktemp = "${pkgs.coreutils}/bin/mktemp";
-  timeout = "${pkgs.timeout}/bin/timeout";
   rev = "${pkgs.utillinux}/bin/rev";
   rm = "${pkgs.coreutils}/bin/rm";
   sed = "${pkgs.gnused}/bin/sed";
-  solc = "${pkgs.solc-versions.solc_0_6_7}/bin/solc";
   tee = "${pkgs.coreutils}/bin/tee";
+  timeout = "${pkgs.coreutils}/bin/timeout";
 
   # --- test scripts ---
 
@@ -86,11 +85,10 @@ let
     fi
 
     ${echo} "Checking bytecode equivalence: $a_bin vs $b_bin"
-    ${pkgs.coreutils}/bin/timeout 20s \
-      ${pkgs.hevm}/bin/hevm equivalence --solver $3       \
-                                        --code-a "$a_bin" \
-                                        --code-b "$b_bin" \
-                                        --smttimeout 20000
+    ${timeout} 30s ${hevm} equivalence --solver $3       \
+                                       --code-a "$a_bin" \
+                                       --code-b "$b_bin" \
+                                       --smttimeout 20000
     status=$?
 
     if [[ $status == 1 ]]

--- a/nix/hevm-tests/yul-equivalence.nix
+++ b/nix/hevm-tests/yul-equivalence.nix
@@ -16,7 +16,6 @@ let
   hevm = "${pkgs.hevm}/bin/hevm";
   mkdir = "${pkgs.coreutils}/bin/mkdir";
   mktemp = "${pkgs.coreutils}/bin/mktemp";
-  rev = if pkgs.system == "x86_64-darwin" then "rev" else "${pkgs.busybox}/bin/rev";
   rm = "${pkgs.coreutils}/bin/rm";
   sed = "${pkgs.gnused}/bin/sed";
   tee = "${pkgs.coreutils}/bin/tee";
@@ -222,16 +221,15 @@ let
     fi
 
     # object notation
+    # add a calldatacopy after all 'code {'
     if [ "$(${echo} $in | head -n 1 | ${awk} '{print $1;}')" == "object" ]; then
       ${echo} "$in" | ${sed} '/code\ {/ a calldatacopy(0,0,1024)'
       exit 0
     fi
 
     # simple notation
-    ${echo} "$in"                            \
-    | ${sed} 's/^{/{\n/'                     \
-    | ${sed} '0,/{/s//{\ncalldatacopy(0,0,1024)/' \
-    | ${rev} | ${sed} -e 's/}$/\n}/' | ${rev}
+    # add a calldatacopy after the first {
+    ${echo} "$in" | ${sed} -z '0,/^\s*{/s//{\ncalldatacopy(0,0,1024)/'
   '';
 
   # Takes two Yul files, compiles them to EVM bytecode and checks equivalence.

--- a/nix/hevm-tests/yul-equivalence.nix
+++ b/nix/hevm-tests/yul-equivalence.nix
@@ -16,7 +16,7 @@ let
   hevm = "${pkgs.hevm}/bin/hevm";
   mkdir = "${pkgs.coreutils}/bin/mkdir";
   mktemp = "${pkgs.coreutils}/bin/mktemp";
-  rev = "${pkgs.busybox}/bin/rev";
+  rev = if pkgs.system == "x86_64-darwin" then "rev" else "${pkgs.busybox}/bin/rev";
   rm = "${pkgs.coreutils}/bin/rm";
   sed = "${pkgs.gnused}/bin/sed";
   tee = "${pkgs.coreutils}/bin/tee";

--- a/nix/hevm/tests.nix
+++ b/nix/hevm/tests.nix
@@ -1,0 +1,113 @@
+{ pkgs, lib }:
+let
+  awk = "${pkgs.gawk}/bin/awk";
+  cat = "${pkgs.coreutils}/bin/cat";
+  echo = "${pkgs.coreutils}/bin/echo";
+  grep = "${pkgs.gnugrep}/bin/grep";
+  hevm = "${pkgs.hevm}/bin/hevm";
+  mktemp = "${pkgs.coreutils}/bin/mktemp";
+  timeout = "${pkgs.timeout}/bin/timeout";
+  rm = "${pkgs.coreutils}/bin/rm";
+  sed = "${pkgs.gnused}/bin/sed";
+  solc = "${pkgs.solc-versions.solc_0_6_7}/bin/solc";
+
+  solidity = pkgs.fetchFromGitHub {
+    owner = "ethereum";
+    repo = "solidity";
+    rev = "b8d736ae0c506b1b3cf5d2456af67e8dc2c0ca8e"; # v0.6.7
+    sha256 = "1zqfcfgy70hmckxb3l59rabdpzj7gf1vzg6kkw4xz0c6lzy7mrpz";
+  };
+
+  compile = pkgs.writeShellScript "compile" ''
+    out=$(${mktemp})
+    ${solc} --yul --yul-dialect evm $1 > $out 2>&1
+    status=$?
+    cat $out | ${awk} 'f{print;f=0} /Binary representation:/{f=1}'
+    exit $status
+  '';
+
+  run-yul-equivalence = pkgs.writeShellScript "run-yul-equivalence" ''
+    # Takes two Yul files, compiles them to EVM bytecode and checks equivalence.
+
+    a_bin=$(${compile} $1)
+    if [ $? -eq 1 ]
+    then
+        ${echo} "Could not compile first Yul source."
+        ${cat} $1
+        exit 1
+    fi
+
+    b_bin=$(${compile} $2)
+    if [ $? -eq 1 ]
+    then
+        ${echo} "Could not compile second Yul source."
+        ${cat} $1
+        exit 1
+    fi
+
+    if [[ "$a_bin" == "$b_bin" ]]
+    then
+        ${echo} "Bytecodes are the same."
+        exit 0
+    fi
+
+    ${echo} "Checking bytecode equivalence: $a_bin vs $b_bin"
+    ${pkgs.coreutils}/bin/timeout 10s ${pkgs.hevm}/bin/hevm equivalence --code-a "$a_bin" --code-b "$b_bin" --smttimeout 1000
+    if [[ $? == 124 ]]
+    then
+        ${echo} "HEVM timeout."
+        ${cat} $1
+        exit 1
+    fi
+
+    exit 0
+  '';
+
+  prefixes = {
+    yulOptimizerTests = "${solidity}/test/libyul/yulOptimizerTests";
+  };
+
+  ignored-tests = {
+    yulOptimizerTests = [
+      # unbounded loop
+      "commonSubexpressionEliminator/branches_for.yul"
+      "commonSubexpressionEliminator/loop.yul"
+      "conditionalSimplifier/no_opt_if_break_is_not_last.yul"
+      "conditionalUnsimplifier/no_opt_if_break_is_not_last.yul"
+
+      # cannot compile
+      "commonSubexpressionEliminator/object_access.yul"
+      "conditionalSimplifier/add_correct_type.yul"
+      "conditionalSimplifier/add_correct_type_wasm.yul"
+    ];
+  };
+in
+{
+  yulEquivalence = pkgs.runCommand "hevm-equivalence" {} ''
+    check_equiv()
+    {
+        # Takes one file which follows the Solidity Yul optimizer unit tests format,
+        # extracts both the nonoptimized and the optimized versions, and checks equivalence.
+
+        ${echo} "---------------------------------------------"
+        ${echo} "checking $1"
+
+        ignoredTests=(${toString ignored-tests.yulOptimizerTests})
+        testName=$(${echo} "$1" | ${grep} -oP "^${prefixes.yulOptimizerTests}/\K.*")
+
+        if [[ " ''${ignoredTests[@]} " =~ " ''${testName} " ]]; then
+            ${echo} "$testName is ignored, skipping"
+            return 0
+        fi
+
+        nonopt_src=$(${mktemp})
+        ${sed} '0,/^\/\/ step:/d' $1 | ${sed} -e 's!\/\/!!' > $nonopt_src
+        ${run-yul-equivalence} $1 $nonopt_src
+        ${rm} $nonopt_src
+    }
+
+    for filename in ${prefixes.yulOptimizerTests}/**/*.yul; do
+      check_equiv $filename
+    done
+  '';
+}

--- a/nix/hevm/tests.nix
+++ b/nix/hevm/tests.nix
@@ -84,6 +84,11 @@ let
     if [[ $status == 1 ]]
     then
         ${echo} hevm execution failed
+        ${echo} "file1:"
+        ${cat} $1
+        ${echo} "-------------"
+        ${echo} "file2:"
+        ${cat} $2
         exit 1
     fi
     if [[ $status == 124 ]]
@@ -106,17 +111,27 @@ let
 
   ignored-tests = {
     yulOptimizerTests = [
-      # unbounded loop
+      # --- timeout investigate ----
+      "controlFlowSimplifier/terminating_for_nested.yul"
+      "controlFlowSimplifier/terminating_for_nested_reversed.yul"
+
+      # --- unbounded loop ---
+
       "commonSubexpressionEliminator/branches_for.yul"
       "commonSubexpressionEliminator/loop.yul"
-      #"conditionalSimplifier/no_opt_if_break_is_not_last.yul"
-      #"conditionalUnsimplifier/no_opt_if_break_is_not_last.yul"
+      "conditionalSimplifier/clear_after_if_continue.yul"
+      "conditionalSimplifier/no_opt_if_break_is_not_last.yul"
+      "conditionalUnsimplifier/clear_after_if_continue.yul"
+      "conditionalUnsimplifier/no_opt_if_break_is_not_last.yul"
 
-      # unexpected symbolic arg
-      "commonSubexpressionEliminator/function_scopes.yul" #OpMstore
-      "commonSubexpressionEliminator/variable_for_variable.yul" #OpMstore
+      # --- unexpected symbolic arg ---
 
-      # cannot compile
+      # OpMstore
+      "commonSubexpressionEliminator/function_scopes.yul"
+      "commonSubexpressionEliminator/variable_for_variable.yul"
+
+      # --- cannot compile ---
+
       "commonSubexpressionEliminator/object_access.yul"
       "conditionalSimplifier/add_correct_type.yul"
       "conditionalSimplifier/add_correct_type_wasm.yul"

--- a/overlay.nix
+++ b/overlay.nix
@@ -20,7 +20,7 @@ in rec {
   # experimental dapp builder, allows for easy overriding of phases
   buildDappPackage = import ./nix/build-dapp-package.nix { inherit (self) pkgs; };
 
-  # Here we can make e.g. integration tests for Dappsys,
+  # Here we can make e.g. integration tests for Dappsys.
   dapp-tests = import ./src/dapp-tests { inherit (self) pkgs; };
 
   # These are tests that verify the correctness of hevm symbolic using various

--- a/overlay.nix
+++ b/overlay.nix
@@ -25,7 +25,7 @@ in rec {
 
   # These are tests that verify the correctness of hevm symbolic using various
   # external test suites (e.g. the solc tests)
-  hevm-tests = import ./nix/hevm-tests { pkgs = self.pkgs; lib = self.pkgs.lib; };
+  hevm-tests = import ./nix/hevm-tests { pkgs = self.pkgs; };
 
   bashScript = { name, version ? "0", deps ? [], text, check ? true } :
     self.pkgs.writeTextFile {

--- a/overlay.nix
+++ b/overlay.nix
@@ -25,7 +25,7 @@ in rec {
 
   # These are tests that verify the correctness of hevm symbolic using various
   # external test suites (e.g. the solc tests)
-  hevm-tests = import ./nix/hevm/tests.nix { pkgs = self.pkgs; lib = self.pkgs.lib; };
+  hevm-tests = import ./nix/hevm-tests { pkgs = self.pkgs; lib = self.pkgs.lib; };
 
   bashScript = { name, version ? "0", deps ? [], text, check ? true } :
     self.pkgs.writeTextFile {

--- a/overlay.nix
+++ b/overlay.nix
@@ -21,8 +21,11 @@ in rec {
   buildDappPackage = import ./nix/build-dapp-package.nix { inherit (self) pkgs; };
 
   # Here we can make e.g. integration tests for Dappsys,
-  # or tests that verify Hevm correctness, etc.
   dapp-tests = import ./src/dapp-tests { inherit (self) pkgs; };
+
+  # These are tests that verify the correctness of hevm symbolic using various
+  # external test suites (e.g. the solc tests)
+  hevm-tests = import ./nix/hevm/tests.nix { pkgs = self.pkgs; lib = self.pkgs.lib; };
 
   bashScript = { name, version ? "0", deps ? [], text, check ? true } :
     self.pkgs.writeTextFile {

--- a/release.nix
+++ b/release.nix
@@ -41,6 +41,7 @@ let
     inherit qrtx;
     inherit seth;
     inherit token;
+    inherit hevm-tests;
 
     hevm-compliance = hevmCompliance dist;
   # the union is necessary because nix-build does not evaluate sets

--- a/release.nix
+++ b/release.nix
@@ -41,12 +41,11 @@ let
     inherit qrtx;
     inherit seth;
     inherit token;
-    inherit hevm-tests;
 
     hevm-compliance = hevmCompliance dist;
   # the union is necessary because nix-build does not evaluate sets
-  # recursively, and `solc-versions` is a set
-  } // dist.pkgs.solc-versions ;
+  # recursively, and `solc-versions` and `hevm-tests` are sets.
+  } // dist.pkgs.solc-versions // dist.pkgs.hevm-tests ;
 
 in {
   dapphub.linux.stable = stable linux;


### PR DESCRIPTION
## Overview

This PR integrates two parts of the solc test suite and uses them to verify `hevm symbolic`:

1. the yul optimzer tests: a corpus of ~400 pairs of yul programs that have been written to be equivalant. Used to test `hevm equivalence`
2. the SMTCheker tests: a corpus of ~450 solidity contracts containing assertions, and annotations on whether or not those assertions should be violated. Used to test `hevm symbolic`

Not every test was useful in our context, but accounting for skipped tests, this gives us 474 new test cases.

The yul equivlance tests are run with both `cvc4` and `z3`, but the smt checker tests can only be run in  a reasonable time using `cvc4`. Interstingly `z3` is slightly faster on the equivalance tests (~30s for z3 and ~40s for cvc4 on my machine).

## Issues Found

During the course of integrating these tests I found 3 `hevm` bugs (including one soundness issue)

- https://github.com/dapphub/dapptools/issues/456
- https://github.com/dapphub/dapptools/issues/457
- https://github.com/dapphub/dapptools/issues/466

I also found four instances of incorrect tests in the yul optimizer test suite (https://github.com/ethereum/solidity/issues/9500).

The smtChecker tests are currently failing due to the soundness issue (https://github.com/dapphub/dapptools/issues/466).

## Results

*SMTChecker*:

```
ran: 451
passed: 288
skipped: 162
failed (smt reports assertion, hevm reports safe): 1
failed (hevm reports assertion, smt reports safe): 0
hevm timeout: 0 
hevm failure: 0
```

*yulEquivlence*

```
ran: 409
passed: 185
same bytecode: 89
ignored: 135
could not compile first program: 0
could not compile second program: 0
hevm timeout: 0
hevm execution failed: 0
```

cc @leonardoalt 