### PR TITLE
Pessimistically explore both branches on new SMT queries

### DIFF
--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -177,7 +177,7 @@ interpret fetcher maxIter =
                    interpret fetcher maxIter (Stepper.evm m >>= k)
 
           case q of
-            PleaseAskSMT cond pathcond continue -> do
+            PleaseAskSMT _ _ continue -> do
               codelocation <- getCodeLocation <$> get
               iters <- use (iterations . at codelocation)
               case iters of


### PR DESCRIPTION
The current symbolic execution strategy always consults the solver on which branches of a JUMPI are possible. These intermediate queries lets us explore all possible behaviours, and then finally construct a query which checks each possible endstate against the postcondition (usually given by `assert`s).

Some experiments indicate that these intermediate branching queries are quite expensive.
This PR changes this execution strategy so that whenever we reach a branching point we have not seen before, we explore both branches without consulting SMT. This means that we can end up exploring more states than are possible, but since our final query always checks the pathconditions for consistency, this is safe and the extra paths will be pruned anyway.

The numbers for the `hevm-tests` suite look pretty much the same, but the test suite in `test.hs` runs about twice as fast, and for large contracts the difference grows larger
