### PR TITLE
hevm: support hls

### DIFF
--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -10,6 +10,8 @@
 {-# Language OverloadedStrings #-}
 {-# Language TypeOperators #-}
 
+module Main where
+
 import qualified EVM
 import EVM.Concrete (createAddress, w256)
 import EVM.Symbolic (forceLitBytes, litBytes, litAddr, w256lit, sw256, SymWord(..), Buffer(..), len)

--- a/src/hevm/hie.yaml
+++ b/src/hevm/hie.yaml
@@ -1,0 +1,8 @@
+cradle:
+  cabal:
+    - path: "./src"
+      component: "lib:hevm"
+    - path: "./hevm-cli"
+      component: "exe:hevm"
+    - path: "./test"
+      component: "test:test"


### PR DESCRIPTION
Some small changes that make `hevm` play nice with the haskell language server

- adds a `Module main where` declaration to `hevm-cli.hs`
- adds an `hie.yaml` file