### PR TITLE
hevm: add knowledge to path conditions when query is Known

### DIFF
--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -93,6 +93,8 @@ let
 
     # these can pass with high enough timeout and --max-iterations
     # but we keep them disabled for now to speed up the tests
+    "loops/for_loop_array_assignment_storage_memory.sol"
+    "loops/while_nested_break.sol"
     "operators/delete_array.sol"
     "operators/delete_array_2d.sol"
     "operators/delete_array_index_2d.sol"

--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -39,7 +39,9 @@ let
     "loops/while_loop_simple_5.sol"
     "loops/do_while_1_false_positives.sol"
     "loops/while_loop_array_assignment_storage_storage.sol"
+    "loops/while_nested_break_fail.sol"
     "operators/delete_array_index_2d.sol"
+
   ];
 
   ignored = [
@@ -94,9 +96,11 @@ let
     "operators/delete_array.sol"
     "operators/delete_array_2d.sol"
     "operators/delete_array_index_2d.sol"
+    "types/array_dynamic_3_fail.sol"
+    "types/array_mapping_aliasing_2.sol"
 
     # --- hevm timeout ---
-
+    "types/array_aliasing_storage_1.sol"
     "types/array_aliasing_memory_1.sol"
     "types/array_aliasing_memory_2.sol"
     "types/array_aliasing_memory_3.sol"
@@ -268,7 +272,7 @@ let
       iterations=""
       boundedTests=(${toString bounded})
       if [[ " ''${boundedTests[@]} " =~ " ''${testName} " ]]; then
-        iterations="--max-iterations 5"
+        iterations="--max-iterations 3"
       fi
 
       ${echo}

--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -44,10 +44,6 @@ let
 
   ignored = [
 
-    # --- hevm soundness bug ---
-    # TODO: enable me once https://github.com/dapphub/dapptools/issues/466 is fixed
-    "types/mapping_aliasing_2.sol"
-
     # --- constructor arguments ---
 
     "functions/constructor_hierarchy_3.sol"

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -8,6 +8,8 @@
 - z3 updated to 4.8.7
 - Generate more interesting values in property based testing, 
  and implement proper shrinking for all abi values.
+- Fixed soundness bug when using KECCAK or SHA256 opcode/precompile
+- Fixed an issue in debug mode where backstepping could cause path information to be forgotten
 
 ### Added
 

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed soundness bug when using KECCAK or SHA256 opcode/precompile
 - Fixed an issue in debug mode where backstepping could cause path information to be forgotten
 - Ensure that pathconditions are consistent when branching, and end the execution with VMFailure: DeadPath if this is not the case
+- Fixed a soundness bug where nonzero jumpconditions  were assumed to equal one.
 
 ### Added
 

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -10,6 +10,7 @@
  and implement proper shrinking for all abi values.
 - Fixed soundness bug when using KECCAK or SHA256 opcode/precompile
 - Fixed an issue in debug mode where backstepping could cause path information to be forgotten
+- Ensure that pathconditions are consistent when branching, and end the execution with VMFailure: DeadPath if this is not the case
 
 ### Added
 

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1490,6 +1490,7 @@ askSMT addr pcval jumpcondition continue = do
 
    where -- Only one path is possible
          choosePath (Known w) = do assign result Nothing
+                                   pathConditions <>= [litWord w .== jumpcondition]
                                    iteration <- use (iterations . at (addr, pcval) . non 0)
                                    assign (cache . path . at ((addr, pcval), iteration)) (Just (Known w))
                                    assign (iterations . at (addr, pcval)) (Just (iteration + 1))

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -2549,8 +2549,7 @@ symkeccakN :: SInteger -> SInteger -> SWord 256
 symkeccakN = uninterpret "keccak"
 
 toSInt :: [SWord 8] -> SInteger
-toSInt bs = sum $ zipWith (\a i -> sFromIntegral $ a * 256 ^ i) bs [0..]
-
+toSInt bs = sum $ zipWith (\a i -> sFromIntegral a * 256 ^ i) bs [0..]
 
 -- | Although we'd like to define this directly as an uninterpreted function,
 -- we cannot because [a] is not a symbolic type. We must convert the list into a suitable

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -173,16 +173,16 @@ oracle state info q = do
                           -- No. We are on an inconsistent path.
                           Unsat -> return $ continue EVM.Inconsistent
                           -- Yes. It must be 0.
-                          Sat -> return $ continue (EVM.Known 0)
+                          Sat -> return $ continue (EVM.Iszero True)
                           -- Assume 0 is still possible.
-                          Unk -> return $ continue (EVM.Known 0)
+                          Unk -> return $ continue (EVM.Iszero True)
             -- Sat means its possible for condition
             -- to be nonzero.
             Sat -> do jump <- checksat $ pathconds .&& jumpcondition .== 0
                       -- can it also be zero?
                       case jump of
                         -- No. It must be nonzero
-                        Unsat -> return $ continue (EVM.Known 1)
+                        Unsat -> return $ continue (EVM.Iszero False)
                         -- Yes. Both branches possible
                         Sat -> return $ continue EVM.Unknown
                         -- Explore both branches in case of timeout

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -519,7 +519,7 @@ appEvent st@(ViewVm s) (VtyEvent (V.EvKey (V.KChar 'p') [])) =
 appEvent (ViewVm s) (VtyEvent (V.EvKey (V.KChar '0') [])) =
   case view (uiVm . result) s of
     Just (VMFailure (Choose (PleaseChoosePath contin))) ->
-      takeStep (s & set uiVm (execState (contin 0) (view uiVm s)))
+      takeStep (s & set uiVm (execState (contin True) (view uiVm s)))
         StepNormally
         StepOne
     _ -> continue (ViewVm s)
@@ -528,7 +528,7 @@ appEvent (ViewVm s) (VtyEvent (V.EvKey (V.KChar '0') [])) =
 appEvent (ViewVm s) (VtyEvent (V.EvKey (V.KChar '1') [])) =
   case view (uiVm . result) s of
     Just (VMFailure (Choose (PleaseChoosePath contin))) ->
-      takeStep (s & set uiVm (execState (contin 1) (view uiVm s)))
+      takeStep (s & set uiVm (execState (contin False) (view uiVm s)))
         StepNormally
         StepOne
     _ -> continue (ViewVm s)

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -432,6 +432,24 @@ main = defaultMain $ testGroup "hevm"
             |]
           Left (_, res) <- runSMTWith z3 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
           putStrLn $ "successfully explored: " <> show (length res) <> " paths"
+
+       ,
+
+        testCase "keccak soundness" $ do
+          Just c <- solcRuntime "C"
+            [i|
+              contract C {
+                mapping (uint => mapping (uint => uint)) maps;
+
+                  function f(uint x, uint y) public view {
+                  assert(maps[y][0] == maps[x][0]);
+                }
+              }
+            |]
+          -- should find a counterexample
+          Right counterexample <- runSMTWith cvc4 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
+          putStrLn $ "found counterexample:"
+
     ]
   , testGroup "Equivalence checking"
     [


### PR DESCRIPTION
Fixes #456. I previously failed to add the knowledge gained from queries returning `Known`, thinking that if this only happens when there is only one alternative, in which case we are not really adding any new information. But `Known` can also be the result of a cached choice, so the newly gained knowledge should be stored.