### PR TITLE
Dynamic buffers

### DIFF
--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -745,7 +745,10 @@ symvmFromCommand cmd = do
           error $ "contract not found."
         Just contract' ->
           return $
-            vm1 calldata' callvalue' caller' (contract'' & set EVM.storage store)
+            vm1 calldata' callvalue' caller'
+                (contract''
+                   & set EVM.storage store
+                   & set EVM.origStorage store)
           where
             contract'' = case code cmd of
               Nothing -> contract'
@@ -761,7 +764,9 @@ symvmFromCommand cmd = do
     (_, _, Just c)  ->
       return $
         vm1 calldata' callvalue' caller' $
-          (EVM.initialContract . codeType $ decipher c) & set EVM.storage store
+          (EVM.initialContract . codeType $ decipher c)
+             & set EVM.storage store
+             & set EVM.origStorage store
     (_, _, Nothing) ->
       error $ "must provide at least (rpc + address) or code"
 

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -2179,7 +2179,6 @@ accessMemoryRange
   -> SymWord
   -> EVM ()
   -> EVM ()
-accessMemoryRange _ _ 0 continue = continue
 accessMemoryRange fees f l continue =
   case (maybeLitWord f, maybeLitWord l) of
     (Just f', Just l') ->

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -207,8 +207,8 @@ data FrameContext
     , creationContextSubstate  :: SubState
     }
   | CallContext
-    { callContextOffset    :: Word
-    , callContextSize      :: Word
+    { callContextOffset    :: SymWord
+    , callContextSize      :: SymWord
     , callContextCodehash  :: W256
     , callContextAbi       :: Maybe Word
     , callContextData      :: Buffer
@@ -249,7 +249,7 @@ data TxState = TxState
 data SubState = SubState
   { _selfdestructs   :: [Addr]
   , _touchedAccounts :: [Addr]
-  , _refunds         :: [(Addr, Word)]
+  , _refunds         :: [(Addr, Word)] -- TODO: make symbolic as well
   -- in principle we should include logs here, but do not for now
   }
 
@@ -288,7 +288,7 @@ data Contract = Contract
   , _opIxMap      :: Vector Int
   , _codeOps      :: RegularVector.Vector (Int, Op)
   , _external     :: Bool
-  , _origStorage  :: Map Word Word
+  , _origStorage  :: Storage
   }
 
 deriving instance Show Contract
@@ -459,7 +459,7 @@ initialContract theContractCode = Contract
   , _opIxMap  = mkOpIxMap theCode
   , _codeOps  = mkCodeOps theCode
   , _external = False
-  , _origStorage = mempty
+  , _origStorage = Concrete mempty
   } where theCode = case theContractCode of
             InitCode b    -> b
             RuntimeCode b -> b
@@ -497,25 +497,25 @@ exec1 = do
 
   if self > 0x0 && self <= 0x9 then do
     -- call to precompile
-    error "hold off precompile for now"
-    -- let ?op = 0x00 -- dummy value
-    -- copyBytesToMemory (the state calldata) (num len (the state calldata)) 0 0
-    -- executePrecompile self (the state gas) 0 (num (len (the state calldata))) 0 0 []
-    -- vmx <- get
-    -- case view (state.stack) vmx of
-    --   (x:_) -> case maybeLitWord x of
-    --     Just 0 -> do
-    --       fetchAccount self $ \_ -> do
-    --         touchAccount self
-    --         vmError PrecompileFailure
-    --     Just _ ->
-    --       fetchAccount self $ \_ -> do
-    --         touchAccount self
-    --         out <- use (state . returndata)
-    --         finishFrame (FrameReturned out)
-    --     Nothing -> vmError UnexpectedSymbolicArg
-    --   _ ->
-    --     underrun
+
+    let ?op = 0x00 -- dummy value
+    copyBytesToMemory (the state calldata) (sw256 $ sFromIntegral $ len (the state calldata)) 0 0
+    executePrecompile self (the state gas) 0 (sw256 $ sFromIntegral $ len (the state calldata)) 0 0 []
+    vmx <- get
+    case view (state.stack) vmx of
+      (x:_) -> case maybeLitWord x of
+        Just 0 -> do
+          fetchAccount self $ \_ -> do
+            touchAccount self
+            vmError PrecompileFailure
+        Just _ ->
+          fetchAccount self $ \_ -> do
+            touchAccount self
+            out <- use (state . returndata)
+            finishFrame (FrameReturned out)
+        Nothing -> vmError UnexpectedSymbolicArg
+      _ ->
+        underrun
 
   else if the state pc >= num (BS.length (the state code))
     then doStop
@@ -558,28 +558,27 @@ exec1 = do
                   assign (ix 0) (stk ^?! ix i)
                   assign (ix i) (stk ^?! ix 0)
 
-        -- -- op: LOG
-        -- x | x >= 0xa0 && x <= 0xa4 ->
-        --   notStatic $
-        --   let n = (num x - 0xa0) in
-        --   case stk of
-        --     (xOffset':xSize':xs) ->
-        --       if length xs < n
-        --       then underrun
-        --       else
-        --         forceConcrete2 (xOffset', xSize') $ \(xOffset, xSize) -> do
-        --             let (topics, xs') = splitAt n xs
-        --                 bytes         = readMemory (num xOffset) (num xSize) vm
-        --                 log           = Log self bytes topics
+        -- op: LOG
+        x | x >= 0xa0 && x <= 0xa4 ->
+          notStatic $
+          let n = (num x - 0xa0) in
+          case stk of
+            (xOffset:xSize:xs) ->
+              if length xs < n
+              then underrun
+              else do
+                    let (topics, xs') = splitAt n xs
+                        bytes         = readMemory xOffset xSize vm
+                        log           = Log self bytes topics
 
-        --             burn (g_log + g_logdata * xSize + num n * g_logtopic) $
-        --               accessMemoryRange fees xOffset xSize $ do
-        --                 traceLog log
-        --                 next
-        --                 assign (state . stack) xs'
-        --                 pushToSequence logs log
-        --     _ ->
-        --       underrun
+                    burnSym (litWord g_log + litWord g_logdata * xSize + litWord (num n * g_logtopic)) $
+                      accessMemoryRange fees xOffset xSize $ do
+                        traceLog log
+                        next
+                        assign (state . stack) xs'
+                        pushToSequence logs log
+            _ ->
+              underrun
 
         -- op: STOP
         0x00 -> doStop
@@ -643,39 +642,38 @@ exec1 = do
         -- op: SAR
         0x1d -> stackOp2 (const g_verylow) $ \((S _ n), (S _ x)) -> sw256 $ sSignedShiftArithRight x n
 
-        -- -- op: SHA3
-        -- -- more accurately refered to as KECCAK
-        -- 0x20 ->
-        --   case stk of
-        --     (xOffset' : xSize' : xs) ->
-        --       forceConcrete xOffset' $
-        --         \xOffset -> forceConcrete xSize' $ \xSize -> do
-        --           (hash, invMap) <- case readMemory xOffset xSize vm of
-        --                              ConcreteBuffer bs -> pure (litWord $ keccakBlob bs, Map.singleton (keccakBlob bs) bs)
+        -- op: SHA3
+        -- more accurately refered to as KECCAK
+        0x20 ->
+          case stk of
+            (xOffset : xSize : xs) -> do
 
-        --                              -- Although we would like to simply assert that the uninterpreted function symkeccak'
-        --                              -- is injective, this proves to cause a lot of concern for our smt solvers, probably
-        --                              -- due to the introduction of universal quantifiers into the queries.
+               (hash, invMap) <- case readMemory xOffset xSize vm of
 
-        --                              -- Instead, we keep track of all of the particular invocations of symkeccak' we see
-        --                              -- (similarly to sha3Crack), and simply assert that injectivity holds for these
-        --                              -- particular invocations.
+                 DynamicSymBuffer bs -> error "currently unsupported: KECCAK of dynamic bytes"
+                 ConcreteBuffer bs -> pure (litWord $ keccakBlob bs, Map.singleton (keccakBlob bs) bs)
 
-        --                              StaticSymBuffer bs -> do
-        --                                            let hash' = symkeccak' bs
-        --                                                previousUsed = view (env . keccakUsed) vm
-        --                                            env . keccakUsed <>= [(bs, hash')]
-        --                                            pathConditions <>= fmap (\(preimage, image) ->
-        --                                                                        image .== hash' .=> preimage .== bs)
-        --                                                                    previousUsed
-        --                                            return (sw256 hash', mempty)
+                 -- Although we would like to simply assert that the uninterpreted function symkeccak'
+                 -- is injective, this proves to cause a lot of concern for our smt solvers, probably
+                 -- due to the introduction of universal quantifiers into the queries.
 
-        --           burn (g_sha3 + g_sha3word * ceilDiv (num xSize) 32) $
-        --             accessMemoryRange fees xOffset xSize $ do
-        --               next
-        --               assign (state . stack) (hash : xs)
-        --               (env . sha3Crack) <>= invMap
-        --     _ -> underrun
+                 -- Instead, we keep track of all of the particular invocations of symkeccak' we see
+                 -- (similarly to sha3Crack), and simply assert that injectivity holds for these
+                 -- particular invocations.
+
+                 StaticSymBuffer bs -> do
+                   let hash' = symkeccak' bs
+                       previousUsed = view (env . keccakUsed) vm
+                   env . keccakUsed <>= [(bs, hash')]
+                   pathConditions <>= flip fmap previousUsed (\(preimg, img) -> img .== hash' .=> preimg .== bs)
+                   return (sw256 hash', mempty)
+
+               burnSym (litWord g_sha3 + litWord g_sha3word * ceilSDiv xSize 32) $
+                 accessMemoryRange fees xOffset xSize $ do
+                   next
+                   assign (state . stack) (hash : xs)
+                   (env . sha3Crack) <>= invMap
+            _ -> underrun
 
         -- op: ADDRESS
         0x30 ->
@@ -929,44 +927,38 @@ exec1 = do
                 if availableGas <= g_callstipend
                   then finishFrame (FrameErrored (OutOfGas availableGas g_callstipend))
                   else do
-                    let original = case view storage this of
-                                  Concrete _ -> fromMaybe 0 (Map.lookup (forceLit x) (view origStorage this))
-                                  Symbolic _ -> 0 -- we don't use this value anywhere anyway
-                        cost = case (maybeLitWord current, maybeLitWord new) of
-                                 (Just current', Just new') ->
-                                    if (current' == new') then g_sload
-                                    else if (current' == original) && (original == 0) then g_sset
-                                    else if (current' == original) then g_sreset
-                                    else g_sload
+                    let original = fromMaybe 0 (readStorage (view origStorage this) x)
 
-                                 -- if any of the arguments are symbolic,
-                                 -- assume worst case scenario
-                                 _ -> g_sset
+                        cost = ite (current .== new) (litWord g_sload)
+                                           (ite (current .== original .&& original .== 0) (litWord g_sset)
+                                                (ite (current .== original) (litWord g_sreset)
+                                                     (litWord g_sload)))
 
-                    burn cost $ do
+                        anticost = ite (current .== new) 0
+                                               (ite (current .== original)
+                                                    (ite (original ./= 0 .&& new .== 0) (litWord r_sclear) 0)
+                                                    (ite (original ./= 0)
+                                                         (ite (new .== 0) (litWord r_sclear) 0)
+                                                         (ite (original .== 0)
+                                                              (litWord (g_sset   - g_sload))
+                                                              (litWord (g_sreset - g_sload)))))
+
+                        unrefund = ite (current ./= new .&&
+                                        current ./= original .&&
+                                        original ./= 0 .&&
+                                        new ./= 0)
+                                       (litWord r_sclear)
+                                       0
+
+                    burnSym cost $ do
                       next
                       assign (state . stack) xs
                       modifying (env . contracts . ix self . storage)
                         (writeStorage x new)
 
-                      case (maybeLitWord current, maybeLitWord new) of
-                         (Just current', Just new') ->
-                            unless (current' == new') $
-                              if current' == original
-                              then when (original /= 0 && new' == 0) $
-                                      refund r_sclear
-                              else do
-                                      when (original /= 0) $
-                                        if new' == 0
-                                        then refund r_sclear
-                                        else unRefund r_sclear
-                                      when (original == new') $
-                                        if original == 0
-                                        then refund (g_sset - g_sload)
-                                        else refund (g_sreset - g_sload)
-                         -- if any of the arguments are symbolic,
-                         -- don't change the refund counter
-                         _ -> noop
+                      refundSym anticost
+                      unRefundSym unrefund
+
             _ -> underrun
 
         -- op: JUMP
@@ -1026,78 +1018,77 @@ exec1 = do
                       (x .|. complement (bit n - 1))
                       (x .&. (bit n - 1))
 
-        -- -- op: CREATE
-        -- 0xf0 ->
-        --   notStatic $
-        --   case stk of
-        --     (xValue' : xOffset' : xSize' : xs) -> forceConcrete3 (xValue', xOffset', xSize') $
-        --       \(xValue, xOffset, xSize) -> do
-        --         accessMemoryRange fees xOffset xSize $ do
-        --           availableGas <- use (state . gas)
-        --           let
-        --             newAddr = createAddress self (wordValue (view nonce this))
-        --             (cost, gas') = costOfCreate fees availableGas 0
-        --           burn (cost - gas') $ forceConcreteBuffer (readMemory (num xOffset) (num xSize) vm) $ \initCode ->
-        --             create self this gas' xValue xs newAddr initCode
-        --     _ -> underrun
+        -- op: CREATE
+        0xf0 ->
+          notStatic $
+          case stk of
+            (xValue : xOffset : xSize : xs) -> forceConcrete xValue $ \xValue' ->
+                accessMemoryRange fees xOffset xSize $ do
+                  availableGas <- use (state . gas)
+                  let
+                    newAddr = createAddress self (wordValue (view nonce this))
+                    (cost, gas') = costOfCreate fees availableGas 0
+                  burn (cost - gas') $ forceConcreteBuffer (readMemory xOffset xSize vm) $ \initCode ->
+                    create self this gas' xValue' xs newAddr initCode
+            _ -> underrun
 
-        -- -- op: CALL
-        -- 0xf1 ->
-        --   case stk of
-        --     ( xGas'
-        --       : xTo'
-        --       : (forceLit -> xValue)
-        --       : xInOffset'
-        --       : xInSize'
-        --       : xOutOffset'
-        --       : xOutSize'
-        --       : xs
-        --      ) -> forceConcrete6 (xGas', xTo', xInOffset', xInSize', xOutOffset', xOutSize') $
-        --       \(xGas, (num -> xTo), xInOffset, xInSize, xOutOffset, xOutSize) ->
-        --       (if xValue > 0 then notStatic else id) $
-        --         case xTo of
-        --           n | n > 0 && n <= 9 ->
-        --             precompiledContract this xGas xTo xTo xValue xInOffset xInSize xOutOffset xOutSize xs
-        --           n | num n == cheatCode ->
-        --             do
-        --               assign (state . stack) xs
-        --               cheat (xInOffset, xInSize) (xOutOffset, xOutSize)
-        --           _ -> delegateCall this xGas xTo xTo xValue xInOffset xInSize xOutOffset xOutSize xs $ do
-        --                     zoom state $ do
-        --                       assign callvalue (litWord xValue)
-        --                       assign caller (litAddr self)
-        --                       assign contract xTo
-        --                     zoom (env . contracts) $ do
-        --                       ix self . balance -= xValue
-        --                       ix xTo  . balance += xValue
-        --                     touchAccount self
-        --                     touchAccount xTo
-        --     _ ->
-        --       underrun
+        -- op: CALL
+        0xf1 ->
+          case stk of
+            ( xGas'
+              : xTo'
+              : xValue'
+              : xInOffset
+              : xInSize
+              : xOutOffset
+              : xOutSize
+              : xs
+             ) -> forceConcrete3 (xGas', xTo', xValue') $
+              \(xGas, (num -> xTo), xValue) ->
+              (if xValue > 0 then notStatic else id) $
+                case xTo of
+                  n | n > 0 && n <= 9 ->
+                    precompiledContract this xGas xTo xTo xValue xInOffset xInSize xOutOffset xOutSize xs
+                  n | num n == cheatCode ->
+                    do
+                      assign (state . stack) xs
+                      cheat xInOffset xInSize xOutOffset xOutSize
+                  _ -> delegateCall this xGas xTo xTo xValue xInOffset xInSize xOutOffset xOutSize xs $ do
+                            zoom state $ do
+                              assign callvalue (litWord xValue)
+                              assign caller (litAddr self)
+                              assign contract xTo
+                            zoom (env . contracts) $ do
+                              ix self . balance -= xValue
+                              ix xTo  . balance += xValue
+                            touchAccount self
+                            touchAccount xTo
+            _ ->
+              underrun
 
-        -- -- op: CALLCODE
-        -- 0xf2 ->
-        --   case stk of
-        --     ( xGas'
-        --       : xTo'
-        --       : (forceLit -> xValue)
-        --       : xInOffset'
-        --       : xInSize'
-        --       : xOutOffset'
-        --       : xOutSize'
-        --       : xs
-        --       ) -> forceConcrete6 (xGas', xTo', xInOffset', xInSize', xOutOffset', xOutSize') $
-        --       \(xGas, (num -> xTo), xInOffset, xInSize, xOutOffset, xOutSize) ->
-        --         case xTo of
-        --           n | n > 0 && n <= 9 ->
-        --             precompiledContract this xGas xTo self xValue xInOffset xInSize xOutOffset xOutSize xs
-        --           _ -> delegateCall this xGas xTo self xValue xInOffset xInSize xOutOffset xOutSize xs $ do
-        --                  zoom state $ do
-        --                    assign callvalue (litWord xValue)
-        --                    assign caller (litAddr self)
-        --                  touchAccount self
-        --     _ ->
-        --       underrun
+        -- op: CALLCODE
+        0xf2 ->
+          case stk of
+            ( xGas'
+              : xTo'
+              : (forceLit -> xValue)
+              : xInOffset
+              : xInSize
+              : xOutOffset
+              : xOutSize
+              : xs
+              ) -> forceConcrete2 (xGas', xTo') $
+              \(xGas, (num -> xTo)) ->
+                case xTo of
+                  n | n > 0 && n <= 9 ->
+                    precompiledContract this xGas xTo self xValue xInOffset xInSize xOutOffset xOutSize xs
+                  _ -> delegateCall this xGas xTo self xValue xInOffset xInSize xOutOffset xOutSize xs $ do
+                         zoom state $ do
+                           assign callvalue (litWord xValue)
+                           assign caller (litAddr self)
+                         touchAccount self
+            _ ->
+              underrun
 
         -- op: RETURN
         0xf3 ->
@@ -1137,96 +1128,96 @@ exec1 = do
                           finishFrame (FrameReturned output)
             _ -> underrun
 
-        -- -- op: DELEGATECALL
-        -- 0xf4 ->
-        --   case stk of
-        --     (xGas'
-        --      :xTo'
-        --      :xInOffset'
-        --      :xInSize'
-        --      :xOutOffset'
-        --      :xOutSize'
-        --      :xs) -> forceConcrete6 (xGas', xTo', xInOffset', xInSize', xOutOffset', xOutSize') $
-        --       \(xGas, (num -> xTo), xInOffset, xInSize, xOutOffset, xOutSize) ->
-        --         case xTo of
-        --           n | n > 0 && n <= 9 ->
-        --             precompiledContract this xGas xTo self 0 xInOffset xInSize xOutOffset xOutSize xs
-        --           n | num n == cheatCode -> do
-        --                 assign (state . stack) xs
-        --                 cheat (xInOffset, xInSize) (xOutOffset, xOutSize)
-        --           _ -> do
-        --                 delegateCall this xGas xTo self 0 xInOffset xInSize xOutOffset xOutSize xs $ do
-        --                   touchAccount self
-        --     _ -> underrun
+        -- op: DELEGATECALL
+        0xf4 ->
+          case stk of
+            (xGas'
+             :xTo'
+             :xInOffset
+             :xInSize
+             :xOutOffset
+             :xOutSize
+             :xs) -> forceConcrete2 (xGas', xTo') $
+              \(xGas, (num -> xTo)) ->
+                case xTo of
+                  n | n > 0 && n <= 9 ->
+                    precompiledContract this xGas xTo self 0 xInOffset xInSize xOutOffset xOutSize xs
+                  n | num n == cheatCode -> do
+                        assign (state . stack) xs
+                        cheat xInOffset xInSize xOutOffset xOutSize
+                  _ -> do
+                        delegateCall this xGas xTo self 0 xInOffset xInSize xOutOffset xOutSize xs $ do
+                          touchAccount self
+            _ -> underrun
 
-        -- -- op: CREATE2
-        -- 0xf5 -> notStatic $
-        --   case stk of
-        --     (xValue'
-        --      :xOffset'
-        --      :xSize'
-        --      :xSalt'
-        --      :xs) -> forceConcrete4 (xValue', xOffset', xSize', xSalt') $
-        --       \(xValue, xOffset, xSize, xSalt) ->
-        --         accessMemoryRange fees xOffset xSize $ do
-        --           availableGas <- use (state . gas)
-        --           forceConcreteBuffer (readMemory (num xOffset) (num xSize) vm) $ \initCode ->
-        --            let
-        --             newAddr  = create2Address self (num xSalt) initCode
-        --             (cost, gas') = costOfCreate fees availableGas xSize
-        --            in burn (cost - gas') $
-        --             create self this gas' xValue xs newAddr initCode
-        --     _ -> underrun
+        -- op: CREATE2
+        0xf5 -> notStatic $
+          case stk of
+            (xValue'
+             :xOffset
+             :xSize'
+             :xSalt'
+             :xs) -> forceConcrete3 (xValue', xSalt', xSize') $
+              \(xValue, xSalt, xSize) ->
+                accessMemoryRange fees xOffset (litWord xSize) $ do
+                  availableGas <- use (state . gas)
+                  forceConcreteBuffer (readMemory xOffset (litWord xSize) vm) $ \initCode ->
+                   let
+                    newAddr  = create2Address self (num xSalt) initCode
+                    (cost, gas') = costOfCreate fees availableGas xSize
+                   in burn (cost - gas') $
+                    create self this gas' xValue xs newAddr initCode
+            _ -> underrun
 
-        -- -- op: STATICCALL
-        -- 0xfa ->
-        --   case stk of
-        --     (xGas'
-        --      :xTo'
-        --      :xInOffset'
-        --      :xInSize'
-        --      :xOutOffset'
-        --      :xOutSize'
-        --      :xs) -> forceConcrete6 (xGas', xTo', xInOffset', xInSize', xOutOffset', xOutSize') $
-        --       \(xGas, (num -> xTo), xInOffset, xInSize, xOutOffset, xOutSize) ->
-        --         case xTo of
-        --           n | n > 0 && n <= 9 ->
-        --             precompiledContract this xGas xTo xTo 0 xInOffset xInSize xOutOffset xOutSize xs
-        --           _ -> delegateCall this xGas xTo xTo 0 xInOffset xInSize xOutOffset xOutSize xs $ do
-        --                     zoom state $ do
-        --                       assign callvalue 0
-        --                       assign caller (litAddr self)
-        --                       assign contract xTo
-        --                       assign static True
-        --                     touchAccount self
-        --                     touchAccount xTo
-        --     _ ->
-        --       underrun
+        -- op: STATICCALL
+        0xfa ->
+          case stk of
+            (xGas'
+             :xTo'
+             :xInOffset
+             :xInSize
+             :xOutOffset
+             :xOutSize
+             :xs) -> forceConcrete2 (xGas', xTo') $
+              \(xGas, (num -> xTo)) -> 
+                case xTo of
+                  n | n > 0 && n <= 9 ->
+                    precompiledContract this xGas xTo xTo 0 xInOffset xInSize xOutOffset xOutSize xs
+                  _ -> delegateCall this xGas xTo xTo 0 xInOffset xInSize xOutOffset xOutSize xs $ do
+                            zoom state $ do
+                              assign callvalue 0
+                              assign caller (litAddr self)
+                              assign contract xTo
+                              assign static True
+                            touchAccount self
+                            touchAccount xTo
+            _ ->
+              underrun
 
-        -- -- op: SELFDESTRUCT
-        -- 0xff ->
-        --   notStatic $
-        --   case stk of
-        --     [] -> underrun
-        --     (xTo':_) -> forceConcrete xTo' $ \(num -> xTo) ->
-        --       let
-        --         funds = view balance this
-        --         recipientExists = accountExists xTo vm
-        --         c_new = if not recipientExists && funds /= 0
-        --                 then num g_selfdestruct_newaccount
-        --                 else 0
-        --       in burn (g_selfdestruct + c_new) $ do
-        --            destructs <- use (tx . substate . selfdestructs)
-        --            unless (elem self destructs) $ refund r_selfdestruct
-        --            selfdestruct self
-        --            touchAccount xTo
+        -- op: SELFDESTRUCT
+        0xff ->
+          notStatic $
+          case stk of
+            [] -> underrun
+            (xTo':_) -> forceConcrete xTo' $ \(num -> xTo) ->
+              let
+                funds = view balance this
+                recipientExists = accountExists xTo vm
+                c_new = if not recipientExists && funds /= 0
+                        then num g_selfdestruct_newaccount
+                        else 0
+              in burn (g_selfdestruct + c_new) $ do
+                   destructs <- use (tx . substate . selfdestructs)
+                   unless (elem self destructs) $ refund r_selfdestruct
+                   selfdestruct self
+                   touchAccount xTo
 
-        --            if funds /= 0
-        --            then fetchAccount xTo $ \_ -> do
-        --                   env . contracts . ix xTo . balance += funds
-        --                   assign (env . contracts . ix self . balance) 0
-        --                   doStop
-        --            else doStop
+                   if funds /= 0
+                   then fetchAccount xTo $ \_ -> do
+                          env . contracts . ix xTo . balance += funds
+                          assign (env . contracts . ix self . balance) 0
+                          doStop
+                   else doStop
 
         -- op: REVERT
         0xfd ->
@@ -1237,39 +1228,37 @@ exec1 = do
                 finishFrame (FrameReverted output)
             _ -> underrun
 
-        xxx -> error $ "unimplemented opcode: " <> show xxx
---          vmError (UnrecognizedOpcode xxx)
+        xxx -> vmError (UnrecognizedOpcode xxx)
 
 -- | Checks a *CALL for failure; OOG, too many callframes, memory access etc.
 callChecks
   :: (?op :: Word8)
-  => Contract -> Word -> Addr -> Word -> Word -> Word -> Word -> Word -> [SymWord]
+  => Contract -> Word -> Addr -> Word -> SymWord -> SymWord -> SymWord -> SymWord -> [SymWord]
    -- continuation with gas avail for call
   -> (Word -> EVM ())
   -> EVM ()
 callChecks this xGas xContext xValue xInOffset xInSize xOutOffset xOutSize xs continue = do
-  error "no calls for now"
-  -- vm <- get
-  -- let fees = view (block . schedule) vm
-  -- accessMemoryRange fees xInOffset xInSize $
-  --   accessMemoryRange fees xOutOffset xOutSize $ do
-  --     availableGas <- use (state . gas)
-  --     let recipientExists = accountExists xContext vm
-  --         (cost, gas') = costOfCall fees recipientExists xValue availableGas xGas
-  --     burn (cost - gas') $ do
-  --       if xValue > view balance this
-  --       then do
-  --         assign (state . stack) (0 : xs)
-  --         assign (state . returndata) mempty
-  --         pushTrace $ ErrorTrace $ BalanceTooLow xValue (view balance this)
-  --         next
-  --       else if length (view frames vm) >= 1024
-  --            then do
-  --              assign (state . stack) (0 : xs)
-  --              assign (state . returndata) mempty
-  --              pushTrace $ ErrorTrace $ CallDepthLimitReached
-  --              next
-  --            else continue gas'
+  vm <- get
+  let fees = view (block . schedule) vm
+  accessMemoryRange fees xInOffset xInSize $
+    accessMemoryRange fees xOutOffset xOutSize $ do
+      availableGas <- use (state . gas)
+      let recipientExists = accountExists xContext vm
+          (cost, gas') = costOfCall fees recipientExists xValue availableGas xGas
+      burn (cost - gas') $ do
+        if xValue > view balance this
+        then do
+          assign (state . stack) (0 : xs)
+          assign (state . returndata) mempty
+          pushTrace $ ErrorTrace $ BalanceTooLow xValue (view balance this)
+          next
+        else if length (view frames vm) >= 1024
+             then do
+               assign (state . stack) (0 : xs)
+               assign (state . returndata) mempty
+               pushTrace $ ErrorTrace $ CallDepthLimitReached
+               next
+             else continue gas'
 
 precompiledContract
   :: (?op :: Word8)
@@ -1278,7 +1267,7 @@ precompiledContract
   -> Addr
   -> Addr
   -> Word
-  -> Word -> Word -> Word -> Word
+  -> SymWord -> SymWord -> SymWord -> SymWord
   -> [SymWord]
   -> EVM ()
 precompiledContract this xGas precompileAddr recipient xValue inOffset inSize outOffset outSize xs =
@@ -1306,159 +1295,159 @@ precompiledContract this xGas precompileAddr recipient xValue inOffset inSize ou
 executePrecompile
   :: (?op :: Word8)
   => Addr
-  -> Word -> Word -> Word -> Word -> Word -> [SymWord]
+  -> Word -> SymWord -> SymWord -> SymWord -> SymWord -> [SymWord]
   -> EVM ()
-executePrecompile preCompileAddr gasCap inOffset inSize outOffset outSize xs = error "no precompile rn" --do _ 
-  -- vm <- get
-  -- let input = readMemory (num inOffset) (num inSize) vm
-  --     fees = view (block . schedule) vm
-  --     cost = costOfPrecompile fees preCompileAddr input
-  --     notImplemented = error $ "precompile at address " <> show preCompileAddr <> " not yet implemented"
-  --     precompileFail = burn (gasCap - cost) $ do
-  --                        assign (state . stack) (0 : xs)
-  --                        pushTrace $ ErrorTrace $ PrecompileFailure
-  --                        next
-  -- if cost > gasCap then
-  --   burn gasCap $ do
-  --     assign (state . stack) (0 : xs)
-  --     next
-  -- else
-  --   burn cost $
-  --     case preCompileAddr of
-  --       -- ECRECOVER
-  --       0x1 ->
-  --        -- TODO: support symbolic variant
-  --        forceConcreteBuffer input $ \input' ->
-  --         case EVM.Precompiled.execute 0x1 (truncpadlit 128 input') 32 of
-  --           Nothing -> do
-  --             -- return no output for invalid signature
-  --             assign (state . stack) (1 : xs)
-  --             assign (state . returndata) mempty
-  --             next
-  --           Just output -> do
-  --             assign (state . stack) (1 : xs)
-  --             assign (state . returndata) (ConcreteBuffer output)
-  --             copyBytesToMemory (ConcreteBuffer output) outSize 0 outOffset
-  --             next
+executePrecompile preCompileAddr gasCap inOffset inSize outOffset outSize xs = do
+  vm <- get
+  let input = readMemory inOffset inSize vm
+      fees = view (block . schedule) vm
+      cost = costOfPrecompile fees preCompileAddr input
+      notImplemented = error $ "precompile at address " <> show preCompileAddr <> " not yet implemented"
+      precompileFail = burn (gasCap - cost) $ do
+                         assign (state . stack) (0 : xs)
+                         pushTrace $ ErrorTrace $ PrecompileFailure
+                         next
+  if cost > gasCap then
+    burn gasCap $ do
+      assign (state . stack) (0 : xs)
+      next
+  else
+    burn cost $
+      case preCompileAddr of
+        -- ECRECOVER
+        0x1 ->
+         -- TODO: support symbolic variant
+         forceConcreteBuffer input $ \input' ->
+          case EVM.Precompiled.execute 0x1 (truncpadlit 128 input') 32 of
+            Nothing -> do
+              -- return no output for invalid signature
+              assign (state . stack) (1 : xs)
+              assign (state . returndata) mempty
+              next
+            Just output -> do
+              assign (state . stack) (1 : xs)
+              assign (state . returndata) (ConcreteBuffer output)
+              copyBytesToMemory (ConcreteBuffer output) outSize 0 outOffset
+              next
 
-  --       -- SHA2-256
-  --       0x2 ->
-  --         let
-  --           hash = case input of
-  --                    ConcreteBuffer input' -> ConcreteBuffer $ BS.pack $ BA.unpack $ (Crypto.hash input' :: Digest SHA256)
-  --                    StaticSymBuffer input' -> StaticSymBuffer $ symSHA256 input'
-  --         in do
-  --           assign (state . stack) (1 : xs)
-  --           assign (state . returndata) hash
-  --           copyBytesToMemory hash outSize 0 outOffset
-  --           next
+        -- SHA2-256
+        0x2 ->
+          let
+            hash = case input of
+                     ConcreteBuffer input' -> ConcreteBuffer $ BS.pack $ BA.unpack $ (Crypto.hash input' :: Digest SHA256)
+                     StaticSymBuffer input' -> StaticSymBuffer $ symSHA256 input'
+          in do
+            assign (state . stack) (1 : xs)
+            assign (state . returndata) hash
+            copyBytesToMemory hash outSize 0 outOffset
+            next
 
-  --       -- RIPEMD-160
-  --       0x3 ->
-  --        -- TODO: support symbolic variant
-  --        forceConcreteBuffer input $ \input' ->
+        -- RIPEMD-160
+        0x3 ->
+         -- TODO: support symbolic variant
+         forceConcreteBuffer input $ \input' ->
 
-  --         let
-  --           padding = BS.pack $ replicate 12 0
-  --           hash' = BS.pack $ BA.unpack (Crypto.hash input' :: Digest RIPEMD160)
-  --           hash  = ConcreteBuffer $ padding <> hash'
-  --         in do
-  --           assign (state . stack) (1 : xs)
-  --           assign (state . returndata) hash
-  --           copyBytesToMemory hash outSize 0 outOffset
-  --           next
+          let
+            padding = BS.pack $ replicate 12 0
+            hash' = BS.pack $ BA.unpack (Crypto.hash input' :: Digest RIPEMD160)
+            hash  = ConcreteBuffer $ padding <> hash'
+          in do
+            assign (state . stack) (1 : xs)
+            assign (state . returndata) hash
+            copyBytesToMemory hash outSize 0 outOffset
+            next
 
-  --       -- IDENTITY
-  --       0x4 -> do
-  --           assign (state . stack) (1 : xs)
-  --           assign (state . returndata) input
-  --           copyCallBytesToMemory input outSize 0 outOffset
-  --           next
+        -- IDENTITY
+        0x4 -> do
+            assign (state . stack) (1 : xs)
+            assign (state . returndata) input
+            copyCallBytesToMemory input outSize 0 outOffset
+            next
 
-  --       -- MODEXP
-  --       0x5 ->
-  --        -- TODO: support symbolic variant
-  --        forceConcreteBuffer input $ \input' ->
+        -- MODEXP
+        0x5 ->
+         -- TODO: support symbolic variant
+         forceConcreteBuffer input $ \input' ->
 
-  --         let
-  --           (lenb, lene, lenm) = parseModexpLength input'
+          let
+            (lenb, lene, lenm) = parseModexpLength input'
 
-  --           output = ConcreteBuffer $
-  --             case (isZero (96 + lenb + lene) lenm input') of
-  --                True ->
-  --                  truncpadlit (num lenm) (asBE (0 :: Int))
-  --                False ->
-  --                  let
-  --                    b = asInteger $ lazySlice 96 lenb $ input'
-  --                    e = asInteger $ lazySlice (96 + lenb) lene $ input'
-  --                    m = asInteger $ lazySlice (96 + lenb + lene) lenm $ input'
-  --                  in
-  --                    padLeft (num lenm) (asBE (expFast b e m))
-  --         in do
-  --           assign (state . stack) (1 : xs)
-  --           assign (state . returndata) output
-  --           copyBytesToMemory output outSize 0 outOffset
-  --           next
+            output = ConcreteBuffer $
+              case (isZero (96 + lenb + lene) lenm input') of
+                 True ->
+                   truncpadlit (num lenm) (asBE (0 :: Int))
+                 False ->
+                   let
+                     b = asInteger $ lazySlice 96 lenb $ input'
+                     e = asInteger $ lazySlice (96 + lenb) lene $ input'
+                     m = asInteger $ lazySlice (96 + lenb + lene) lenm $ input'
+                   in
+                     padLeft (num lenm) (asBE (expFast b e m))
+          in do
+            assign (state . stack) (1 : xs)
+            assign (state . returndata) output
+            copyBytesToMemory output outSize 0 outOffset
+            next
 
-  --       -- ECADD
-  --       0x6 ->
-  --        -- TODO: support symbolic variant
-  --        forceConcreteBuffer input $ \input' ->
-  --          case EVM.Precompiled.execute 0x6 (truncpadlit 128 input') 64 of
-  --         Nothing -> precompileFail
-  --         Just output -> do
-  --           let truncpaddedOutput = ConcreteBuffer $ truncpadlit 64 output
-  --           assign (state . stack) (1 : xs)
-  --           assign (state . returndata) truncpaddedOutput
-  --           copyBytesToMemory truncpaddedOutput outSize 0 outOffset
-  --           next
+        -- ECADD
+        0x6 ->
+         -- TODO: support symbolic variant
+         forceConcreteBuffer input $ \input' ->
+           case EVM.Precompiled.execute 0x6 (truncpadlit 128 input') 64 of
+          Nothing -> precompileFail
+          Just output -> do
+            let truncpaddedOutput = ConcreteBuffer $ truncpadlit 64 output
+            assign (state . stack) (1 : xs)
+            assign (state . returndata) truncpaddedOutput
+            copyBytesToMemory truncpaddedOutput outSize 0 outOffset
+            next
 
-  --       -- ECMUL
-  --       0x7 ->
-  --        -- TODO: support symbolic variant
-  --        forceConcreteBuffer input $ \input' ->
+        -- ECMUL
+        0x7 ->
+         -- TODO: support symbolic variant
+         forceConcreteBuffer input $ \input' ->
 
-  --         case EVM.Precompiled.execute 0x7 (truncpadlit 96 input') 64 of
-  --         Nothing -> precompileFail
-  --         Just output -> do
-  --           let truncpaddedOutput = ConcreteBuffer $ truncpadlit 64 output
-  --           assign (state . stack) (1 : xs)
-  --           assign (state . returndata) truncpaddedOutput
-  --           copyBytesToMemory truncpaddedOutput outSize 0 outOffset
-  --           next
+          case EVM.Precompiled.execute 0x7 (truncpadlit 96 input') 64 of
+          Nothing -> precompileFail
+          Just output -> do
+            let truncpaddedOutput = ConcreteBuffer $ truncpadlit 64 output
+            assign (state . stack) (1 : xs)
+            assign (state . returndata) truncpaddedOutput
+            copyBytesToMemory truncpaddedOutput outSize 0 outOffset
+            next
 
-  --       -- ECPAIRING
-  --       0x8 ->
-  --        -- TODO: support symbolic variant
-  --        forceConcreteBuffer input $ \input' ->
+        -- ECPAIRING
+        0x8 ->
+         -- TODO: support symbolic variant
+         forceConcreteBuffer input $ \input' ->
 
-  --         case EVM.Precompiled.execute 0x8 input' 32 of
-  --         Nothing -> precompileFail
-  --         Just output -> do
-  --           let truncpaddedOutput = ConcreteBuffer $ truncpadlit 32 output
-  --           assign (state . stack) (1 : xs)
-  --           assign (state . returndata) truncpaddedOutput
-  --           copyBytesToMemory truncpaddedOutput outSize 0 outOffset
-  --           next
+          case EVM.Precompiled.execute 0x8 input' 32 of
+          Nothing -> precompileFail
+          Just output -> do
+            let truncpaddedOutput = ConcreteBuffer $ truncpadlit 32 output
+            assign (state . stack) (1 : xs)
+            assign (state . returndata) truncpaddedOutput
+            copyBytesToMemory truncpaddedOutput outSize 0 outOffset
+            next
 
-  --       -- BLAKE2
-  --       0x9 ->
-  --        -- TODO: support symbolic variant
-  --        forceConcreteBuffer input $ \input' -> do
+        -- BLAKE2
+        0x9 ->
+         -- TODO: support symbolic variant
+         forceConcreteBuffer input $ \input' -> do
 
-  --         case (BS.length input', 1 >= BS.last input') of
-  --           (213, True) -> case EVM.Precompiled.execute 0x9 input' 64 of
-  --             Just output -> do
-  --               let truncpaddedOutput = ConcreteBuffer $ truncpadlit 64 output
-  --               assign (state . stack) (1 : xs)
-  --               assign (state . returndata) truncpaddedOutput
-  --               copyBytesToMemory truncpaddedOutput outSize 0 outOffset
-  --               next
-  --             Nothing -> precompileFail
-  --           _ -> precompileFail
+          case (BS.length input', 1 >= BS.last input') of
+            (213, True) -> case EVM.Precompiled.execute 0x9 input' 64 of
+              Just output -> do
+                let truncpaddedOutput = ConcreteBuffer $ truncpadlit 64 output
+                assign (state . stack) (1 : xs)
+                assign (state . returndata) truncpaddedOutput
+                copyBytesToMemory truncpaddedOutput outSize 0 outOffset
+                next
+              Nothing -> precompileFail
+            _ -> precompileFail
 
 
-  --       _   -> notImplemented
+        _   -> notImplemented
 
 truncpadlit :: Int -> ByteString -> ByteString
 truncpadlit n xs = if m > n then BS.take n xs
@@ -1775,10 +1764,20 @@ forceConcreteBuffer (StaticSymBuffer b) continue = case maybeLitBytes b of
 forceConcreteBuffer (ConcreteBuffer b) continue = continue b
 
 -- * Substate manipulation
+refundSym :: SymWord -> EVM ()
+refundSym n = case maybeLitWord n of
+  Nothing -> refund 0 -- TODO: make refunds symbolic
+  Just n' -> refund n'
+
 refund :: Word -> EVM ()
 refund n = do
   self <- use (state . contract)
   pushTo (tx . substate . refunds) (self, n)
+
+unRefundSym :: SymWord -> EVM ()
+unRefundSym n = case maybeLitWord n of
+  Nothing -> unRefund 0 --TODO: make refunds symbolic
+  Just n' -> unRefund n'  
 
 unRefund :: Word -> EVM ()
 unRefund n = do
@@ -1802,41 +1801,39 @@ selfdestruct = pushTo ((tx . substate) . selfdestructs)
 cheatCode :: Addr
 cheatCode = num (keccak "hevm cheat code")
 
--- cheat
---   :: (?op :: Word8)
---   => (Word, Word) -> (Word, Word)
---   -> EVM ()
--- cheat (inOffset, inSize) (outOffset, outSize) = do
---   mem <- use (state . memory)
---   vm <- get
---   let
---     abi = readMemoryWord32 inOffset mem
---     input = readMemory (inOffset + 4) (inSize - 4) vm
---   case fromSized <$> unliteral abi of
---     Nothing -> vmError UnexpectedSymbolicArg
---     Just abi ->
---               case Map.lookup abi cheatActions of
---                 Nothing ->
---                   vmError (BadCheatCode (Just abi))
---                 Just (argTypes, action) ->
---                   case input of
---                     StaticSymBuffer _ -> vmError UnexpectedSymbolicArg
---                     ConcreteBuffer input' ->
---                       case runGetOrFail
---                              (getAbiSeq (length argTypes) argTypes)
---                              (LS.fromStrict input') of
---                         Right ("", _, args) ->
---                           action (toList args) >>= \case
---                             Nothing -> do
---                               next
---                               push 1
---                             Just (encodeAbiValue -> bs) -> do
---                               next
---                               modifying (state . memory)
---                                 (writeMemory (ConcreteBuffer bs) outSize 0 outOffset)
---                               push 1
---                         _ ->
---                           vmError (BadCheatCode (Just abi))
+cheat
+  :: (?op :: Word8)
+  => SymWord -> SymWord -> SymWord -> SymWord
+  -> EVM ()
+cheat inOffset' inSize' outOffset' outSize' =
+  case (maybeLitWord inOffset', maybeLitWord inSize', maybeLitWord outOffset', maybeLitWord outSize') of
+    (Just inOffset, Just inSize, Just outOffset, Just outSize) -> do
+      mem <- use (state . memory)
+      vm <- get
+      let
+        abi' = readMemoryWord32 inOffset' mem
+        input = readMemory (inOffset' + 4) (inSize' - 4) vm
+      forceConcrete (sw256 $ sFromIntegral abi') $ \(num -> abi) -> forceConcreteBuffer input $ \input' ->
+         case Map.lookup abi cheatActions of
+           Nothing ->
+             vmError (BadCheatCode (Just abi))
+           Just (argTypes, action) ->
+              case runGetOrFail
+                     (getAbiSeq (length argTypes) argTypes)
+                     (LS.fromStrict input') of
+                Right ("", _, args) ->
+                  action (toList args) >>= \case
+                    Nothing -> do
+                      next
+                      push 1
+                    Just (encodeAbiValue -> bs) -> do
+                      next
+                      modifying (state . memory)
+                        (writeMemory (ConcreteBuffer bs) outSize' 0 outOffset')
+                      push 1
+                _ ->
+                  vmError (BadCheatCode (Just abi))
+    _ -> vmError UnexpectedSymbolicArg
 
 type CheatAction = ([AbiType], [AbiValue] -> EVM (Maybe AbiValue))
 
@@ -1858,60 +1855,59 @@ cheatActions =
   where
     action s ts f = (abiKeccak s, (ts, f))
 
--- -- * General call implementation ("delegateCall")
--- delegateCall
---   :: (?op :: Word8)
---   => Contract -> Word -> Addr -> Addr -> Word -> Word -> Word -> Word -> Word -> [SymWord]
---   -> EVM ()
---   -> EVM ()
--- delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOutSize xs continue =
---   callChecks this gasGiven xContext xValue xInOffset xInSize xOutOffset xOutSize xs $
---   \xGas -> do
---     vm0 <- get
---     fetchAccount xTo . const $
---       preuse (env . contracts . ix xTo) >>= \case
---         Nothing ->
---           vmError (NoSuchContract xTo)
---         Just target ->
---           burn xGas $ do
---             let newContext = CallContext
---                   { callContextOffset = xOutOffset
---                   , callContextSize = xOutSize
---                   , callContextCodehash = view codehash target
---                   , callContextReversion = view (env . contracts) vm0
---                   , callContextSubState = view (tx . substate) vm0
---                   , callContextAbi =
---                       if xInSize >= 4
---                       then case unliteral $ readMemoryWord32 xInOffset (view (state . memory) vm0)
---                            of Nothing -> Nothing
---                               Just abi -> Just . w256 $ num abi
---                       else Nothing
---                   , callContextData = (readMemory (num xInOffset) (num xInSize) vm0)
---                   }
+-- * General call implementation ("delegateCall")
+delegateCall
+  :: (?op :: Word8)
+  => Contract -> Word -> Addr -> Addr -> Word -> SymWord -> SymWord -> SymWord -> SymWord -> [SymWord]
+  -> EVM ()
+  -> EVM ()
+delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOutSize xs continue =
+  callChecks this gasGiven xContext xValue xInOffset xInSize xOutOffset xOutSize xs $
+  \xGas -> do
+    vm0 <- get
+    fetchAccount xTo . const $
+      preuse (env . contracts . ix xTo) >>= \case
+        Nothing ->
+          vmError (NoSuchContract xTo)
+        Just target ->
+          burn xGas $ do
+            let newContext = CallContext
+                  { callContextOffset = xOutOffset
+                  , callContextSize = xOutSize
+                  , callContextCodehash = view codehash target
+                  , callContextReversion = view (env . contracts) vm0
+                  , callContextSubState = view (tx . substate) vm0
+                  , callContextAbi =
+                      if maybe False (<= 4) $ maybeLitWord xInSize
+                      then do abi <- unliteral $ readMemoryWord32 xInOffset (view (state . memory) vm0)
+                              return $ w256 $ num abi
+                      else Nothing
+                  , callContextData = (readMemory xInOffset xInSize vm0)
+                  }
 
---             pushTrace (FrameTrace newContext)
---             next
---             vm1 <- get
+            pushTrace (FrameTrace newContext)
+            next
+            vm1 <- get
 
---             pushTo frames $ Frame
---               { _frameState = (set stack xs) (view state vm1)
---               , _frameContext = newContext
---               }
+            pushTo frames $ Frame
+              { _frameState = (set stack xs) (view state vm1)
+              , _frameContext = newContext
+              }
 
---             zoom state $ do
---               assign gas xGas
---               assign pc 0
---               assign code (view bytecode target)
---               assign codeContract xTo
---               assign stack mempty
---               assign memory mempty
---               assign memorySize 0
---               assign returndata mempty
---               assign calldata (readMemory (num xInOffset) (num xInSize) vm0, literal (num xInSize))
+            zoom state $ do
+              assign gas xGas
+              assign pc 0
+              assign code (view bytecode target)
+              assign codeContract xTo
+              assign stack mempty
+              assign memory mempty
+              assign memorySize 0
+              assign returndata mempty
+              assign calldata (readMemory xInOffset xInSize vm0)
 
---             continue
+            continue
 
--- -- * Contract creation
+-- * Contract creation
 
 -- EIP 684
 collision :: Maybe Contract -> Bool
@@ -2084,7 +2080,7 @@ finishFrame how = do
       case view frameContext nextFrame of
 
         -- Were we calling?
-        CallContext (num -> outOffset) (num -> outSize) _ _ _ reversion substate' -> do
+        CallContext outOffset outSize _ _ _ reversion substate' -> do
 
           let
             revertContracts = assign (env . contracts) reversion
@@ -2207,13 +2203,11 @@ copyBytesToMemory bs size xOffset yOffset =
             writeMemory bs size xOffset yOffset mem
 
 copyCallBytesToMemory
-  :: Buffer -> Word -> Word -> Word -> EVM ()
-copyCallBytesToMemory bs size xOffset yOffset =
-  if size == 0 then noop
-  else do
-    mem <- use (state . memory)
-    assign (state . memory) $
-      writeMemory bs (sw256 $ smin (literal (num size)) (sFromIntegral (len bs))) (litWord xOffset) (litWord yOffset) mem
+  :: Buffer -> SymWord -> SymWord -> SymWord -> EVM ()
+copyCallBytesToMemory bs size xOffset yOffset = do
+  mem <- use (state . memory)
+  assign (state . memory) $
+    writeMemory bs (smin size (sw256 $ sFromIntegral $ len bs)) xOffset yOffset mem
 
 readMemory :: SymWord -> SymWord -> VM -> Buffer
 readMemory offset size vm = sliceWithZero offset size (view (state . memory) vm)
@@ -2541,47 +2535,52 @@ costOfCreate (FeeSchedule {..}) availableGas hashSize =
 
 -- Gas cost of precompiles
 costOfPrecompile :: FeeSchedule Word -> Addr -> Buffer -> Word
-costOfPrecompile (FeeSchedule {..}) precompileAddr input = error "wait"
-  -- case precompileAddr of
-  --   -- ECRECOVER
-  --   0x1 -> 3000
-  --   -- SHA2-256
-  --   0x2 -> num $ (((len input + 31) `div` 32) * 12) + 60
-  --   -- RIPEMD-160
-  --   0x3 -> num $ (((len input + 31) `div` 32) * 120) + 600
-  --   -- IDENTITY
-  --   0x4 -> num $ (((len input + 31) `div` 32) * 3) + 15
-  --   -- MODEXP
-  --   0x5 -> num $ (f (num (max lenm lenb)) * num (max lene' 1)) `div` (num g_quaddivisor)
-  --     where input' = case input of
-  --             StaticSymBuffer _ -> error "unsupported: symbolic MODEXP gas cost calc"
-  --             ConcreteBuffer b -> b
-  --           (lenb, lene, lenm) = parseModexpLength input'
-  --           lene' | lene <= 32 && ez = 0
-  --                 | lene <= 32 = num (log2 e')
-  --                 | e' == 0 = 8 * (lene - 32)
-  --                 | otherwise = num (log2 e') + 8 * (lene - 32)
+costOfPrecompile (FeeSchedule {..}) precompileAddr input =
+  case precompileAddr of
+    -- ECRECOVER
+    0x1 -> 3000
+    -- SHA2-256
+    0x2 -> num $ (((l input + 31) `div` 32) * 12) + 60
+      where l i = fromMaybe (error "unsupported: dynamic data to SHA256") (unliteral $ len input)
+    -- RIPEMD-160
+    0x3 -> num $ (((l input + 31) `div` 32) * 120) + 600
+      where l i = fromMaybe (error "unsupported: dynamic data to SHA256") (unliteral $ len input)
+    -- IDENTITY
+    0x4 -> num $ (((l input + 31) `div` 32) * 3) + 15
+      where l i = fromMaybe (error "unsupported: dynamic data to SHA256") (unliteral $ len input)
+    -- MODEXP
+    0x5 -> num $ (f (num (max lenm lenb)) * num (max lene' 1)) `div` (num g_quaddivisor)
+      where input' = case input of
+              ConcreteBuffer b -> b
+              _ -> error "unsupported: symbolic MODEXP gas cost calc"
+            (lenb, lene, lenm) = parseModexpLength input'
+            lene' | lene <= 32 && ez = 0
+                  | lene <= 32 = num (log2 e')
+                  | e' == 0 = 8 * (lene - 32)
+                  | otherwise = num (log2 e') + 8 * (lene - 32)
 
-  --           ez = isZero (96 + lenb) lene input'
-  --           e' = w256 $ word $ LS.toStrict $
-  --                  lazySlice (96 + lenb) (min 32 lene) input'
+            ez = isZero (96 + lenb) lene input'
+            e' = w256 $ word $ LS.toStrict $
+                   lazySlice (96 + lenb) (min 32 lene) input'
 
-  --           f :: Integer -> Integer
-  --           f x | x <= 64 = x * x
-  --               | x <= 1024 = (x * x) `div` 4 + 96 * x - 3072
-  --               | otherwise = (x * x) `div` 16 + 480 * x - 199680
-  --   -- ECADD
-  --   0x6 -> g_ecadd
-  --   -- ECMUL
-  --   0x7 -> g_ecmul
-  --   -- ECPAIRING
-  --   0x8 -> num $ ((len input) `div` 192) * (num g_pairing_point) + (num g_pairing_base)
-  --   -- BLAKE2
-  --   0x9 -> let input' = case input of
-  --                        StaticSymBuffer _ -> error "unsupported: symbolic BLAKE2B gas cost calc"
-  --                        ConcreteBuffer b -> b
-  --          in g_fround * (num $ asInteger $ lazySlice 0 4 input')
-  --   _ -> error ("unimplemented precompiled contract " ++ show precompileAddr)
+            f :: Integer -> Integer
+            f x | x <= 64 = x * x
+                | x <= 1024 = (x * x) `div` 4 + 96 * x - 3072
+                | otherwise = (x * x) `div` 16 + 480 * x - 199680
+    -- ECADD
+    0x6 -> g_ecadd
+    -- ECMUL
+    0x7 -> g_ecmul
+    -- ECPAIRING
+    0x8 -> num $ ((l input) `div` 192) * (num g_pairing_point) + (num g_pairing_base)
+      where l i = fromMaybe (error "unsupported: dynamic data to SHA256") (unliteral $ len input)
+    -- BLAKE2
+    0x9 -> let input' = case input of
+                         ConcreteBuffer b -> b
+                         _ -> error "unsupported: symbolic BLAKE2B gas cost calc"
+                         
+           in g_fround * (num $ asInteger $ lazySlice 0 4 input')
+    _ -> error ("unimplemented precompiled contract " ++ show precompileAddr)
 
 -- Gas cost of memory expansion
 memoryCost :: FeeSchedule Word -> Word -> Word

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -466,7 +466,9 @@ initialContract theContractCode = Contract
 
 contractWithStore :: ContractCode -> Storage -> Contract
 contractWithStore theContractCode store =
-  initialContract theContractCode & set storage store
+  initialContract theContractCode
+    & set storage store
+    & set origStorage store
 
 -- * Opcode dispatch (exec1)
 

--- a/src/hevm/src/EVM/ABI.hs
+++ b/src/hevm/src/EVM/ABI.hs
@@ -437,7 +437,7 @@ genAbiValue = \case
    AbiTupleType ts ->
      AbiTuple <$> mapM genAbiValue ts
   where
-    genUInt n = AbiUInt n <$> arbitraryIntegralWithMax n
+    genUInt n = AbiUInt n <$> arbitraryIntegralWithMax (2^n-1)
 
 instance Arbitrary AbiType where
   arbitrary = sized $ \n -> oneof $ -- prevent empty tuples
@@ -533,7 +533,7 @@ listP parser = between (char '[') (char ']') ((do skipSpaces
 -- Essentially a mix between three types of generators:
 -- one that strongly prefers values close to 0, one that prefers values close to max
 -- and one that chooses uniformly.
-arbitraryIntegralWithMax :: (Integral a) => Int -> Gen a
+arbitraryIntegralWithMax :: (Integral a) => Integer -> Gen a
 arbitraryIntegralWithMax maxbound =
   sized $ \s ->
     do let mn = 0 :: Int

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -42,6 +42,7 @@ import qualified Data.Set as Set
 import qualified Data.Vector as Vector
 import qualified EVM.Fetch as Fetch
 import qualified EVM.Stepper as Stepper
+import qualified Data.ByteString as BS
 
 data UiVmState = UiVmState
   { _uiVm             :: VM
@@ -462,7 +463,7 @@ instance SDisplay (SWord 8) where
 
 -- no idea what's going on here
 instance SDisplay Buffer where
-  sexp (SymbolicBuffer x) = sexp x
+  sexp (StaticSymBuffer x) = sexp x
   sexp (ConcreteBuffer x) = sexp x
 
 instance (SDisplay k, SDisplay v) => SDisplay (Map k v) where
@@ -509,10 +510,11 @@ instance SDisplay ByteString where
   sexp = A . txt . pack . show . ByteStringS
 
 sexpMemory :: Buffer -> SExpr Text
-sexpMemory bs =
-  if len bs > 1024
-  then L [A "large-memory", A (txt (len bs))]
-  else sexp bs
+sexpMemory (ConcreteBuffer bs) =
+  if BS.length bs > 1024
+  then L [A "large-memory", A (txt (BS.length bs))]
+  else sexp (ConcreteBuffer bs)
+sexpMemory bs = sexp bs
 
 defaultUnitTestOptions :: MonadIO m => m UnitTestOptions
 defaultUnitTestOptions = do

--- a/src/hevm/src/EVM/Exec.hs
+++ b/src/hevm/src/EVM/Exec.hs
@@ -22,7 +22,7 @@ vmForEthrunCreation :: ByteString -> VM
 vmForEthrunCreation creationCode =
   (makeVm $ VMOpts
     { vmoptContract = initialContract (InitCode creationCode)
-    , vmoptCalldata = (mempty, 0)
+    , vmoptCalldata = mempty
     , vmoptValue = 0
     , vmoptAddress = createAddress ethrunAddress 1
     , vmoptCaller = litAddr ethrunAddress

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -194,11 +194,15 @@ oracle state info model q = do
       case contract of
         Just x  -> case model of
           EVM.ConcreteS -> return $ continue x
-          EVM.InitialS  -> return $ continue $ x & set EVM.storage (EVM.Symbolic $ SBV.sListArray 0 [])
+          EVM.InitialS  -> return $ continue $ x
+             & set EVM.storage (EVM.Symbolic $ SBV.sListArray 0 [])
+             & set EVM.origStorage (EVM.Symbolic $ SBV.sListArray 0 [])
           EVM.SymbolicS -> 
             flip runReaderT state $ SBV.runQueryT $ do
               store <- freshArray_ Nothing
-              return $ continue $ x & set EVM.storage (EVM.Symbolic store)
+              return $ continue $ x
+                & set EVM.storage (EVM.Symbolic store)
+                & set EVM.origStorage (EVM.Symbolic store)
         Nothing -> error ("oracle error: " ++ show q)
 
     --- for other queries (there's only slot left right now) we default to zero or http

--- a/src/hevm/src/EVM/Format.hs
+++ b/src/hevm/src/EVM/Format.hs
@@ -114,7 +114,7 @@ formatBytes b =
     else formatBinary b
 
 formatSBytes :: Buffer -> Text
-formatSBytes (SymbolicBuffer b) = "<" <> pack (show (length b)) <> " symbolic bytes>"
+formatSBytes (StaticSymBuffer b) = "<" <> pack (show (length b)) <> " symbolic bytes>"
 formatSBytes (ConcreteBuffer b) = formatBytes b
 
 formatQString :: ByteString -> Text
@@ -124,7 +124,7 @@ formatString :: ByteString -> Text
 formatString bs = decodeUtf8 (fst (BS.spanEnd (== 0) bs))
 
 formatSString :: Buffer -> Text
-formatSString (SymbolicBuffer bs) = "<" <> pack (show (length bs)) <> " symbolic bytes (string)>"
+formatSString (StaticSymBuffer bs) = "<" <> pack (show (length bs)) <> " symbolic bytes (string)>"
 formatSString (ConcreteBuffer bs) = formatString bs
 
 formatBinary :: ByteString -> Text
@@ -132,7 +132,7 @@ formatBinary =
   (<>) "0x" . decodeUtf8 . toStrict . toLazyByteString . byteStringHex
 
 formatSBinary :: Buffer -> Text
-formatSBinary (SymbolicBuffer bs) = "<" <> pack (show (length bs)) <> " symbolic bytes>"
+formatSBinary (StaticSymBuffer bs) = "<" <> pack (show (length bs)) <> " symbolic bytes>"
 formatSBinary (ConcreteBuffer bs) = formatBinary bs
 
 showTraceTree :: DappInfo -> VM -> Text
@@ -250,7 +250,7 @@ getAbiTypes abi = map (parseTypeName mempty) types
         splitOn "," (dropEnd 1 (last (splitOn "(" abi)))
 
 showCall :: [AbiType] -> Buffer -> Text
-showCall ts (SymbolicBuffer bs) = showValues ts $ SymbolicBuffer (drop 4 bs)
+showCall ts (StaticSymBuffer bs) = showValues ts $ StaticSymBuffer (drop 4 bs)
 showCall ts (ConcreteBuffer bs) = showValues ts $ ConcreteBuffer (BS.drop 4 bs)
 
 showError :: ByteString -> Text
@@ -260,14 +260,14 @@ showError bs = case BS.take 4 bs of
   _             -> formatBinary bs
 
 showValues :: [AbiType] -> Buffer -> Text
-showValues ts (SymbolicBuffer sbs) = "symbolic: " <> (pack . show $ AbiTupleType (fromList ts))
+showValues ts (StaticSymBuffer sbs) = "symbolic: " <> (pack . show $ AbiTupleType (fromList ts))
 showValues ts (ConcreteBuffer bs) =
   case runGetOrFail (getAbiSeq (length ts) ts) (fromStrict bs) of
     Right (_, _, xs) -> showAbiValues xs
     Left (_, _, _)   -> formatBinary bs
 
 showValue :: AbiType -> Buffer -> Text
-showValue t (SymbolicBuffer _) = "symbolic: " <> (pack $ show t)
+showValue t (StaticSymBuffer _) = "symbolic: " <> (pack $ show t)
 showValue t (ConcreteBuffer bs) =
   case runGetOrFail (getAbi t) (fromStrict bs) of
     Right (_, _, x) -> showAbiValue x

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -45,33 +45,31 @@ sbytes1024 = liftA2 (++) sbytes512 sbytes512
 -- We don't assume input types are restricted to their proper range here;
 -- such assumptions should instead be given as preconditions.
 -- This could catch some interesting calldata mismanagement errors.
-symAbiArg :: AbiType -> Query ([SWord 8], SWord 32)
-symAbiArg (AbiUIntType n) | n `mod` 8 == 0 && n <= 256 = do x <- sbytes32
-                                                            return (x, 32)
-                          | otherwise = error "bad type"
+staticAbiArg :: AbiType -> Query [SWord 8]
+staticAbiArg (AbiUIntType n)
+  | n `mod` 8 == 0 && n <= 256 = sbytes32
+  | otherwise = error "bad type"
 
-symAbiArg (AbiIntType n)  | n `mod` 8 == 0 && n <= 256 = do x <- sbytes32
-                                                            return (x, 32)
-                          | otherwise = error "bad type"
-symAbiArg AbiBoolType = do x <- sbytes32
-                           return (x, 32)
+staticAbiArg (AbiIntType n)
+  | n `mod` 8 == 0 && n <= 256 = sbytes32
+  | otherwise = error "bad type"
 
-symAbiArg AbiAddressType = do x <- sbytes32
-                              return (x, 32)
+staticAbiArg AbiBoolType = sbytes32
 
-symAbiArg (AbiBytesType n) | n <= 32 = do x <- sbytes32
-                                          return (x, 32)
-                           | otherwise = error "bad type"
+staticAbiArg AbiAddressType = sbytes32
+
+staticAbiArg (AbiBytesType n)
+  | n <= 32 = sbytes32
+  | otherwise = error "bad type"
 
 -- TODO: is this encoding correct?
 symAbiArg (AbiArrayType len typ) =
-  do args <- mapM symAbiArg (replicate len typ)
-     return (litBytes (encodeAbiValue (AbiUInt 256 (fromIntegral len))) <> (concat $ fst <$> args),
-             32 + (sum $ snd <$> args))
+  do args <- mconcat <$> mapM symAbiArg (replicate len typ)
+     return $ litBytes (encodeAbiValue (AbiUInt 256 (fromIntegral len))) <> args
 
 symAbiArg (AbiTupleType tuple) =
-  do args <- mapM symAbiArg (toList tuple)
-     return (concat $ fst <$> args, sum $ snd <$> args)
+  mconcat <$> mapM symAbiArg (toList tuple)
+
 symAbiArg n =
   error $ "Unsupported symbolic abiencoding for"
     <> show n
@@ -81,34 +79,34 @@ symAbiArg n =
 -- with concrete arguments.
 -- Any argument given as "<symbolic>" or omitted at the tail of the list are
 -- kept symbolic.
-symCalldata :: Text -> [AbiType] -> [String] -> Query ([SWord 8], SWord 32)
-symCalldata sig typesignature concreteArgs =
-  let args = concreteArgs <> replicate (length typesignature - length concreteArgs)  "<symbolic>"
-      mkArg typ "<symbolic>" = symAbiArg typ
-      mkArg typ arg = let n = litBytes . encodeAbiValue $ makeAbiValue typ arg
-                      in return (n, num (length n))
-      sig' = litBytes $ selector sig
-  in do calldatas <- zipWithM mkArg typesignature args
-        return (sig' <> concat (fst <$> calldatas), 4 + (sum $ snd <$> calldatas))
+staticCalldata :: Text -> [AbiType] -> [String] -> Query [SWord 8]
+staticCalldata sig typesignature concreteArgs =
+  concat <$> zipWithM mkArg typesignature args
+  where
+    -- ensure arg length is long enough
+    args = concreteArgs <> replicate (length typesignature - length concreteArgs)  "<symbolic>"
+
+    mkArg :: AbiType -> String -> Query [SWord 8]
+    mkArg typ "<symbolic>" = symAbiArg typ
+    mkArg typ arg = return $ litBytes . encodeAbiValue $ makeAbiValue typ arg
+
+    sig' = litBytes $ selector sig
 
 abstractVM :: Maybe (Text, [AbiType]) -> [String] -> ByteString -> StorageModel -> Query VM
 abstractVM typesignature concreteArgs x storagemodel = do
-  (cd', cdlen, cdconstraint) <-
-    case typesignature of
-      Nothing -> do cd <- sbytes256
-                    len <- freshVar_
-                    return (cd, len, len .<= 256)
-      Just (name, typs) -> do (cd, cdlen) <- symCalldata name typs concreteArgs
-                              return (cd, cdlen, sTrue)
+  cd' <- case typesignature of
+           Nothing -> sbytes256
+           Just (name, typs) -> staticCalldata name typs concreteArgs
+
   symstore <- case storagemodel of
     SymbolicS -> Symbolic <$> freshArray_ Nothing
     InitialS -> Symbolic <$> freshArray_ (Just 0)
     ConcreteS -> return $ Concrete mempty
   c <- SAddr <$> freshVar_
   value' <- sw256 <$> freshVar_
-  return $ loadSymVM (RuntimeCode x) symstore storagemodel c value' (SymbolicBuffer cd', cdlen) & over pathConditions ((<>) [cdconstraint])
+  return $ loadSymVM (RuntimeCode x) symstore storagemodel c value' (StaticSymBuffer cd')
 
-loadSymVM :: ContractCode -> Storage -> StorageModel -> SAddr -> SymWord -> (Buffer, SWord 32) -> VM
+loadSymVM :: ContractCode -> Storage -> StorageModel -> SAddr -> SymWord -> Buffer -> VM
 loadSymVM x initStore model addr callvalue' calldata' =
     (makeVm $ VMOpts
     { vmoptContract = contractWithStore x initStore
@@ -244,9 +242,9 @@ equivalenceCheck bytecodeA bytecodeB maxiter signature' = do
       precaller = preStateA ^. state . caller
       callvalue' = preStateA ^. state . callvalue
       prestorage = preStateA ^?! env . contracts . ix preself . storage
-      (calldata', cdlen) = view (state . calldata) preStateA
+      calldata' = view (state . calldata) preStateA
       pathconds = view pathConditions preStateA
-      preStateB = loadSymVM (RuntimeCode bytecodeB) prestorage SymbolicS precaller callvalue' (calldata', cdlen) & set pathConditions pathconds
+      preStateB = loadSymVM (RuntimeCode bytecodeB) prestorage SymbolicS precaller callvalue' calldata' & set pathConditions pathconds
 
   smtState <- queryState
   (aVMs, bVMs) <- both (\x -> io $ fst <$> runStateT (interpret (Fetch.oracle smtState Nothing SymbolicS) maxiter Stepper.runFully) x)
@@ -292,13 +290,13 @@ both' f (x, y) = (f x, f y)
 
 showCounterexample :: VM -> Maybe (Text, [AbiType]) -> Query ()
 showCounterexample vm maybesig = do
-  let (calldata', cdlen) = view (EVM.state . EVM.calldata) vm
+  let calldata' = view (EVM.state . EVM.calldata) vm
       S _ cvalue = view (EVM.state . EVM.callvalue) vm
       SAddr caller' = view (EVM.state . EVM.caller) vm
-  cdlen' <- num <$> getValue cdlen
+--  cdlen' <- num <$> getValue cdlen
   calldatainput <- case calldata' of
-    SymbolicBuffer cd -> mapM (getValue.fromSized) (take cdlen' cd) >>= return . pack
-    ConcreteBuffer cd -> return $ BS.take cdlen' cd
+    StaticSymBuffer cd -> mapM (getValue.fromSized) cd >>= return . pack
+    ConcreteBuffer cd  -> return $ cd
   callvalue' <- num <$> getValue cvalue
   caller'' <- num <$> getValue caller'
   io $ do

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -95,8 +95,8 @@ staticCalldata sig typesignature concreteArgs =
 abstractVM :: Maybe (Text, [AbiType]) -> [String] -> ByteString -> StorageModel -> Query VM
 abstractVM typesignature concreteArgs x storagemodel = do
   cd' <- case typesignature of
-           Nothing -> sbytes256
-           Just (name, typs) -> staticCalldata name typs concreteArgs
+           Nothing -> DynamicSymBuffer <$> freshVar_
+           Just (name, typs) -> StaticSymBuffer <$> staticCalldata name typs concreteArgs
 
   symstore <- case storagemodel of
     SymbolicS -> Symbolic <$> freshArray_ Nothing
@@ -104,7 +104,7 @@ abstractVM typesignature concreteArgs x storagemodel = do
     ConcreteS -> return $ Concrete mempty
   c <- SAddr <$> freshVar_
   value' <- sw256 <$> freshVar_
-  return $ loadSymVM (RuntimeCode x) symstore storagemodel c value' (StaticSymBuffer cd')
+  return $ loadSymVM (RuntimeCode x) symstore storagemodel c value' cd'
 
 loadSymVM :: ContractCode -> Storage -> StorageModel -> SAddr -> SymWord -> Buffer -> VM
 loadSymVM x initStore model addr callvalue' calldata' =

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -45,20 +45,20 @@ sbytes1024 = liftA2 (++) sbytes512 sbytes512
 -- We don't assume input types are restricted to their proper range here;
 -- such assumptions should instead be given as preconditions.
 -- This could catch some interesting calldata mismanagement errors.
-staticAbiArg :: AbiType -> Query [SWord 8]
-staticAbiArg (AbiUIntType n)
+symAbiArg :: AbiType -> Query [SWord 8]
+symAbiArg (AbiUIntType n)
   | n `mod` 8 == 0 && n <= 256 = sbytes32
   | otherwise = error "bad type"
 
-staticAbiArg (AbiIntType n)
+symAbiArg (AbiIntType n)
   | n `mod` 8 == 0 && n <= 256 = sbytes32
   | otherwise = error "bad type"
 
-staticAbiArg AbiBoolType = sbytes32
+symAbiArg AbiBoolType = sbytes32
 
-staticAbiArg AbiAddressType = sbytes32
+symAbiArg AbiAddressType = sbytes32
 
-staticAbiArg (AbiBytesType n)
+symAbiArg (AbiBytesType n)
   | n <= 32 = sbytes32
   | otherwise = error "bad type"
 
@@ -81,7 +81,7 @@ symAbiArg n =
 -- kept symbolic.
 staticCalldata :: Text -> [AbiType] -> [String] -> Query [SWord 8]
 staticCalldata sig typesignature concreteArgs =
-  concat <$> zipWithM mkArg typesignature args
+  fmap (sig' <>) $ concat <$> zipWithM mkArg typesignature args
   where
     -- ensure arg length is long enough
     args = concreteArgs <> replicate (length typesignature - length concreteArgs)  "<symbolic>"

--- a/src/hevm/src/EVM/Symbolic.hs
+++ b/src/hevm/src/EVM/Symbolic.hs
@@ -198,7 +198,9 @@ dynWriteMemoryPadding zeroList bs1 (S _ n) (S _ src) (S _ dst) bs0 =
 
     a       = SL.take dst' bs0'
     b       = SL.subList bs1' src' n'
-    c       = SL.drop (dst' + n') bs0'
+    c       = ite (dst' + n' .> SL.length bs0)
+                  (SL.nil)
+                  (SL.subList bs0 (dst' + n') (dst' + n' - SL.length bs0))
   in
     a .++ b .++ c
 

--- a/src/hevm/src/EVM/Symbolic.hs
+++ b/src/hevm/src/EVM/Symbolic.hs
@@ -187,6 +187,23 @@ dynWriteMemory bs1 (S _ n) (S _ src) (S _ dst) bs0 =
   in
     a .++ b .++ c
 
+dynWriteMemoryPadding :: SList (WordN 8) -> SList (WordN 8) -> SymWord -> SymWord -> SymWord -> SList (WordN 8) -> SList (WordN 8)
+dynWriteMemoryPadding zeroList bs1 (S _ n) (S _ src) (S _ dst) bs0 =
+  let
+    bs0'    = bs0 .++ zeroList
+    bs1'    = bs1 .++ zeroList
+    n'      = sFromIntegral n
+    src'    = sFromIntegral src
+    dst'    = sFromIntegral dst
+
+    a       = SL.take dst' bs0'
+    b       = SL.subList bs1' src' n'
+    c       = SL.drop (dst' + n') bs0'
+  in
+    a .++ b .++ c
+
+
+
 -- TODO: ensure we actually pad with zeros
 sliceWithZero'' :: SymWord -> SymWord -> SList (WordN 8) -> SList (WordN 8)
 sliceWithZero'' (S _ o) (S _ s) m = SL.subList m (sFromIntegral s) (sFromIntegral o)

--- a/src/hevm/src/EVM/Symbolic.hs
+++ b/src/hevm/src/EVM/Symbolic.hs
@@ -98,25 +98,33 @@ truncpad n xs = if m > n then take n xs
                 else mappend xs (replicate (n - m) 0)
   where m = length xs
 
--- returns undefined stuff when you try to take too much
 takeStatic :: (SymVal a) => Int -> SList a -> [SBV a]
 takeStatic n ls =
   let (x, xs) = SL.uncons ls
   in x:(takeStatic (n - 1) xs)
 
+dropStatic :: (SymVal a) => Int -> SList a -> [SBV a]
+dropStatic n ls =
+  let (x, xs) = SL.uncons ls
+  in x:(takeStatic (n - 1) xs)
+
+-- special case of sliceWithZero when size is known
 truncpad' :: Int -> SList (WordN 8) -> [SWord 8]
-truncpad' n xs =
-  ite
-    (m .> (literal (num n)))
-    (takeStatic n xs)
-    (takeStatic n (xs .++ SL.implode (replicate n 0)))
-  where m = SL.length xs
+truncpad' n xs = case unliteral $ SL.length xs of
+  Just (num -> l) -> if l > n
+                     then takeStatic n xs
+                     else takeStatic n (xs .++ literal (replicate (n - l) 0))
+
+  Nothing -> ite
+               (SL.length xs .> (literal (num n)))
+               (takeStatic n xs)
+               (takeStatic n (xs .++ literal (replicate n 0)))
 
 swordAt :: Int -> [SWord 8] -> SymWord
 swordAt i bs = sw256 . fromBytes $ truncpad 32 $ drop i bs
 
-swordAt' :: SInteger -> SList (WordN 8) -> SymWord
-swordAt' i bs = sw256 . fromBytes $ truncpad' 32 $ SL.drop i bs
+swordAt' :: SWord 32 -> SList (WordN 8) -> SymWord
+swordAt' i bs = sw256 . fromBytes $ truncpad' 32 $ SL.drop (sFromIntegral i) bs
 
 readByteOrZero' :: Int -> [SWord 8] -> SWord 8
 readByteOrZero' i bs = fromMaybe 0 (bs ^? ix i)
@@ -132,7 +140,7 @@ writeMemory' bs1 (C _ n) (C _ src) (C _ dst) bs0 =
     c      = if src > num (length bs1)
              then replicate (num n) 0
              else sliceWithZero' (num src) (num n) bs1
-    b'     = drop (num (n)) b
+    b'     = drop (num n) b
   in
     a <> a' <> c <> b'
 
@@ -166,51 +174,17 @@ readByteOrZero'' i bs =
   (bs .!! (sFromIntegral i))
   (literal 0)
 
--- Warning: if (length bs0) < dst or (length bs1) < src + n we can get `havoc` garbage in the resulting
--- list. It should really be 0. If we could write the following function, we could pad appropriately:
--- replicate :: (SymVal a) => SInteger -> SBV a -> SList a
--- but I can't really write this...
--- 
--- TODO: make sure we enforce this condition before calling this
-dynWriteMemory :: SList (WordN 8) -> SymWord -> SymWord -> SymWord -> SList (WordN 8) -> SList (WordN 8)
-dynWriteMemory bs1 (S _ n) (S _ src) (S _ dst) bs0 =
+
+dynWriteMemory :: Buffer -> SymWord -> SymWord -> SymWord -> Buffer -> Buffer
+dynWriteMemory bs1 n@(S _ n') src@(S _ src') dst@(S _ dst') bs0 =
   let
-    n'      = sFromIntegral n
-    src'    = sFromIntegral src
-    dst'    = sFromIntegral dst
-
-    a       = SL.take dst' bs0
-    b       = SL.subList bs1 src' n'
-    c       = ite (dst' + n' .> SL.length bs0)
-              (SL.nil)
-              (SL.drop (dst' + n') bs0)
+    a       = sliceWithZero 0 dst bs0
+    b       = sliceWithZero src n bs1
+    c       = sliceWithZero (dst + n)
+                (sw256 (sFromIntegral (len bs0)) - (dst + n))
+                bs0
   in
-    a .++ b .++ c
-
-dynWriteMemoryPadding :: SList (WordN 8) -> SList (WordN 8) -> SymWord -> SymWord -> SymWord -> SList (WordN 8) -> SList (WordN 8)
-dynWriteMemoryPadding zeroList bs1 (S _ n) (S _ src) (S _ dst) bs0 =
-  let
-    bs0'    = bs0 .++ zeroList
-    bs1'    = bs1 .++ zeroList
-    n'      = sFromIntegral n
-    src'    = sFromIntegral src
-    dst'    = sFromIntegral dst
-
-    a       = SL.take dst' bs0'
-    b       = SL.subList bs1' src' n'
-    c       = ite (dst' + n' .> SL.length bs0)
-                  (SL.nil)
-                  (SL.subList bs0 (dst' + n') (dst' + n' - SL.length bs0))
-  in
-    a .++ b .++ c
-
-
-
--- TODO: ensure we actually pad with zeros
-sliceWithZero'' :: SymWord -> SymWord -> SList (WordN 8) -> SList (WordN 8)
-sliceWithZero'' (S _ o) (S _ s) m = SL.subList m (sFromIntegral s) (sFromIntegral o)
-
-
+    a <> b <> c
 
 -- readMemoryWord' :: Word -> [SWord 8] -> SymWord
 -- readMemoryWord' (C _ i) m = sw256 $ fromBytes $ truncpad 32 (drop (num i) m)
@@ -218,9 +192,9 @@ sliceWithZero'' (S _ o) (S _ s) m = SL.subList m (sFromIntegral s) (sFromIntegra
 -- readMemoryWord32' :: Word -> [SWord 8] -> SWord 32
 -- readMemoryWord32' (C _ i) m = fromBytes $ truncpad 4 (drop (num i) m)
 
--- setMemoryWord' :: Word -> SymWord -> [SWord 8] -> [SWord 8]
--- setMemoryWord' (C _ i) (S _ x) =
---   writeMemory' (toBytes x) 32 0 (num i)
+setMemoryWord'' :: SWord 32 -> SymWord -> Buffer -> Buffer
+setMemoryWord'' i (S _ x) =
+  dynWriteMemory (StaticSymBuffer $ toBytes x) 32 0 (sw256 (sFromIntegral i))
 
 -- setMemoryByte' :: Word -> SWord 8 -> [SWord 8] -> [SWord 8]
 -- setMemoryByte' (C _ i) x =
@@ -295,13 +269,13 @@ readByteOrZero i (StaticSymBuffer bs) = readByteOrZero' i bs
 readByteOrZero i (ConcreteBuffer bs) = num $ Concrete.readByteOrZero i bs
 readByteOrZero i (DynamicSymBuffer bs) = readByteOrZero'' (literal $ num i) bs
 
+-- pad up to 10000 bytes in the dynamic case
 sliceWithZero :: SymWord -> SymWord -> Buffer -> Buffer
-sliceWithZero o s bf = case (maybeLitWord o, maybeLitWord s, bf) of
-  (Just o', Just s', StaticSymBuffer m) -> StaticSymBuffer (sliceWithZero' (num o') (num s') m)
-  (Just o', Just s', ConcreteBuffer m) -> ConcreteBuffer (Concrete.byteStringSliceWithDefaultZeroes (num o') (num s') m)
-sliceWithZero o s (StaticSymBuffer bf) = DynamicSymBuffer $ sliceWithZero'' o s (SL.implode bf)
-sliceWithZero o s (ConcreteBuffer bf) = DynamicSymBuffer $ sliceWithZero'' o s (SL.implode (litBytes bf))
-sliceWithZero o s (DynamicSymBuffer bf) = DynamicSymBuffer $ sliceWithZero'' o s bf
+sliceWithZero (S _ o) (S _ s) bf = case (unliteral o, unliteral s, bf) of
+  (Just o', Just s', StaticSymBuffer m)  -> StaticSymBuffer (sliceWithZero' (num o') (num s') m)
+  (Just o', Just s', ConcreteBuffer m)   -> ConcreteBuffer (Concrete.byteStringSliceWithDefaultZeroes (num o') (num s') m)
+  (_,       Just s', m)                  -> StaticSymBuffer $ truncpad' (num s') $ SL.drop (sFromIntegral o) (dynamize m)
+  _ -> DynamicSymBuffer $ SL.subList (dynamize bf .++ literal (replicate 10000 0)) (sFromIntegral o) (sFromIntegral s)
 
 writeMemory :: Buffer -> SymWord -> SymWord -> SymWord -> Buffer -> Buffer
 writeMemory bs1 n src dst bs0 =
@@ -314,23 +288,24 @@ writeMemory bs1 n src dst bs0 =
       StaticSymBuffer $ writeMemory' (litBytes bs0') n' src' dst' bs1'
     (Just n', Just src', Just dst', StaticSymBuffer bs0', StaticSymBuffer bs1') ->
       StaticSymBuffer $ writeMemory' bs0' n' src' dst' bs1'
-    _ -> let bs0' = dynamize bs0
-             bs1' = dynamize bs1
-         in DynamicSymBuffer $ dynWriteMemory bs0' n src dst bs1'
+    _ -> dynWriteMemory bs0 n src dst bs1
 
-readMemoryWord :: Word -> Buffer -> SymWord
-readMemoryWord i (StaticSymBuffer m) = readMemoryWord' i m
-readMemoryWord i (ConcreteBuffer m) = litWord $ Concrete.readMemoryWord i m
+readMemoryWord :: SWord 32 -> Buffer -> SymWord
+readMemoryWord i bf = case (unliteral i, bf) of
+  (Just i', StaticSymBuffer m) -> readMemoryWord' (num i') m
+  (Just i',  ConcreteBuffer m) -> litWord $ Concrete.readMemoryWord (num i') m
+  _ -> swordAt' i (dynamize bf)
 
 readMemoryWord32 :: Word -> Buffer -> SWord 32
 readMemoryWord32 i (StaticSymBuffer m) = readMemoryWord32' i m
 readMemoryWord32 i (ConcreteBuffer m) = num $ Concrete.readMemoryWord32 i m
 
-setMemoryWord :: Word -> SymWord -> Buffer -> Buffer
-setMemoryWord i x (StaticSymBuffer z) = StaticSymBuffer $ setMemoryWord' i x z
-setMemoryWord i x (ConcreteBuffer z) = case maybeLitWord x of
-  Just x' -> ConcreteBuffer $ Concrete.setMemoryWord i x' z
-  Nothing -> StaticSymBuffer $ setMemoryWord' i x (litBytes z)
+setMemoryWord :: SWord 32 -> SymWord -> Buffer -> Buffer
+setMemoryWord i x bf = case (unliteral i, maybeLitWord x, bf) of
+  (Just i', Just x', ConcreteBuffer z) -> ConcreteBuffer $ Concrete.setMemoryWord (num i') x' z
+  (Just i', _, ConcreteBuffer z) -> StaticSymBuffer $ setMemoryWord' (num i') x (litBytes z)
+  (Just i', _, StaticSymBuffer z) -> StaticSymBuffer $ setMemoryWord' (num i') x z
+  _ -> setMemoryWord'' i x bf
 
 setMemoryByte :: Word -> SWord 8 -> Buffer -> Buffer
 setMemoryByte i x (StaticSymBuffer m) = StaticSymBuffer $ setMemoryByte' i x m

--- a/src/hevm/src/EVM/Symbolic.hs
+++ b/src/hevm/src/EVM/Symbolic.hs
@@ -143,10 +143,13 @@ swordAt :: Int -> [SWord 8] -> SymWord
 swordAt i bs = sw256 . fromBytes $ truncpad 32 $ drop i bs
 
 swordAt' :: SWord 32 -> SList (WordN 8) -> SymWord
-swordAt' i bs = case truncpad' 32 $ dropS (sw256 $ sFromIntegral i) bs of
-  ConcreteBuffer s -> litWord $ Concrete.w256 $ Concrete.wordAt 0 s
-  StaticSymBuffer s -> sw256 $ fromBytes s
-  DynamicSymBuffer s -> sw256 $ fromBytes [s .!! literal i | i <- [0..31]]
+swordAt' i bs =
+ ite (SL.length bs .<= sFromIntegral i)
+ (sw256 0)
+ (case truncpad' 32 $ dropS (sw256 $ sFromIntegral i) bs of
+   ConcreteBuffer s -> litWord $ Concrete.w256 $ Concrete.wordAt 0 s
+   StaticSymBuffer s -> sw256 $ fromBytes s
+   DynamicSymBuffer s -> sw256 $ fromBytes [s .!! literal i | i <- [0..31]])
 
 readByteOrZero' :: Int -> [SWord 8] -> SWord 8
 readByteOrZero' i bs = fromMaybe 0 (bs ^? ix i)

--- a/src/hevm/src/EVM/Symbolic.hs
+++ b/src/hevm/src/EVM/Symbolic.hs
@@ -98,33 +98,55 @@ truncpad n xs = if m > n then take n xs
                 else mappend xs (replicate (n - m) 0)
   where m = length xs
 
-takeStatic :: (SymVal a) => Int -> SList a -> [SBV a]
-takeStatic n ls =
-  let (x, xs) = SL.uncons ls
-  in x:(takeStatic (n - 1) xs)
+-- | Is the list concretely known empty?
+isConcretelyEmpty :: SymVal a => SList a -> Bool
+isConcretelyEmpty sl | Just l <- unliteral sl = null l
+                     | True                   = False
 
+-- must only be called when list length is concrete
+takeStatic :: (SymVal a) => Int -> SList a -> [SBV a]
+takeStatic 0 ls = []
+takeStatic n ls = 
+  if isConcretelyEmpty ls
+  then []
+  else case unliteral $ SL.length ls of
+    Nothing -> error "takeStatic must know the length of the list"
+    Just l -> if l == 0 then [] else
+      let (x, xs) = SL.uncons ls
+      in x:(takeStatic (n - 1) xs)
+
+-- must only be called when list length is concrete
 dropStatic :: (SymVal a) => Int -> SList a -> [SBV a]
 dropStatic n ls =
-  let (x, xs) = SL.uncons ls
-  in x:(takeStatic (n - 1) xs)
+  if isConcretelyEmpty ls
+  then []
+  else case unliteral $ SL.length ls of
+    Nothing -> error "dropStatic must know the length of the list"
+    Just l -> if l == 0 then [] else
+      if n == 0
+      then takeStatic (num l) ls
+      else let (_, xs) = SL.uncons ls
+           in (dropStatic (n - 1) xs)
 
 -- special case of sliceWithZero when size is known
-truncpad' :: Int -> SList (WordN 8) -> [SWord 8]
+truncpad' :: Int -> SList (WordN 8) -> Buffer
 truncpad' n xs = case unliteral $ SL.length xs of
-  Just (num -> l) -> if l > n
-                     then takeStatic n xs
-                     else takeStatic n (xs .++ literal (replicate (n - l) 0))
+  Just (num -> l) -> StaticSymBuffer $ if l > n
+                                       then takeStatic n xs
+                                       else takeStatic n (xs .++ literal (replicate (n - l) 0))
 
-  Nothing -> ite
-               (SL.length xs .> (literal (num n)))
-               (takeStatic n xs)
-               (takeStatic n (xs .++ literal (replicate n 0)))
+  Nothing -> DynamicSymBuffer $ ite
+               (SL.length xs .> literal (num n))
+               (SL.take (literal (num n)) xs)
+               (SL.take (literal (num n)) (xs .++ literal (replicate n 0)))
 
 swordAt :: Int -> [SWord 8] -> SymWord
 swordAt i bs = sw256 . fromBytes $ truncpad 32 $ drop i bs
 
 swordAt' :: SWord 32 -> SList (WordN 8) -> SymWord
-swordAt' i bs = sw256 . fromBytes $ truncpad' 32 $ SL.drop (sFromIntegral i) bs
+swordAt' i bs = case truncpad' 32 $ SL.drop (sFromIntegral i) bs of
+  StaticSymBuffer s -> sw256 $ fromBytes s
+  DynamicSymBuffer s -> error "todo"
 
 readByteOrZero' :: Int -> [SWord 8] -> SWord 8
 readByteOrZero' i bs = fromMaybe 0 (bs ^? ix i)
@@ -165,9 +187,6 @@ readSWord' (C _ i) x =
   else swordAt (num i) x
 
 -- | Operations over dynamic symbolic memory (smt list of bytes)
-swordAt'' :: SWord 32 -> SList (WordN 8) -> SymWord
-swordAt'' i bs = sw256 . fromBytes $ truncpad' 32 $ SL.drop (sFromIntegral i) bs
-
 readByteOrZero'' :: SWord 32 -> SList (WordN 8) -> SWord 8
 readByteOrZero'' i bs =
   ite (SL.length bs .> (sFromIntegral i + 1))
@@ -180,9 +199,8 @@ dynWriteMemory bs1 n@(S _ n') src@(S _ src') dst@(S _ dst') bs0 =
   let
     a       = sliceWithZero 0 dst bs0
     b       = sliceWithZero src n bs1
-    c       = sliceWithZero (dst + n)
-                (sw256 (sFromIntegral (len bs0)) - (dst + n))
-                bs0
+    c       = ditchS (sFromIntegral $ dst' + n') bs0
+
   in
     a <> b <> c
 
@@ -233,7 +251,6 @@ instance EqSymbolic Buffer where
   StaticSymBuffer a .== StaticSymBuffer b = a .== b
   a .== b = dynamize a .== dynamize b
 
-
 instance Semigroup Buffer where
   ConcreteBuffer a     <> ConcreteBuffer b   = ConcreteBuffer (a <> b)
   ConcreteBuffer a     <> StaticSymBuffer b  = StaticSymBuffer (litBytes a <> b)
@@ -264,6 +281,11 @@ ditch n (StaticSymBuffer bs) = StaticSymBuffer $ drop n bs
 ditch n (ConcreteBuffer bs) = ConcreteBuffer $ BS.drop n bs
 ditch n (DynamicSymBuffer bs) = DynamicSymBuffer $ SL.drop (literal $ num n) bs
 
+ditchS :: SInteger -> Buffer -> Buffer
+ditchS n bs = case unliteral n of
+  Nothing -> DynamicSymBuffer $ SL.drop n (dynamize bs)
+  Just n -> ditch (num n) bs
+
 readByteOrZero :: Int -> Buffer -> SWord 8
 readByteOrZero i (StaticSymBuffer bs) = readByteOrZero' i bs
 readByteOrZero i (ConcreteBuffer bs) = num $ Concrete.readByteOrZero i bs
@@ -272,10 +294,10 @@ readByteOrZero i (DynamicSymBuffer bs) = readByteOrZero'' (literal $ num i) bs
 -- pad up to 10000 bytes in the dynamic case
 sliceWithZero :: SymWord -> SymWord -> Buffer -> Buffer
 sliceWithZero (S _ o) (S _ s) bf = case (unliteral o, unliteral s, bf) of
-  (Just o', Just s', StaticSymBuffer m)  -> StaticSymBuffer (sliceWithZero' (num o') (num s') m)
-  (Just o', Just s', ConcreteBuffer m)   -> ConcreteBuffer (Concrete.byteStringSliceWithDefaultZeroes (num o') (num s') m)
-  (_,       Just s', m)                  -> StaticSymBuffer $ truncpad' (num s') $ SL.drop (sFromIntegral o) (dynamize m)
-  _ -> DynamicSymBuffer $ SL.subList (dynamize bf .++ literal (replicate 10000 0)) (sFromIntegral o) (sFromIntegral s)
+  (Just o', Just s', StaticSymBuffer m) -> StaticSymBuffer (sliceWithZero' (num o') (num s') m)
+  (Just o', Just s', ConcreteBuffer m)  -> ConcreteBuffer (Concrete.byteStringSliceWithDefaultZeroes (num o') (num s') m)
+  (Just o', Just s', m)                 -> DynamicSymBuffer $ SL.subList (dynamize m .++ literal (replicate (num (s' + o')) 0)) (sFromIntegral o) (sFromIntegral s)
+  _                                     -> DynamicSymBuffer $ SL.subList (dynamize bf .++ literal (replicate 10000 0)) (sFromIntegral o) (sFromIntegral s)
 
 writeMemory :: Buffer -> SymWord -> SymWord -> SymWord -> Buffer -> Buffer
 writeMemory bs1 n src dst bs0 =

--- a/src/hevm/src/EVM/Symbolic.hs
+++ b/src/hevm/src/EVM/Symbolic.hs
@@ -10,7 +10,6 @@ import qualified Data.ByteString as BS
 import Data.ByteString (ByteString)
 import Control.Lens hiding (op, (:<), (|>), (.>))
 import Data.Maybe                   (fromMaybe, fromJust)
-
 import EVM.Types
 import EVM.Concrete (Word (..), Whiff(..))
 import qualified EVM.Concrete as Concrete
@@ -92,7 +91,7 @@ sgt :: SymWord -> SymWord -> SymWord
 sgt (S _ x) (S _ y) =
   sw256 $ ite (sFromIntegral x .> (sFromIntegral y :: (SInt 256))) 1 0
 
--- | Operations over symbolic memory (list of symbolic bytes)
+-- | Operations over static symbolic memory (list of symbolic bytes)
 swordAt :: Int -> [SWord 8] -> SymWord
 swordAt i bs = sw256 . fromBytes $ truncpad 32 $ drop i bs
 
@@ -134,106 +133,134 @@ readSWord' (C _ i) x =
   then 0
   else swordAt (num i) x
 
+-- | Operations over dynamic symbolic memory (smt array of symbolic bytes)
+swordAt'' :: SWord 32 -> SArray (WordN 32) (WordN 8) -> SymWord
+swordAt'' i bs = sw256 . fromBytes $ zipWith readArray bs [i + b | b <- [0..31]]
 
-select' :: (Ord b, Num b, SymVal b, Mergeable a) => [a] -> a -> SBV b -> a
-select' xs err ind = walk xs ind err
-    where walk []     _ acc = acc
-          walk (e:es) i acc = walk es (i-1) (ite (i .== 0) e acc)
+readByteOrZero'' :: SWord 32 -> [SWord 8] -> SWord 8
+readByteOrZero'' i bs = readArray bs i
 
--- Generates a ridiculously large set of constraints (roughly 25k) when
--- the index is symbolic, but it still seems (kind of) manageable
--- for the solvers.
-readSWordWithBound :: SWord 32 -> Buffer -> SWord 32 -> SymWord
-readSWordWithBound ind (SymbolicBuffer xs) bound =
-  let boundedList = [ite (i .<= bound) x 0 | (x, i) <- zip xs [1..]]
-  in sw256 . fromBytes $ [select' boundedList 0 (ind + j) | j <- [0..31]]
-readSWordWithBound ind (ConcreteBuffer xs) bound =
-  case fromSized <$> unliteral ind of
-    Nothing -> readSWordWithBound ind (SymbolicBuffer (litBytes xs)) bound
-    Just x' ->                                       
-       -- INVARIANT: bound should always be length xs for concrete bytes
-       -- so we should be able to safely ignore it here
-         litWord $ Concrete.readMemoryWord (num x') xs
+-- sliceWithZero'' :: Int -> Int -> [SWord 8] -> [SWord 8]
+-- sliceWithZero'' o s m = truncpad s $ drop o m
 
+dynWriteMemory :: SArray (WordN 32) (WordN 8) -> SymWord -> SymWord -> Word -> [SWord 8] -> [SWord 8]
+dynWriteMemory bs1 (C _ n) (C _ src) (C _ dst) bs0 =
+  let
+    (a, b) = splitAt (num dst) bs0
+    a'     = replicate (num dst - length a) 0
+    c      = if src > num (length bs1)
+             then replicate (num n) 0
+             else sliceWithZero' (num src) (num n) bs1
+    b'     = drop (num (n)) b
+  in
+    a <> a' <> c <> b'
+
+readMemoryWord' :: Word -> [SWord 8] -> SymWord
+readMemoryWord' (C _ i) m = sw256 $ fromBytes $ truncpad 32 (drop (num i) m)
+
+readMemoryWord32' :: Word -> [SWord 8] -> SWord 32
+readMemoryWord32' (C _ i) m = fromBytes $ truncpad 4 (drop (num i) m)
+
+setMemoryWord' :: Word -> SymWord -> [SWord 8] -> [SWord 8]
+setMemoryWord' (C _ i) (S _ x) =
+  writeMemory' (toBytes x) 32 0 (num i)
+
+setMemoryByte' :: Word -> SWord 8 -> [SWord 8] -> [SWord 8]
+setMemoryByte' (C _ i) x =
+  writeMemory' [x] 1 0 (num i)
+
+readSWord' :: Word -> [SWord 8] -> SymWord
+readSWord' (C _ i) x =
+  if i > num (length x)
+  then 0
+  else swordAt (num i) x
 
 -- | Operations over buffers (concrete or symbolic)
 
 -- | A buffer is a list of bytes. For concrete execution, this is simply `ByteString`.
--- In symbolic settings, it is a list of symbolic bitvectors of size 8.
+-- In symbolic settings, its structure is sometimes known statically,
+-- and sometimes only determined dynamically.
+-- In the static case, it's a simple list of symbolic bitvectors of size 8.
+-- In the dynamic case, it's a pair of an SMT array and a symbolic word representing
+-- the buffer length.
 data Buffer
   = ConcreteBuffer ByteString
-  | SymbolicBuffer [SWord 8]
+  | StaticSymBuffer [SWord 8]
+  | DynamicSymBuffer (SArray (WordN 32) (WordN 8), SWord 32)
   deriving (Show)
 
-instance Semigroup Buffer where
-  ConcreteBuffer a <> ConcreteBuffer b = ConcreteBuffer (a <> b)
-  ConcreteBuffer a <> SymbolicBuffer b = SymbolicBuffer (litBytes a <> b)
-  SymbolicBuffer a <> ConcreteBuffer b = SymbolicBuffer (a <> litBytes b)
-  SymbolicBuffer a <> SymbolicBuffer b = SymbolicBuffer (a <> b)
-
-instance Monoid Buffer where
-  mempty = ConcreteBuffer mempty
+dynamize :: Buffer -> Buffer
+dynamize (ConcreteBuffer a)  = dynamize $ StaticSymBuffer (litBytes a)
+dynamize (DynamicSymBuffer a) = DynamicSymBuffer a
+dynamize (StaticSymBuffer a) =
+  DynamicSymBuffer (sListArray (Just 0) $ zip [0..] a, literal . num $ length a)
 
 instance EqSymbolic Buffer where
   ConcreteBuffer a .== ConcreteBuffer b = literal (a == b)
-  ConcreteBuffer a .== SymbolicBuffer b = litBytes a .== b
-  SymbolicBuffer a .== ConcreteBuffer b = a .== litBytes b
-  SymbolicBuffer a .== SymbolicBuffer b = a .== b
+  ConcreteBuffer a .== StaticSymBuffer b = litBytes a .== b
+  StaticSymBuffer a .== ConcreteBuffer b = a .== litBytes b
+  StaticSymBuffer a .== StaticSymBuffer b = a .== b
+  DynamicSymBuffer a .== DynamicSymBuffer b = a .== b
+  a .== b = dynamize a .== dynamize b
 
 
 -- a whole foldable instance seems overkill, but length is always good to have!
-len :: Buffer -> Int
-len (SymbolicBuffer bs) = length bs
-len (ConcreteBuffer bs) = BS.length bs
+len :: Buffer -> SWord 32
+len (DynamicSymBuffer (a, b)) = b
+len (StaticSymBuffer bs) = literal . num $ length bs
+len (ConcreteBuffer bs) = literal . num $ BS.length bs
 
 grab :: Int -> Buffer -> Buffer
-grab n (SymbolicBuffer bs) = SymbolicBuffer $ take n bs
+grab n (StaticSymBuffer bs) = StaticSymBuffer $ take n bs
 grab n (ConcreteBuffer bs) = ConcreteBuffer $ BS.take n bs
+grab _ = error "oops: tried to grab dynamic buffer"
 
 ditch :: Int -> Buffer -> Buffer
-ditch n (SymbolicBuffer bs) = SymbolicBuffer $ drop n bs
+ditch n (StaticSymBuffer bs) = StaticSymBuffer $ drop n bs
 ditch n (ConcreteBuffer bs) = ConcreteBuffer $ BS.drop n bs
+ditch _ = error "oops: tried to ditch dynamic buffer"
 
 readByteOrZero :: Int -> Buffer -> SWord 8
-readByteOrZero i (SymbolicBuffer bs) = readByteOrZero' i bs
+readByteOrZero i (StaticSymBuffer bs) = readByteOrZero' i bs
 readByteOrZero i (ConcreteBuffer bs) = num $ Concrete.readByteOrZero i bs
+readByteOrZero i (DynamicSymBuffer (a, b)) = ite (i < b) (readArray a i) 0
 
 sliceWithZero :: Int -> Int -> Buffer -> Buffer
-sliceWithZero o s (SymbolicBuffer m) = SymbolicBuffer (sliceWithZero' o s m)
+sliceWithZero o s (StaticSymBuffer m) = StaticSymBuffer (sliceWithZero' o s m)
 sliceWithZero o s (ConcreteBuffer m) = ConcreteBuffer (Concrete.byteStringSliceWithDefaultZeroes o s m)
 
 writeMemory :: Buffer -> Word -> Word -> Word -> Buffer -> Buffer
 writeMemory (ConcreteBuffer bs1) n src dst (ConcreteBuffer bs0) =
   ConcreteBuffer (Concrete.writeMemory bs1 n src dst bs0)
-writeMemory (ConcreteBuffer bs1) n src dst (SymbolicBuffer bs0) =
-  SymbolicBuffer (writeMemory' (litBytes bs1) n src dst bs0)
-writeMemory (SymbolicBuffer bs1) n src dst (ConcreteBuffer bs0) =
-  SymbolicBuffer (writeMemory' bs1 n src dst (litBytes bs0))
-writeMemory (SymbolicBuffer bs1) n src dst (SymbolicBuffer bs0) =
-  SymbolicBuffer (writeMemory' bs1 n src dst bs0)
+writeMemory (ConcreteBuffer bs1) n src dst (StaticSymBuffer bs0) =
+  StaticSymBuffer (writeMemory' (litBytes bs1) n src dst bs0)
+writeMemory (StaticSymBuffer bs1) n src dst (ConcreteBuffer bs0) =
+  StaticSymBuffer (writeMemory' bs1 n src dst (litBytes bs0))
+writeMemory (StaticSymBuffer bs1) n src dst (StaticSymBuffer bs0) =
+  StaticSymBuffer (writeMemory' bs1 n src dst bs0)
 
 readMemoryWord :: Word -> Buffer -> SymWord
-readMemoryWord i (SymbolicBuffer m) = readMemoryWord' i m
+readMemoryWord i (StaticSymBuffer m) = readMemoryWord' i m
 readMemoryWord i (ConcreteBuffer m) = litWord $ Concrete.readMemoryWord i m
 
 readMemoryWord32 :: Word -> Buffer -> SWord 32
-readMemoryWord32 i (SymbolicBuffer m) = readMemoryWord32' i m
+readMemoryWord32 i (StaticSymBuffer m) = readMemoryWord32' i m
 readMemoryWord32 i (ConcreteBuffer m) = num $ Concrete.readMemoryWord32 i m
 
 setMemoryWord :: Word -> SymWord -> Buffer -> Buffer
-setMemoryWord i x (SymbolicBuffer z) = SymbolicBuffer $ setMemoryWord' i x z
+setMemoryWord i x (StaticSymBuffer z) = StaticSymBuffer $ setMemoryWord' i x z
 setMemoryWord i x (ConcreteBuffer z) = case maybeLitWord x of
   Just x' -> ConcreteBuffer $ Concrete.setMemoryWord i x' z
-  Nothing -> SymbolicBuffer $ setMemoryWord' i x (litBytes z)
+  Nothing -> StaticSymBuffer $ setMemoryWord' i x (litBytes z)
 
 setMemoryByte :: Word -> SWord 8 -> Buffer -> Buffer
-setMemoryByte i x (SymbolicBuffer m) = SymbolicBuffer $ setMemoryByte' i x m
+setMemoryByte i x (StaticSymBuffer m) = StaticSymBuffer $ setMemoryByte' i x m
 setMemoryByte i x (ConcreteBuffer m) = case fromSized <$> unliteral x of
-  Nothing -> SymbolicBuffer $ setMemoryByte' i x (litBytes m)
+  Nothing -> StaticSymBuffer $ setMemoryByte' i x (litBytes m)
   Just x' -> ConcreteBuffer $ Concrete.setMemoryByte i x' m
 
 readSWord :: Word -> Buffer -> SymWord
-readSWord i (SymbolicBuffer x) = readSWord' i x
+readSWord i (StaticSymBuffer x) = readSWord' i x
 readSWord i (ConcreteBuffer x) = num $ Concrete.readMemoryWord i x
 
 -- | Custom instances for SymWord, many of which have direct

--- a/src/hevm/src/EVM/Symbolic.hs
+++ b/src/hevm/src/EVM/Symbolic.hs
@@ -276,15 +276,20 @@ sliceWithZero :: Int -> Int -> Buffer -> Buffer
 sliceWithZero o s (StaticSymBuffer m) = StaticSymBuffer (sliceWithZero' o s m)
 sliceWithZero o s (ConcreteBuffer m) = ConcreteBuffer (Concrete.byteStringSliceWithDefaultZeroes o s m)
 
-writeMemory :: Buffer -> Word -> Word -> Word -> Buffer -> Buffer
-writeMemory (ConcreteBuffer bs1) n src dst (ConcreteBuffer bs0) =
-  ConcreteBuffer (Concrete.writeMemory bs1 n src dst bs0)
-writeMemory (ConcreteBuffer bs1) n src dst (StaticSymBuffer bs0) =
-  StaticSymBuffer (writeMemory' (litBytes bs1) n src dst bs0)
-writeMemory (StaticSymBuffer bs1) n src dst (ConcreteBuffer bs0) =
-  StaticSymBuffer (writeMemory' bs1 n src dst (litBytes bs0))
-writeMemory (StaticSymBuffer bs1) n src dst (StaticSymBuffer bs0) =
-  StaticSymBuffer (writeMemory' bs1 n src dst bs0)
+writeMemory :: Buffer -> SymWord -> SymWord -> SymWord -> Buffer -> Buffer
+writeMemory bs1 n src dst bs0 =
+  case (maybeLitWord n, maybeLitWord src, maybeLitWord dst, bs0, bs1) of
+    (Just n', Just src', Just dst', ConcreteBuffer bs0', ConcreteBuffer bs1') ->
+      ConcreteBuffer $ Concrete.writeMemory bs0' n' src' dst' bs1'
+    (Just n', Just src', Just dst', StaticSymBuffer bs0', ConcreteBuffer bs1') ->
+      StaticSymBuffer $ writeMemory' bs0' n' src' dst' (litBytes bs1')
+    (Just n', Just src', Just dst', ConcreteBuffer bs0', StaticSymBuffer bs1') ->
+      StaticSymBuffer $ writeMemory' (litBytes bs0') n' src' dst' bs1'
+    (Just n', Just src', Just dst', StaticSymBuffer bs0', StaticSymBuffer bs1') ->
+      StaticSymBuffer $ writeMemory' bs0' n' src' dst' bs1'
+    _ -> let DynamicSymBuffer bs0' = dynamize bs0
+             DynamicSymBuffer bs1' = dynamize bs1
+         in DynamicSymBuffer $ dynWriteMemory bs0' n src dst bs1'
 
 readMemoryWord :: Word -> Buffer -> SymWord
 readMemoryWord i (StaticSymBuffer m) = readMemoryWord' i m

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -778,7 +778,7 @@ updateUiVmState ui vm =
       case view result vm of
         Just (VMSuccess (ConcreteBuffer msg)) ->
           Just ("VMSuccess: " <> (show $ ByteStringS msg))
-        Just (VMSuccess (SymbolicBuffer msg)) ->
+        Just (VMSuccess (StaticSymBuffer msg)) ->
           Just ("VMSuccess: <symbolicbuffer> " <> (show msg))
         Just (VMFailure (Revert msg)) ->
           Just ("VMFailure: " <> (show . ByteStringS $ msg))
@@ -864,7 +864,7 @@ withHighlight False = withDefAttr dimAttr
 withHighlight True  = withDefAttr boldAttr
 
 prettyIfConcrete :: Buffer -> String
-prettyIfConcrete (SymbolicBuffer x) = show x
+prettyIfConcrete (StaticSymBuffer x) = show x
 prettyIfConcrete (ConcreteBuffer x) = prettyHex 40 x
 
 drawTracePane :: UiVmState -> UiWidget
@@ -872,7 +872,7 @@ drawTracePane s =
   case view uiShowMemory s of
     True ->
       hBorderWithLabel (txt "Calldata")
-      <=> str (prettyIfConcrete $ fst (view (uiVm . state . calldata) s))
+      <=> str (prettyIfConcrete $ view (uiVm . state . calldata) s)
       <=> hBorderWithLabel (txt "Returndata")
       <=> str (prettyIfConcrete (view (uiVm . state . returndata) s))
       <=> hBorderWithLabel (txt "Output")

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -214,11 +214,6 @@ padLeft n xs = BS.replicate (n - BS.length xs) 0 <> xs
 padRight :: Int -> ByteString -> ByteString
 padRight n xs = xs <> BS.replicate (n - BS.length xs) 0
 
-truncpad :: Int -> [SWord 8] -> [SWord 8]
-truncpad n xs = if m > n then take n xs
-                else mappend xs (replicate (n - m) 0)
-  where m = length xs
-
 word256 :: ByteString -> Word256
 word256 xs = case Cereal.runGet m (padLeft 32 xs) of
                Left _ -> error "internal error"

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -553,7 +553,7 @@ setupCall TestVMParams{..} sig args  = do
   use (env . contracts) >>= assign (tx . txReversion)
   assign (tx . isCreate) False
   loadContract testAddress
-  assign (state . calldata) $ (ConcreteBuffer $ abiMethod sig args, literal . num . BS.length $ abiMethod sig args)
+  assign (state . calldata) (ConcreteBuffer $ abiMethod sig args)
   assign (state . caller) (litAddr testCaller)
   assign (state . gas) (w256 testGasCall)
 
@@ -563,7 +563,7 @@ initialUnitTestVm (UnitTestOptions {..}) theContract =
     TestVMParams {..} = testParams
     vm = makeVm $ VMOpts
            { vmoptContract = initialContract (InitCode (view creationCode theContract))
-           , vmoptCalldata = (mempty, 0)
+           , vmoptCalldata = mempty
            , vmoptValue = 0
            , vmoptAddress = testAddress
            , vmoptCaller = litAddr testCaller

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -185,7 +185,7 @@ checkExpectedContracts vm expected =
      )
 
 clearOrigStorage :: EVM.Contract -> EVM.Contract
-clearOrigStorage = set EVM.origStorage mempty
+clearOrigStorage = set EVM.origStorage (EVM.Concrete mempty)
 
 clearZeroStorage :: EVM.Contract -> EVM.Contract
 clearZeroStorage c = case EVM._storage c of
@@ -325,16 +325,12 @@ realizeContract x =
   EVM.initialContract (x ^. code)
     & EVM.balance .~ EVM.w256 (x ^. balance)
     & EVM.nonce   .~ EVM.w256 (x ^. nonce)
-    & EVM.storage .~ EVM.Concrete (
-        Map.fromList .
-        map (bimap EVM.w256 (litWord . EVM.w256)) .
-        Map.toList $ x ^. storage
-        )
-    & EVM.origStorage .~ (
-        Map.fromList .
-        map (bimap EVM.w256 EVM.w256) .
-        Map.toList $ x ^. storage
-        )
+    & EVM.storage .~ store
+    & EVM.origStorage .~ store
+  where store = EVM.Concrete $
+          Map.fromList .
+          map (bimap EVM.w256 (litWord . EVM.w256)) .
+          Map.toList $ x ^. storage
 
 data BlockchainError
   = TooManyBlocks

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -255,7 +255,7 @@ parseVmOpts v =
        (JSON.Object env, JSON.Object exec) ->
          EVM.VMOpts
            <$> (dataField exec "code" >>= pure . EVM.initialContract . EVM.RuntimeCode)
-           <*> (dataField exec "data" >>= \a -> pure ( (ConcreteBuffer a), literal . num $ BS.length a))
+           <*> (dataField exec "data" >>= pure . ConcreteBuffer)
            <*> (w256lit <$> wordField exec "value")
            <*> addrField exec "address"
            <*> (litAddr <$> addrField exec "caller")
@@ -380,7 +380,7 @@ fromCreateBlockchainCase block tx preState postState =
       in Right $ Case
          (EVM.VMOpts
           { vmoptContract      = EVM.initialContract (EVM.InitCode (txData tx))
-          , vmoptCalldata      = (mempty, 0)
+          , vmoptCalldata      = mempty
           , vmoptValue         = w256lit $ txValue tx
           , vmoptAddress       = createdAddr
           , vmoptCaller        = (litAddr origin)
@@ -419,7 +419,7 @@ fromNormalBlockchainCase block tx preState postState =
       (_, _, Just origin, Just checkState) -> Right $ Case
         (EVM.VMOpts
          { vmoptContract      = EVM.initialContract theCode
-         , vmoptCalldata      = (ConcreteBuffer $ txData tx, literal . num . BS.length $ txData tx)
+         , vmoptCalldata      = ConcreteBuffer $ txData tx
          , vmoptValue         = litWord (EVM.w256 $ txValue tx)
          , vmoptAddress       = toAddr
          , vmoptCaller        = (litAddr origin)

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -142,6 +142,23 @@ main = defaultMain $ testGroup "hevm"
        === (Just $ Literal Patricia.Empty)
     ]
 
+  , testGroup "Symbolic buffers"
+    [  testProperty "dynWriteMemory works like writeMemory" $ \(src, offset, dst) ->
+        runSMT $ query $ do
+          cd  <- sbytes128
+          mem <- sbytes128
+          let staticWriting = writeMemory' cd src offset dst mem
+          let dynamicWriting =
+                dynWriteMemory
+                 (implode cd)
+                 (literal src)
+                 (literal offset)
+                 (literal dst)
+                 (implode mem)
+          implode staticWriting
+                            
+    ]
+
   , testGroup "Symbolic execution"
       [
       -- Somewhat tautological since we are asserting the precondition

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -26,6 +26,7 @@ import qualified Data.Vector as Vector
 import Data.String.Here
 
 import Control.Monad.Fail
+import Debug.Trace
 
 import Data.Binary.Put (runPut)
 import Data.SBV hiding ((===), forAll, sList)
@@ -172,421 +173,404 @@ main = defaultMain $ testGroup "hevm"
                                    getList (StaticSymBuffer bf) = mapM getValue bf
                                    getList (DynamicSymBuffer bf) = getValue bf
 
-      ,  testProperty "dynWriteMemory works like writeMemory" $
---          withMaxSuccess 10000 $
-          forAll (genAbiValue (AbiTupleType $ Vector.fromList [AbiUIntType 16, AbiUIntType 16, AbiUIntType 16])) $ \(AbiTuple args) ->
-        let [AbiUInt 16 src', AbiUInt 16 dst', AbiUInt 16 len'] = Vector.toList args
-        in ioProperty $ runSMTWith z3 $ query $ do
-               cd  <- sbytes32
-               mem <- sbytes32
+--       ,  testProperty "dynWriteMemory works like writeMemory" $
+-- --          withMaxSuccess 10000 $
+--           forAll (genAbiValue (AbiTupleType $ Vector.fromList [AbiUIntType 16, AbiUIntType 16, AbiUIntType 16])) $ \(AbiTuple args) ->
+--         let [AbiUInt 16 src', AbiUInt 16 dst', AbiUInt 16 len'] = Vector.toList args
+--         in ioProperty $ runSMTWith z3 $ do
+--           setTimeOut 5000
+--           query $ do
+--                cd  <- sbytes32
+--                mem <- sbytes32
 
-               let
-                   src = w256 $ W256 src'
-                   dst = w256 $ W256 dst'
-                   len = w256 $ W256 len'
+--                let
+--                    src = w256 $ W256 src'
+--                    dst = w256 $ W256 dst'
+--                    len = w256 $ W256 len'
 
-                   staticWriting = writeMemory' cd src len dst mem
-                   dynamicWriting =
-                     dynWriteMemory
-                      (DynamicSymBuffer (implode cd))
-                      (litWord src)
-                      (litWord len)
-                      (litWord dst)
-                      (DynamicSymBuffer (implode mem))
+--                    staticWriting = writeMemory' cd src len dst mem
+--                    dynamicWriting =
+--                      dynWriteMemory
+--                       (DynamicSymBuffer (implode cd))
+--                       (litWord src)
+--                       (litWord len)
+--                       (litWord dst)
+--                       (DynamicSymBuffer (implode mem))
 
-               when ((length staticWriting) < 10000 && len' < 10000) $
-                 checkSatAssuming [StaticSymBuffer staticWriting ./= dynamicWriting] >>= \case
-                   Unsat -> io $ putStrLn "Success!"
-                   Sat -> do getList dynamicWriting >>= io . print
-                             getList (StaticSymBuffer staticWriting) >>= io . print
-                             error "oh no!"
-                                where getList :: Buffer -> Query [WordN 8]
-                                      getList (StaticSymBuffer bf) = mapM getValue bf
-                                      getList (DynamicSymBuffer bf) = getValue bf
-
-
-    -- ,  testCase "dynWriteMemory pads with zeros appropriately" $
-    --       ioProperty $ runSMT $ query $ do
-    --            cd  <- sbytes128
-    --            mem <- sbytes128
-    --            let src = w256 $ W256 src'
-    --                dst = w256 $ W256 dst'
-    --                offset = w256 $ W256 offset'
-    --                staticWriting = writeMemory' cd src offset dst mem
-    --                dynamicWriting =
-    --                  dynWriteMemory
-    --                   (implode cd)
-    --                   (litWord src)
-    --                   (litWord offset)
-    --                   (litWord dst)
-    --                   (implode mem)
-    --            checkSatAssuming [implode staticWriting ./= dynamicWriting] >>= \case
-    --              Unsat -> return ()
-    --              _ -> error "fail!"
-                            
+--                when ((length staticWriting) < 10000 && len' < 10000) $
+--                  checkSatAssuming [StaticSymBuffer staticWriting ./= dynamicWriting] >>= \case
+--                    Unk -> io $ putStrLn "timeout"
+--                    Unsat -> io $ putStrLn "Success!"
+--                    Sat -> do getList dynamicWriting >>= io . print
+--                              getList (StaticSymBuffer staticWriting) >>= io . print
+--                              error "oh no!"
+--                                 where getList :: Buffer -> Query [WordN 8]
+--                                       getList (StaticSymBuffer bf) = mapM getValue bf
+--                                       getList (DynamicSymBuffer bf) = getValue bf                 
+               
    ]
 
-  -- , testGroup "Symbolic execution"
-  --     [
-  --     -- Somewhat tautological since we are asserting the precondition
-  --     -- on the same form as the actual "requires" clause.
-  --     testCase "SafeAdd success case" $ do
-  --       Just safeAdd <- solcRuntime "SafeAdd"
-  --         [i|
-  --         contract SafeAdd {
-  --           function add(uint x, uint y) public pure returns (uint z) {
-  --                require((z = x + y) >= x);
-  --           }
-  --         }
-  --         |]
-  --       let asWord :: [SWord 8] -> SWord 256
-  --           asWord = fromBytes
-  --           pre preVM = let StaticSymBuffer bs = ditch 4 $ view (state . calldata) preVM
-  --                           (x, y) = splitAt 32 bs
-  --                       in asWord x .<= asWord x + asWord y
-  --                          .&& view (state . callvalue) preVM .== 0
-  --           post = Just $ \(prestate, poststate) ->
-  --             let StaticSymBuffer input = view (state.calldata) prestate
-  --                 (x, y) = splitAt 32 (drop 4 input)
-  --             in case view result poststate of
-  --               Just (VMSuccess (StaticSymBuffer out)) -> (asWord out) .== (asWord x) + (asWord y)
-  --               _ -> sFalse
-  --       Left (_, res) <- runSMT $ query $ verifyContract (RuntimeCode safeAdd) Nothing (Just ("add(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] SymbolicS pre post
-  --       putStrLn $ "successfully explored: " <> show (length res) <> " paths"
-  --    ,
+  , testGroup "Symbolic execution"
+      [
+      -- Somewhat tautological since we are asserting the precondition
+      -- on the same form as the actual "requires" clause.
+      testCase "SafeAdd success case" $ do
+        Just safeAdd <- solcRuntime "SafeAdd"
+          [i|
+          contract SafeAdd {
+            function add(uint x, uint y) public pure returns (uint z) {
+                 require((z = x + y) >= x);
+            }
+          }
+          |]
+        let asWord :: HasCallStack => [SWord 8] -> SWord 256
+            asWord = fromBytes
+            pre preVM = let StaticSymBuffer bs = ditch 4 $ view (state . calldata) preVM
+                            (x, y) = trace ("calldata length: " <> show (length bs)) $ splitAt 32 bs
+                        in asWord x .<= asWord x + asWord y
+                           .&& view (state . callvalue) preVM .== 0
+            post = Just $ \(prestate, poststate) ->
+              let StaticSymBuffer input = view (state.calldata) prestate
+                  (x, y) = splitAt 32 (drop 4 input)
+              in case view result poststate of
+                Just (VMSuccess (StaticSymBuffer out)) -> (asWord out) .== (asWord x) + (asWord y)
+                _ -> sFalse
+        Left (_, res) <- runSMT $ query $ verifyContract (RuntimeCode safeAdd) Nothing (Just ("add(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] SymbolicS pre post
+        putStrLn $ "successfully explored: " <> show (length res) <> " paths"
+     ,
 
-  --     testCase "x == y => x + y == 2 * y" $ do
-  --       Just safeAdd <- solcRuntime "SafeAdd"
-  --         [i|
-  --         contract SafeAdd {
-  --           function add(uint x, uint y) public pure returns (uint z) {
-  --                require((z = x + y) >= x);
-  --           }
-  --         }
-  --         |]
-  --       let asWord :: [SWord 8] -> SWord 256
-  --           asWord = fromBytes
-  --           pre preVM = let StaticSymBuffer bs = ditch 4 $ view (state . calldata) preVM
-  --                           (x, y) = splitAt 32 bs
-  --                          in (asWord x .<= asWord x + asWord y)
-  --                             .&& (x .== y)
-  --                             .&& view (state . callvalue) preVM .== 0
-  --           post = Just $ \(prestate, poststate)
-  --             -> let StaticSymBuffer input = view (state.calldata) prestate
-  --                    (_, y) = splitAt 32 (drop 4 input)
-  --                in case view result poststate of
-  --                     Just (VMSuccess (StaticSymBuffer out)) -> asWord out .== 2 * asWord y
-  --                     _ -> sFalse
-  --       Left (_, res) <- runSMTWith z3 $ query $
-  --         verifyContract (RuntimeCode safeAdd) Nothing (Just ("add(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] SymbolicS pre post
-  --       putStrLn $ "successfully explored: " <> show (length res) <> " paths"
-  --     ,
-  --       testCase "factorize 973013" $ do
-  --       Just factor <- solcRuntime "PrimalityCheck"
-  --         [i|
-  --         contract PrimalityCheck {
-  --           function factor(uint x, uint y) public pure  {
-  --                  require(1 < x && x < 973013 && 1 < y && y < 973013);
-  --                  assert(x*y != 973013);
-  --           }
-  --         }
-  --         |]
-  --       bs <- runSMTWith cvc4 $ query $ do
-  --         Right vm <- checkAssert (RuntimeCode factor) Nothing (Just ("factor(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) []
-  --         case view (state . calldata) vm of
-  --           StaticSymBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
-  --           ConcreteBuffer _ -> error "unexpected"
+      testCase "x == y => x + y == 2 * y" $ do
+        Just safeAdd <- solcRuntime "SafeAdd"
+          [i|
+          contract SafeAdd {
+            function add(uint x, uint y) public pure returns (uint z) {
+                 require((z = x + y) >= x);
+            }
+          }
+          |]
+        let asWord :: [SWord 8] -> SWord 256
+            asWord = fromBytes
+            pre preVM = let StaticSymBuffer bs = ditch 4 $ view (state . calldata) preVM
+                            (x, y) = splitAt 32 bs
+                           in (asWord x .<= asWord x + asWord y)
+                              .&& (x .== y)
+                              .&& view (state . callvalue) preVM .== 0
+            post = Just $ \(prestate, poststate)
+              -> let StaticSymBuffer input = view (state.calldata) prestate
+                     (_, y) = splitAt 32 (drop 4 input)
+                 in case view result poststate of
+                      Just (VMSuccess (StaticSymBuffer out)) -> asWord out .== 2 * asWord y
+                      _ -> sFalse
+        Left (_, res) <- runSMTWith z3 $ query $
+          verifyContract (RuntimeCode safeAdd) Nothing (Just ("add(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] SymbolicS pre post
+        putStrLn $ "successfully explored: " <> show (length res) <> " paths"
+      ,
+        testCase "factorize 973013" $ do
+        Just factor <- solcRuntime "PrimalityCheck"
+          [i|
+          contract PrimalityCheck {
+            function factor(uint x, uint y) public pure  {
+                   require(1 < x && x < 973013 && 1 < y && y < 973013);
+                   assert(x*y != 973013);
+            }
+          }
+          |]
+        bs <- runSMTWith cvc4 $ query $ do
+          Right vm <- checkAssert (RuntimeCode factor) Nothing (Just ("factor(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) []
+          case view (state . calldata) vm of
+            StaticSymBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
+            ConcreteBuffer _ -> error "unexpected"
 
-  --       let AbiTuple xy = decodeAbiValue (AbiTupleType $ Vector.fromList [AbiUIntType 256, AbiUIntType 256]) (BS.fromStrict (BS.drop 4 bs))
-  --           [AbiUInt 256 x, AbiUInt 256 y] = Vector.toList xy
-  --       assertEqual "" True (x == 953 && y == 1021 || x == 1021 && y == 953)
-  --       ,
-  --       testCase "summary storage writes" $ do
-  --       Just c <- solcRuntime "A"
-  --         [i|
-  --         contract A {
-  --           uint x;
-  --           function f(uint256 y) public {
-  --              x += y;
-  --              x += y;
-  --           }
-  --         }
-  --         |]
-  --       let pre vm = 0 .== view (state . callvalue) vm
-  --           post = Just $ \(prestate, poststate) ->
-  --             let StaticSymBuffer y = ditch 4 $ view (state.calldata) prestate
-  --                 this = view (state . codeContract) prestate
-  --                 Just preC = view (env.contracts . at this) prestate
-  --                 Just postC = view (env.contracts . at this) poststate
-  --                 Symbolic prestore = _storage preC
-  --                 Symbolic poststore = _storage postC
-  --                 prex = readArray prestore 0
-  --                 postx = readArray poststore 0
-  --             in case view result poststate of
-  --               Just (VMSuccess _) -> prex + 2 * (fromBytes y) .== postx
-  --               _ -> sFalse
-  --       Left (_, res) <- runSMT $ query $ verifyContract (RuntimeCode c) Nothing (Just ("f(uint256)", [AbiUIntType 256])) [] SymbolicS pre post
-  --       putStrLn $ "successfully explored: " <> show (length res) <> " paths"
-  --       ,
-  --       -- Inspired by these `msg.sender == to` token bugs
-  --       -- which break linearity of totalSupply.
-  --       testCase "catch storage collisions" $ do
-  --       Just c <- solcRuntime "A"
-  --         [i|
-  --         contract A {
-  --           function f(uint x, uint y) public {
-  --              assembly {
-  --                let newx := sub(sload(x), 1)
-  --                let newy := add(sload(y), 1)
-  --                sstore(x,newx)
-  --                sstore(y,newy)
-  --              }
-  --           }
-  --         }
-  --         |]
-  --       let pre vm = 0 .== view (state . callvalue) vm
-  --           post = Just $ \(prestate, poststate) ->
-  --             let StaticSymBuffer bs = view (state.calldata) prestate
-  --                 (x,y) = over both (fromBytes) (splitAt 32 $ drop 4 bs)
-  --                 this = view (state . codeContract) prestate
-  --                 (Just preC, Just postC) = both' (view (env.contracts . at this)) (prestate, poststate)
-  --                 --Just postC = view (env.contracts . at this) poststate
-  --                 (Symbolic prestore, Symbolic poststore) = both' (view storage) (preC, postC)
-  --                 (prex,  prey)  = both' (readArray prestore) (x, y)
-  --                 (postx, posty) = both' (readArray poststore) (x, y)
-  --             in case view result poststate of
-  --               Just (VMSuccess _) -> prex + prey .== postx + (posty :: SWord 256)
-  --               _ -> sFalse
-  --       bs <- runSMT $ query $ do
-  --         Right vm <- verifyContract (RuntimeCode c) Nothing (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] SymbolicS pre post
-  --         case view (state . calldata) vm of
-  --           StaticSymBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
-  --           ConcreteBuffer bs -> error "unexpected"
+        let AbiTuple xy = decodeAbiValue (AbiTupleType $ Vector.fromList [AbiUIntType 256, AbiUIntType 256]) (BS.fromStrict (BS.drop 4 bs))
+            [AbiUInt 256 x, AbiUInt 256 y] = Vector.toList xy
+        assertEqual "" True (x == 953 && y == 1021 || x == 1021 && y == 953)
+        ,
+        testCase "summary storage writes" $ do
+        Just c <- solcRuntime "A"
+          [i|
+          contract A {
+            uint x;
+            function f(uint256 y) public {
+               x += y;
+               x += y;
+            }
+          }
+          |]
+        let pre vm = 0 .== view (state . callvalue) vm
+            post = Just $ \(prestate, poststate) ->
+              let StaticSymBuffer y = ditch 4 $ view (state.calldata) prestate
+                  this = view (state . codeContract) prestate
+                  Just preC = view (env.contracts . at this) prestate
+                  Just postC = view (env.contracts . at this) poststate
+                  Symbolic prestore = _storage preC
+                  Symbolic poststore = _storage postC
+                  prex = readArray prestore 0
+                  postx = readArray poststore 0
+              in case view result poststate of
+                Just (VMSuccess _) -> prex + 2 * (fromBytes y) .== postx
+                _ -> sFalse
+        Left (_, res) <- runSMT $ query $ verifyContract (RuntimeCode c) Nothing (Just ("f(uint256)", [AbiUIntType 256])) [] SymbolicS pre post
+        putStrLn $ "successfully explored: " <> show (length res) <> " paths"
+        ,
+        -- Inspired by these `msg.sender == to` token bugs
+        -- which break linearity of totalSupply.
+        testCase "catch storage collisions" $ do
+        Just c <- solcRuntime "A"
+          [i|
+          contract A {
+            function f(uint x, uint y) public {
+               assembly {
+                 let newx := sub(sload(x), 1)
+                 let newy := add(sload(y), 1)
+                 sstore(x,newx)
+                 sstore(y,newy)
+               }
+            }
+          }
+          |]
+        let pre vm = 0 .== view (state . callvalue) vm
+            post = Just $ \(prestate, poststate) ->
+              let StaticSymBuffer bs = view (state.calldata) prestate
+                  (x,y) = over both (fromBytes) (splitAt 32 $ drop 4 bs)
+                  this = view (state . codeContract) prestate
+                  (Just preC, Just postC) = both' (view (env.contracts . at this)) (prestate, poststate)
+                  --Just postC = view (env.contracts . at this) poststate
+                  (Symbolic prestore, Symbolic poststore) = both' (view storage) (preC, postC)
+                  (prex,  prey)  = both' (readArray prestore) (x, y)
+                  (postx, posty) = both' (readArray poststore) (x, y)
+              in case view result poststate of
+                Just (VMSuccess _) -> prex + prey .== postx + (posty :: SWord 256)
+                _ -> sFalse
+        bs <- runSMT $ query $ do
+          Right vm <- verifyContract (RuntimeCode c) Nothing (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] SymbolicS pre post
+          case view (state . calldata) vm of
+            StaticSymBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
+            ConcreteBuffer bs -> error "unexpected"
 
-  --       let AbiTuple xyz = decodeAbiValue (AbiTupleType $ Vector.fromList [AbiUIntType 256, AbiUIntType 256]) (BS.fromStrict (BS.drop 4 bs))
-  --           [AbiUInt 256 x, AbiUInt 256 y] = Vector.toList xyz
-  --       assertEqual "Catch storage collisions" x y
-  --       ,
-  --       testCase "Deposit contract loop (z3)" $ do
-  --         Just c <- solcRuntime "Deposit"
-  --           [i|
-  --           contract Deposit {
-  --             function deposit(uint256 deposit_count) external pure {
-  --               require(deposit_count < 2**32 - 1);
-  --               ++deposit_count;
-  --               bool found = false;
-  --               for (uint height = 0; height < 32; height++) {
-  --                 if ((deposit_count & 1) == 1) {
-  --                   found = true;
-  --                   break;
-  --                 }
-  --                deposit_count = deposit_count >> 1;
-  --                }
-  --               assert(found);
-  --             }
-  --            }
-  --           |]
-  --         Left (_, res) <- runSMTWith z3 $ query $ checkAssert (RuntimeCode c) Nothing (Just ("deposit(uint256)", [AbiUIntType 256])) []
-  --         putStrLn $ "successfully explored: " <> show (length res) <> " paths"
-  --       ,
-  --               testCase "Deposit contract loop (cvc4)" $ do
-  --         Just c <- solcRuntime "Deposit"
-  --           [i|
-  --           contract Deposit {
-  --             function deposit(uint256 deposit_count) external pure {
-  --               require(deposit_count < 2**32 - 1);
-  --               ++deposit_count;
-  --               bool found = false;
-  --               for (uint height = 0; height < 32; height++) {
-  --                 if ((deposit_count & 1) == 1) {
-  --                   found = true;
-  --                   break;
-  --                 }
-  --                deposit_count = deposit_count >> 1;
-  --                }
-  --               assert(found);
-  --             }
-  --            }
-  --           |]
-  --         Left (_, res) <- runSMTWith cvc4 $ query $ checkAssert (RuntimeCode c) Nothing (Just ("deposit(uint256)", [AbiUIntType 256])) []
-  --         putStrLn $ "successfully explored: " <> show (length res) <> " paths"
-  --       ,
-  --       testCase "Deposit contract loop (error version)" $ do
-  --         Just c <- solcRuntime "Deposit"
-  --           [i|
-  --           contract Deposit {
-  --             function deposit(uint8 deposit_count) external pure {
-  --               require(deposit_count < 2**32 - 1);
-  --               ++deposit_count;
-  --               bool found = false;
-  --               for (uint height = 0; height < 32; height++) {
-  --                 if ((deposit_count & 1) == 1) {
-  --                   found = true;
-  --                   break;
-  --                 }
-  --                deposit_count = deposit_count >> 1;
-  --                }
-  --               assert(found);
-  --             }
-  --            }
-  --           |]
-  --         bs <- runSMT $ query $ do
-  --           Right vm <- checkAssert (RuntimeCode c) Nothing (Just ("deposit(uint8)", [AbiUIntType 8])) []
-  --           case view (state . calldata) vm of
-  --             StaticSymBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
-  --             ConcreteBuffer _ -> error "unexpected"
+        let AbiTuple xyz = decodeAbiValue (AbiTupleType $ Vector.fromList [AbiUIntType 256, AbiUIntType 256]) (BS.fromStrict (BS.drop 4 bs))
+            [AbiUInt 256 x, AbiUInt 256 y] = Vector.toList xyz
+        assertEqual "Catch storage collisions" x y
+        ,
+        testCase "Deposit contract loop (z3)" $ do
+          Just c <- solcRuntime "Deposit"
+            [i|
+            contract Deposit {
+              function deposit(uint256 deposit_count) external pure {
+                require(deposit_count < 2**32 - 1);
+                ++deposit_count;
+                bool found = false;
+                for (uint height = 0; height < 32; height++) {
+                  if ((deposit_count & 1) == 1) {
+                    found = true;
+                    break;
+                  }
+                 deposit_count = deposit_count >> 1;
+                 }
+                assert(found);
+              }
+             }
+            |]
+          Left (_, res) <- runSMTWith z3 $ query $ checkAssert (RuntimeCode c) Nothing (Just ("deposit(uint256)", [AbiUIntType 256])) []
+          putStrLn $ "successfully explored: " <> show (length res) <> " paths"
+        ,
+                testCase "Deposit contract loop (cvc4)" $ do
+          Just c <- solcRuntime "Deposit"
+            [i|
+            contract Deposit {
+              function deposit(uint256 deposit_count) external pure {
+                require(deposit_count < 2**32 - 1);
+                ++deposit_count;
+                bool found = false;
+                for (uint height = 0; height < 32; height++) {
+                  if ((deposit_count & 1) == 1) {
+                    found = true;
+                    break;
+                  }
+                 deposit_count = deposit_count >> 1;
+                 }
+                assert(found);
+              }
+             }
+            |]
+          Left (_, res) <- runSMTWith cvc4 $ query $ checkAssert (RuntimeCode c) Nothing (Just ("deposit(uint256)", [AbiUIntType 256])) []
+          putStrLn $ "successfully explored: " <> show (length res) <> " paths"
+        ,
+        testCase "Deposit contract loop (error version)" $ do
+          Just c <- solcRuntime "Deposit"
+            [i|
+            contract Deposit {
+              function deposit(uint8 deposit_count) external pure {
+                require(deposit_count < 2**32 - 1);
+                ++deposit_count;
+                bool found = false;
+                for (uint height = 0; height < 32; height++) {
+                  if ((deposit_count & 1) == 1) {
+                    found = true;
+                    break;
+                  }
+                 deposit_count = deposit_count >> 1;
+                 }
+                assert(found);
+              }
+             }
+            |]
+          bs <- runSMT $ query $ do
+            Right vm <- checkAssert (RuntimeCode c) Nothing (Just ("deposit(uint8)", [AbiUIntType 8])) []
+            case view (state . calldata) vm of
+              StaticSymBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
+              ConcreteBuffer _ -> error "unexpected"
 
-  --         let deposit = decodeAbiValue (AbiUIntType 8) (BS.fromStrict (BS.drop 4 bs))
-  --         assertEqual "overflowing uint8" deposit (AbiUInt 8 255)
-  --    ,
-  --       -- This test uses cvc4 instead of z3
-  --       testCase "explore function dispatch" $ do
-  --       Just c <- solcRuntime "A"
-  --         [i|
-  --         contract A {
-  --           function f(uint x) public pure returns (uint) {
-  --             return x;
-  --           }
-  --         }
-  --         |]
-  --       Left (_, res) <- runSMTWith cvc4 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
-  --       putStrLn $ "successfully explored: " <> show (length res) <> " paths"
-  --       ,
+          let deposit = decodeAbiValue (AbiUIntType 8) (BS.fromStrict (BS.drop 4 bs))
+          assertEqual "overflowing uint8" deposit (AbiUInt 8 255)
+     ,
+        -- This test uses cvc4 instead of z3
+        testCase "explore function dispatch" $ do
+        Just c <- solcRuntime "A"
+          [i|
+          contract A {
+            function f(uint x) public pure returns (uint) {
+              return x;
+            }
+          }
+          |]
+        Left (_, res) <- runSMTWith cvc4 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
+        putStrLn $ "successfully explored: " <> show (length res) <> " paths"
+        ,
 
-  --       testCase "injectivity of keccak (32 bytes)" $ do
-  --         Just c <- solcRuntime "A"
-  --           [i|
-  --           contract A {
-  --             function f(uint x, uint y) public pure {
-  --               if (keccak256(abi.encodePacked(x)) == keccak256(abi.encodePacked(y))) assert(x == y);
-  --             }
-  --           }
-  --           |]
-  --         Left (_, res) <- runSMTWith cvc4 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
-  --         putStrLn $ "successfully explored: " <> show (length res) <> " paths"
-  --       ,
-  --       testCase "injectivity of keccak (32 bytes)" $ do
-  --         Just c <- solcRuntime "A"
-  --           [i|
-  --           contract A {
-  --             function f(uint x, uint y) public pure {
-  --               if (keccak256(abi.encodePacked(x)) == keccak256(abi.encodePacked(y))) assert(x == y);
-  --             }
-  --           }
-  --           |]
-  --         Left (_, res) <- runSMTWith cvc4 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
-  --         putStrLn $ "successfully explored: " <> show (length res) <> " paths"
-  --      ,
+        testCase "injectivity of keccak (32 bytes)" $ do
+          Just c <- solcRuntime "A"
+            [i|
+            contract A {
+              function f(uint x, uint y) public pure {
+                if (keccak256(abi.encodePacked(x)) == keccak256(abi.encodePacked(y))) assert(x == y);
+              }
+            }
+            |]
+          Left (_, res) <- runSMTWith cvc4 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
+          putStrLn $ "successfully explored: " <> show (length res) <> " paths"
+        ,
+        testCase "injectivity of keccak (32 bytes)" $ do
+          Just c <- solcRuntime "A"
+            [i|
+            contract A {
+              function f(uint x, uint y) public pure {
+                if (keccak256(abi.encodePacked(x)) == keccak256(abi.encodePacked(y))) assert(x == y);
+              }
+            }
+            |]
+          Left (_, res) <- runSMTWith cvc4 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
+          putStrLn $ "successfully explored: " <> show (length res) <> " paths"
+       ,
 
-  --       testCase "injectivity of keccak (64 bytes)" $ do
-  --         Just c <- solcRuntime "A"
-  --           [i|
-  --           contract A {
-  --             function f(uint x, uint y, uint w, uint z) public pure {
-  --               assert (keccak256(abi.encodePacked(x,y)) != keccak256(abi.encodePacked(w,z)));
-  --             }
-  --           }
-  --           |]
-  --         bs <- runSMTWith z3 $ query $ do
-  --           Right vm <- checkAssert (RuntimeCode c) Nothing (Just ("f(uint256,uint256,uint256,uint256)", replicate 4 (AbiUIntType 256))) []
-  --           case view (state . calldata) vm of
-  --             StaticSymBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
-  --             ConcreteBuffer _ -> error "unexpected"
+        testCase "injectivity of keccak (64 bytes)" $ do
+          Just c <- solcRuntime "A"
+            [i|
+            contract A {
+              function f(uint x, uint y, uint w, uint z) public pure {
+                assert (keccak256(abi.encodePacked(x,y)) != keccak256(abi.encodePacked(w,z)));
+              }
+            }
+            |]
+          bs <- runSMTWith z3 $ query $ do
+            Right vm <- checkAssert (RuntimeCode c) Nothing (Just ("f(uint256,uint256,uint256,uint256)", replicate 4 (AbiUIntType 256))) []
+            case view (state . calldata) vm of
+              StaticSymBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
+              ConcreteBuffer _ -> error "unexpected"
               
-  --         let AbiTuple xywz = decodeAbiValue (AbiTupleType $ Vector.fromList
-  --                                             [AbiUIntType 256, AbiUIntType 256,
-  --                                              AbiUIntType 256, AbiUIntType 256]) (BS.fromStrict (BS.drop 4 bs))
-  --             [AbiUInt 256 x, AbiUInt 256 y, AbiUInt 256 w, AbiUInt 256 z] = Vector.toList xywz
-  --         assertEqual "x == w" x w
-  --         assertEqual "y == z" y z
-  --      ,
+          let AbiTuple xywz = decodeAbiValue (AbiTupleType $ Vector.fromList
+                                              [AbiUIntType 256, AbiUIntType 256,
+                                               AbiUIntType 256, AbiUIntType 256]) (BS.fromStrict (BS.drop 4 bs))
+              [AbiUInt 256 x, AbiUInt 256 y, AbiUInt 256 w, AbiUInt 256 z] = Vector.toList xywz
+          assertEqual "x == w" x w
+          assertEqual "y == z" y z
+       ,
 
-  --       testCase "calldata beyond calldatasize is 0 (z3)" $ do
-  --         Just c <- solcRuntime "A"
-  --           [i|
-  --           contract A {
-  --             function f() public pure {
-  --               uint y;
-  --               assembly {
-  --                 let x := calldatasize()
-  --                 y := calldataload(x)
-  --               }
-  --               assert(y == 0);
-  --             }
-  --           }
-  --           |]
-  --         Left (_, res) <- runSMTWith z3 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
-  --         putStrLn $ "successfully explored: " <> show (length res) <> " paths"
+        testCase "calldata beyond calldatasize is 0 (z3)" $ do
+          Just c <- solcRuntime "A"
+            [i|
+            contract A {
+              function f() public pure {
+                uint y;
+                assembly {
+                  let x := calldatasize()
+                  y := calldataload(x)
+                }
+                assert(y == 0);
+              }
+            }
+            |]
+          Left (_, res) <- runSMTWith z3 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
+          putStrLn $ "successfully explored: " <> show (length res) <> " paths"
 
-  --      ,
+       ,
 
-  --       testCase "keccak soundness" $ do
-  --         Just c <- solcRuntime "C"
-  --           [i|
-  --             contract C {
-  --               mapping (uint => mapping (uint => uint)) maps;
+        testCase "keccak soundness" $ do
+          Just c <- solcRuntime "C"
+            [i|
+              contract C {
+                mapping (uint => mapping (uint => uint)) maps;
 
-  --                 function f(uint x, uint y) public view {
-  --                 assert(maps[y][0] == maps[x][0]);
-  --               }
-  --             }
-  --           |]
-  --         -- should find a counterexample
-  --         Right counterexample <- runSMTWith cvc4 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
-  --         putStrLn $ "found counterexample:"
+                  function f(uint x, uint y) public view {
+                  assert(maps[y][0] == maps[x][0]);
+                }
+              }
+            |]
+          -- should find a counterexample
+          Right counterexample <- runSMTWith cvc4 $ query $ checkAssert (RuntimeCode c) Nothing Nothing []
+          putStrLn $ "found counterexample:"
 
 
-  --     ,
-  --        testCase "multiple contracts" $ do
-  --         let code =
-  --               [i|
-  --                 contract C {
-  --                   uint x;
-  --                   A constant a = A(0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B);
+      ,
+         testCase "multiple contracts" $ do
+          let code =
+                [i|
+                  contract C {
+                    uint x;
+                    A constant a = A(0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B);
     
-  --                   function call_A() public view {
-  --                     // should fail since a.x() can be anything
-  --                     assert(a.x() == x);
-  --                   }
-  --                 }
-  --                 contract A {
-  --                   uint public x;
-  --                 }
-  --               |]
-  --             aAddr = Addr 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B
-  --         Just c <- solcRuntime "C" code
-  --         Just a <- solcRuntime "A" code
-  --         Right cex <- runSMT $ query $ do
-  --           vm0 <- abstractVM (Just ("call_A()", [])) [] c SymbolicS
-  --           store <- freshArray (show aAddr) Nothing
-  --           let vm = vm0
-  --                 & set (state . callvalue) 0
-  --                 & over (env . contracts)
-  --                      (Map.insert aAddr (initialContract (RuntimeCode a) &
-  --                                          set EVM.storage (Symbolic store)))
-  --           verify vm Nothing Nothing (Just checkAssertions)
-  --         putStrLn $ "found counterexample:"
+                    function call_A() public view {
+                      // should fail since a.x() can be anything
+                      assert(a.x() == x);
+                    }
+                  }
+                  contract A {
+                    uint public x;
+                  }
+                |]
+              aAddr = Addr 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B
+          Just c <- solcRuntime "C" code
+          Just a <- solcRuntime "A" code
+          Right cex <- runSMT $ query $ do
+            vm0 <- abstractVM (Just ("call_A()", [])) [] c SymbolicS
+            store <- freshArray (show aAddr) Nothing
+            let vm = vm0
+                  & set (state . callvalue) 0
+                  & over (env . contracts)
+                       (Map.insert aAddr (initialContract (RuntimeCode a) &
+                                           set EVM.storage (Symbolic store)))
+            verify vm Nothing Nothing (Just checkAssertions)
+          putStrLn $ "found counterexample:"
 
-  --   ]
-  -- , testGroup "Equivalence checking"
-  --   [
-  --     testCase "yul optimized" $ do
-  --       -- These yul programs are not equivalent: (try --calldata $(seth --to-uint256 2) for example)
-  --       --  A:                               B:
-  --       --  {                                {
-  --       --     calldatacopy(0, 0, 32)           calldatacopy(0, 0, 32)
-  --       --     switch mload(0)                  switch mload(0)
-  --       --     case 0 { }                       case 0 { }
-  --       --     case 1 { }                       case 2 { }
-  --       --     default { invalid() }            default { invalid() }
-  --       -- }                                 }
-  --       let aPrgm = hex "602060006000376000805160008114601d5760018114602457fe6029565b8191506029565b600191505b50600160015250"
-  --           bPrgm = hex "6020600060003760005160008114601c5760028114602057fe6021565b6021565b5b506001600152"
-  --       runSMTWith z3 $ query $ do
-  --         Right counterexample <- equivalenceCheck aPrgm bPrgm Nothing Nothing
-  --         return ()
+    ]
+  , testGroup "Equivalence checking"
+    [
+      testCase "yul optimized" $ do
+        -- These yul programs are not equivalent: (try --calldata $(seth --to-uint256 2) for example)
+        --  A:                               B:
+        --  {                                {
+        --     calldatacopy(0, 0, 32)           calldatacopy(0, 0, 32)
+        --     switch mload(0)                  switch mload(0)
+        --     case 0 { }                       case 0 { }
+        --     case 1 { }                       case 2 { }
+        --     default { invalid() }            default { invalid() }
+        -- }                                 }
+        let aPrgm = hex "602060006000376000805160008114601d5760018114602457fe6029565b8191506029565b600191505b50600160015250"
+            bPrgm = hex "6020600060003760005160008114601c5760028114602057fe6021565b6021565b5b506001600152"
+        runSMTWith z3 $ query $ do
+          Right counterexample <- equivalenceCheck aPrgm bPrgm Nothing Nothing
+          return ()
 
-  --   ]
+    ]
   ]
   where
     (===>) = assertSolidityComputation

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -148,28 +148,20 @@ main = defaultMain $ testGroup "hevm"
     ]
 
   , testGroup "Symbolic buffers"
-    [  testProperty "dynWriteMemory works like writeMemory" $ forAll (genAbiValue (AbiTupleType $ Vector.fromList [AbiUIntType 16, AbiUIntType 16, AbiUIntType 16])) $ \(AbiTuple args) ->
-        let [AbiUInt 16 src', AbiUInt 16 dst', AbiUInt 16 len'] = Vector.toList args
-        in ioProperty $ runSMTWith z3 $ query $ do
+
+      [  testCase "dynWriteMemory works" $ runSMTWith z3{verbose=True} $ query $ do
                cd  <- sbytes32
                mem <- sbytes32
 
                let
-                   zeroList = literal (replicate 1000 0)
-                   src = w256 $ W256 src'
-                   dst = w256 $ W256 dst'
-                   len = w256 $ W256 len'
-                   -- getAt :: SList (WordN 8) -> SInt8
-                   -- getAt = uninterpret "zerolistisZero"
-                   staticWriting = writeMemory' cd src len dst mem
+                   staticWriting = writeMemory' cd 2 2 2 mem
                    dynamicWriting =
-                     dynWriteMemoryPadding
-                      zeroList
-                      (implode' cd)
-                      (litWord src)
-                      (litWord len)
-                      (litWord dst)
-                      (implode' mem)
+                     dynWriteMemory
+                      (implode cd)
+                      (litWord 2)
+                      (litWord 2)
+                      (litWord 2)
+                      (implode mem)
                -- constrain (SL.length zeroList .== 2^32-1)
                -- addAxiom "zero list is all zeros"
                --   [ "(assert (forall ((i Int)) (= (seq.nth s2 i) #x00)))"
@@ -178,10 +170,38 @@ main = defaultMain $ testGroup "hevm"
                io $ print $ length staticWriting
                when ((length staticWriting) < 10000) $
                  let staticVer = implode staticWriting
-                 in checkSatAssuming [staticVer ./= dynamicWriting] >>= \case
+                 in io (putStrLn "solving") >> checkSatAssuming [staticVer ./= dynamicWriting] >>= \case
                    Unsat -> return ()
                    Sat -> do getValue dynamicWriting >>= io . print
-                             getValue dynamicWriting >>= io . print
+                             getValue staticVer >>= io . print
+                             error "oh no!"
+
+      ,  testProperty "dynWriteMemory works like writeMemory" $ forAll (genAbiValue (AbiTupleType $ Vector.fromList [AbiUIntType 16, AbiUIntType 16, AbiUIntType 16])) $ \(AbiTuple args) ->
+        let [AbiUInt 16 src', AbiUInt 16 dst', AbiUInt 16 len'] = Vector.toList args
+        in ioProperty $ runSMTWith z3 $ query $ do
+               cd  <- sbytes32
+               mem <- sbytes32
+
+               let
+                   src = w256 $ W256 src'
+                   dst = w256 $ W256 dst'
+                   len = w256 $ W256 len'
+
+                   staticWriting = writeMemory' cd src len dst mem
+                   dynamicWriting =
+                     dynWriteMemory
+                      (implode cd)
+                      (litWord src)
+                      (litWord len)
+                      (litWord dst)
+                      (implode mem)
+
+               when ((length staticWriting) < 10000 && len' < 10000) $
+                 let staticVer = implode staticWriting
+                 in checkSatAssuming [staticVer ./= dynamicWriting] >>= \case
+                   Unsat -> io $ putStrLn "Success!"
+                   Sat -> do getValue dynamicWriting >>= io . print
+                             getValue staticVer >>= io . print
                              error "oh no!"
                              
 
@@ -673,12 +693,3 @@ assertSolidityComputation (SolidityCall s args) x =
      assertEqual (Text.unpack s)
        (fmap Bytes (Just (encodeAbiValue x)))
        (fmap Bytes y)
-
-
--- implode :: SymVal a => [SBV a] -> SList a
--- implode = foldr ((.++) . singleton) (literal [])
-
-implode' :: [SWord 8] -> SList (WordN 8)
-implode' xs = case mapM unliteral xs of
-  Just xs -> literal xs
-  Nothing -> implode xs

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -59,21 +59,21 @@ main = defaultMain $ testGroup "hevm"
           Right ("", _, x') -> x' == x
           _ -> False
     ]
-  -- , testGroup "Solidity expressions"
-  --   [ testCase "Trivial" $
-  --       SolidityCall "x = 3;" []
-  --         ===> AbiUInt 256 3
+  , testGroup "Solidity expressions"
+    [ testCase "Trivial" $
+        SolidityCall "x = 3;" []
+          ===> AbiUInt 256 3
 
-  --   , testCase "Arithmetic" $ do
-  --       SolidityCall "x = a + 1;"
-  --         [AbiUInt 256 1] ===> AbiUInt 256 2
-  --       SolidityCall "x = a - 1;"
-  --         [AbiUInt 8 0] ===> AbiUInt 8 255
+    , testCase "Arithmetic" $ do
+        SolidityCall "x = a + 1;"
+          [AbiUInt 256 1] ===> AbiUInt 256 2
+        SolidityCall "x = a - 1;"
+          [AbiUInt 8 0] ===> AbiUInt 8 255
 
-  --   , testCase "keccak256()" $
-  --       SolidityCall "x = uint(keccak256(abi.encodePacked(a)));"
-  --         [AbiString ""] ===> AbiUInt 256 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
-  --   ]
+    , testCase "keccak256()" $
+        SolidityCall "x = uint(keccak256(abi.encodePacked(a)));"
+          [AbiString ""] ===> AbiUInt 256 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+    ]
 
   , testGroup "Precompiled contracts"
       [ testGroup "Example (reverse)"
@@ -149,7 +149,7 @@ main = defaultMain $ testGroup "hevm"
 
   , testGroup "Symbolic buffers"
 
-      [  testCase "dynWriteMemory works" $ runSMTWith z3{verbose=True} $ query $ do
+      [  testCase "dynWriteMemory works" $ runSMTWith z3 $ query $ do
                cd  <- sbytes32
                mem <- sbytes32
 
@@ -173,7 +173,7 @@ main = defaultMain $ testGroup "hevm"
                                    getList (DynamicSymBuffer bf) = getValue bf
 
       ,  testProperty "dynWriteMemory works like writeMemory" $
-          withMaxSuccess 10000 $
+--          withMaxSuccess 10000 $
           forAll (genAbiValue (AbiTupleType $ Vector.fromList [AbiUIntType 16, AbiUIntType 16, AbiUIntType 16])) $ \(AbiTuple args) ->
         let [AbiUInt 16 src', AbiUInt 16 dst', AbiUInt 16 len'] = Vector.toList args
         in ioProperty $ runSMTWith z3 $ query $ do
@@ -197,10 +197,13 @@ main = defaultMain $ testGroup "hevm"
                when ((length staticWriting) < 10000 && len' < 10000) $
                  checkSatAssuming [StaticSymBuffer staticWriting ./= dynamicWriting] >>= \case
                    Unsat -> io $ putStrLn "Success!"
-                   Sat -> do -- getValue dynamicWriting >>= io . print
-                             -- getValue staticVer >>= io . print
+                   Sat -> do getList dynamicWriting >>= io . print
+                             getList (StaticSymBuffer staticWriting) >>= io . print
                              error "oh no!"
-                             
+                                where getList :: Buffer -> Query [WordN 8]
+                                      getList (StaticSymBuffer bf) = mapM getValue bf
+                                      getList (DynamicSymBuffer bf) = getValue bf
+
 
     -- ,  testCase "dynWriteMemory pads with zeros appropriately" $
     --       ioProperty $ runSMT $ query $ do
@@ -590,11 +593,11 @@ main = defaultMain $ testGroup "hevm"
 
 runSimpleVM :: ByteString -> ByteString -> Maybe ByteString
 runSimpleVM x ins = case loadVM x of
-                      Nothing -> Nothing
-                      Just vm ->
-                        case runState (assign (state.calldata) (ConcreteBuffer ins) >> exec) vm of
-                            (VMSuccess (ConcreteBuffer bs), _) -> Just bs
-                            _ -> Nothing
+  Nothing -> Nothing
+  Just vm ->
+    case runState (assign (state.calldata) (ConcreteBuffer ins) >> exec) vm of
+      (VMSuccess (ConcreteBuffer bs), _) -> Just bs
+      _ -> Nothing
 
 loadVM :: ByteString -> Maybe VM
 loadVM x =


### PR DESCRIPTION
Introduces support for dynamic data types in memory and calldata (and all over the place, really) through [SMT lists](https://rise4fun.com/z3/tutorialcontent/sequences). These are currently only supported by z3. 
Some clean up needs to happen before this is ready to merge, but I am at the point where I want to trigger some more tests.

There will also be a need for some more execution modes, such as `--no-gas-checks` or `--no-memory-checks` in order to avoid constantly queries z3 about stuff that isn't particularly interesting from a security perspective. 