### PR TITLE
Simplify VMTest for a unified transaction initialization procedure

### DIFF
--- a/src/dapp/libexec/dapp/dapp---make-cache
+++ b/src/dapp/libexec/dapp/dapp---make-cache
@@ -2,6 +2,7 @@
 set -e
 
 [[ "$1" ]] && state="$1" || state="$(TMPDIR=. mktemp -d hevm.cache.XXXXX)"
+mkdir -p "$state"
 # Try to make sure `git commit' definitely succeeds...
 export GIT_CONFIG_NOSYSTEM=1
 export GIT_AUTHOR_NAME=hevm

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -7,11 +7,14 @@
 - z3 updated to 4.8.8
 - optimize SMT queries
 - More useful trace output for unknown calls
+- Default to on chain values for `coinbase`, `timestamp`, `difficulty`, `blocknumber` when rpc is provided
+- Perform tx initialization (gas payment, value transfer) in `hevm exec`, `hevm symbolic` and `hevm dapp-test`.
 
 ### Added
 
 - `--cache` flag for `dapp-test`, `exec`, `symbolic`, `interactive`,
   enabling caching of contracts received by rpc.
+- `load(address,bytes32)` cheat code allowing storage reads from arbitrary contracts.
 
 ## 0.41.0 - 2020-08-19
 

--- a/src/hevm/README.md
+++ b/src/hevm/README.md
@@ -292,6 +292,9 @@ sets the block number to `x`.
 - `function store(address c, bytes32 loc, bytes32 val) public`
 sets the slot `loc` of contract `c` to `val`.
 
+- `function load(address c, bytes32 loc) public`
+reads the slot `loc` of contract `c`.
+
 
 ## Contact
 

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -455,14 +455,15 @@ initialContract theContractCode = Contract
       keccak (stripBytecodeMetadata theCode)
   , _storage  = Concrete mempty
   , _balance  = 0
-  , _nonce    = 0
+  , _nonce    = if creation then 1 else 0
   , _opIxMap  = mkOpIxMap theCode
   , _codeOps  = mkCodeOps theCode
   , _external = False
   , _origStorage = mempty
-  } where theCode = case theContractCode of
-            InitCode b    -> b
-            RuntimeCode b -> b
+  } where
+      (creation, theCode) = case theContractCode of
+            InitCode b    -> (True, b)
+            RuntimeCode b -> (False, b)
 
 contractWithStore :: ContractCode -> Storage -> Contract
 contractWithStore theContractCode store =

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -333,7 +333,7 @@ data Block = Block
   , _gaslimit    :: Word
   , _maxCodeSize :: Word
   , _schedule    :: FeeSchedule Word
-  }
+  } deriving Show
 
 blankState :: FrameState
 blankState = FrameState

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1853,11 +1853,11 @@ cheatActions =
           fetchAccount a $ \_ -> do
             modifying (env . contracts . ix a . storage) (writeStorage slot new),
       action "load(address,bytes32)" [AbiAddressType, AbiBytesType 32] $
-        \outSize outOffset [AbiAddress a, AbiBytes 32 x] -> do
+        \outOffset outSize [AbiAddress a, AbiBytes 32 x] -> do
           let slot = w256lit $ word x
-          accessStorage a slot $ \res ->
+          accessStorage a slot $ \res -> do
+            assign (state . returndata . word256At 0) res
             assign (state . memory . word256At outOffset) res
-
     ]
   where
     action s ts f = (abiKeccak s, (ts, f))

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -44,7 +44,7 @@ ghciTest root path state =
         Just repoPath -> do
           facts <- Git.loadFacts (Git.RepoAt repoPath)
           pure (flip Facts.apply facts)
-    params <- getParametersFromEnvironmentVariables
+    params <- getParametersFromEnvironmentVariables Nothing
     let
       opts = UnitTestOptions
         { oracle = EVM.Fetch.zero
@@ -97,7 +97,7 @@ ghciTty root path state =
         Just repoPath -> do
           facts <- Git.loadFacts (Git.RepoAt repoPath)
           pure (flip Facts.apply facts)
-    params <- getParametersFromEnvironmentVariables
+    params <- getParametersFromEnvironmentVariables Nothing
     let
       testOpts = UnitTestOptions
         { oracle = EVM.Fetch.zero

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -516,7 +516,7 @@ sexpMemory bs =
 
 defaultUnitTestOptions :: MonadIO m => m UnitTestOptions
 defaultUnitTestOptions = do
-  params <- liftIO getParametersFromEnvironmentVariables
+  params <- liftIO $ getParametersFromEnvironmentVariables Nothing
   pure UnitTestOptions
     { oracle            = Fetch.zero
     , verbose           = Nothing

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -587,9 +587,8 @@ setupCall TestVMParams{..} sig args = do
   origin' <- fromMaybe (initialContract (RuntimeCode mempty)) <$> use (env . contracts . at testOrigin)
   let originBal = view balance origin'
   when (originBal <= (w256 testGasprice) * (w256 testGasCall)) $ error "insufficient balance for gas cost"
-  modifying (env . contracts) (setupTx testOrigin testCoinbase (w256 testGasprice) (w256 testGasCall))
   vm <- get
-  put $ initTx vm $ view (env . contracts) vm
+  put $ initTx vm
 
 initialUnitTestVm :: UnitTestOptions -> SolcContract -> VM
 initialUnitTestVm (UnitTestOptions {..}) theContract =

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -332,13 +332,6 @@ vmForCase x =
   let
     checkState = checkContracts x
     vm = EVM.makeVm (testVmOpts x)
-    opts = testVmOpts x
-    creation = EVM.vmoptCreate opts
-    touchedAccounts =
-      if creation then
-        [EVM.vmoptOrigin opts]
-      else
-        [EVM.vmoptOrigin opts, EVM.vmoptAddress opts]
   in
     initTx vm checkState
 


### PR DESCRIPTION
Mainly a clean up of `VMTest.hs`, removing things related to the ethereum tests/[VMTest](https://github.com/ethereum/tests/tree/develop/VMTests) which we haven't run in quite a while, as well as simplifying things generally.

One of my concerns here is to try to use less special case logic when running the ethereum tests, so that we can increase confidence in the correctness of other endpoints.

I'm also adding the setupTx functionality to `UnitTest` so that gas is paid for appropriately, fixing #511. If the sending address cannot afford the initial gas deposit this yields a hard error.

This `setupTx` (and `initTx`) process which increments the origin nonce, pays for gas, and sets the relevant tx reversion state is not done for the `hevm exec` or `hevm symbolic` endpoints right now, but I would like to open up the discussion for whether it should. I think some default values would need to be adjusted if that would be the case, and we may need to start fetching additional information (origin balance), and decide what happens if the tx.origin cannot afford the gas deposit.