### PR TITLE
ci: fix typo in hevm-tests invocation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,5 +31,5 @@ jobs:
       - name: run dapp tests
         run: nix-env -iA nixpkgs.bashInteractive && nix-shell --pure src/dapp-tests/shell.nix --command 'make --directory src/dapp-tests'
       - name: run hevm symbolic tests
-        run: nix-build -j 0 -A hevm-tests
+        run: nix-build -j 1 -A hevm-tests
       - run: nix-build release.nix -A dapphub.${{ matrix.os_attr }}.stable


### PR DESCRIPTION
Sorry I broke the CI :cry: I think this should fix it....