### PR TITLE
dapp-tests: hevm symbolic: bump smttimeout for factorization

### DIFF
--- a/src/dapp-tests/integration/tests.sh
+++ b/src/dapp-tests/integration/tests.sh
@@ -53,7 +53,7 @@ dapp_testnet
 test_hevm_symbolic() {
     solc --bin-runtime -o . --overwrite factor.sol
     # should find counterexample
-    hevm symbolic --code $(<A.bin-runtime) --sig "factor(uint x, uint y)" && error || echo "hevm success: found counterexample"
+    hevm symbolic --code $(<A.bin-runtime) --sig "factor(uint x, uint y)" --smttimeout 40000 && error || echo "hevm success: found counterexample"
     rm -rf A.bin-runtime
     hevm symbolic --code $(<dstoken.bin-runtime) --sig "transferFrom(address, address, uint)" --get-models
 


### PR DESCRIPTION
Getting intermittent CI failures due to timeouts for this test (e.g. https://github.com/dapphub/dapptools/runs/974387432?check_suite_focus=true).