### PR TITLE
Add chain-id function for returning the network id

### DIFF
--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -70,6 +70,7 @@ Contents
       * [`seth call`]
       * [`seth calldata`]
       * [`seth chain`]
+      * [`seth chain-id`]
       * [`seth code`]
       * [`seth estimate`]
       * [`seth events`]
@@ -460,6 +461,10 @@ genesis block hash.
 Outputs one of `ethlive`, `etclive`, `kovan`, `ropsten`, `goerli`, `morden`,
 `rinkeby`, or `unknown`.
 
+### `seth chain-id`
+
+Print the ethereum chain id. `1` for Mainnet, `42` for Kovan, etc.
+
 ### `seth code`
 
 Print the bytecode of a contract.
@@ -649,6 +654,7 @@ Show all fields unless `<field>` is given.
 [`seth call`]: #seth-call
 [`seth calldata`]: #seth-calldata
 [`seth chain`]: #seth-chain
+[`seth chain-id`]: #seth-chain-id
 [`seth code`]: #seth-code
 [`seth estimate`]: #seth-estimate
 [`seth events`]: #seth-events

--- a/src/seth/libexec/seth/seth-chain-id
+++ b/src/seth/libexec/seth/seth-chain-id
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+seth rpc net_version

--- a/src/seth/libexec/seth/seth-mktx
+++ b/src/seth/libexec/seth/seth-mktx
@@ -16,7 +16,7 @@ fi
 args=(
   --from "$(seth --to-address "$ETH_FROM")"
   --nonce "${ETH_NONCE:-$(seth nonce "$ETH_FROM")}"
-  --chain-id "$(seth rpc net_version)"
+  --chain-id "$(seth chain-id)"
   --gas-price "${ETH_GAS_PRICE:-$(seth gas-price)}"
   --gas-limit "${ETH_GAS:-200000}"
   --value "$value"


### PR DESCRIPTION
Network id can be helpful in scripts and the rpc command is not intuitive. 

* Added a seth command to return the network id
* Updated docs
* Update reference in mktx to use the alias