### PR TITLE
Sethdebugfixes

### DIFF
--- a/src/seth/libexec/seth/seth-bundle-source
+++ b/src/seth/libexec/seth/seth-bundle-source
@@ -9,7 +9,7 @@
 # seems like we always just want the first element
 set -e
 
-SRC=$(seth source "$1" | jq '.[0]')
+SRC=$(seth source "$1")
 
 SOLC_VERSION=$(echo "$SRC" | jq '.CompilerVersion')
 SOLC_VERSION=${SOLC_VERSION/'"'}

--- a/src/seth/libexec/seth/seth-code
+++ b/src/seth/libexec/seth/seth-code
@@ -9,4 +9,4 @@ set -e
 ADDRESS=$(seth --to-address "$@")
 jshon+=(-s "$ADDRESS" -i append)
 jshon+=(-s "${ETH_BLOCK-latest}" -i append)
-seth rpc eth_getCode -- "${jshon[@]}"
+seth rpc eth_getCode -- "${jshon[@]}" | seth --to-hex

--- a/src/seth/libexec/seth/seth-run-tx
+++ b/src/seth/libexec/seth/seth-run-tx
@@ -20,7 +20,7 @@ else
 fi
 
 TO=$(<<< "$tx" seth --field to)
-DATA=$(<<< "$tx" seth --field input)
+DATA=$(<<< "$tx" seth --field input | seth --to-hex)
 if [[ "$TO" == 'null' ]]; then
   opts+=(--create --code "$DATA")
 else

--- a/src/seth/libexec/seth/seth-source
+++ b/src/seth/libexec/seth/seth-source
@@ -27,8 +27,10 @@ MSG=$(echo "$RESPONSE" | seth --field message)
 ABI=$(echo "$RESPONSE" | seth --field result | jq '.[0].ABI' | seth --show-json)
 
 [[ $MSG == OK ]] || seth --fail "error: bad response: $MSG"
+
+
 if [[ $ABI == "Contract source code not verified" ]]; then
     seth --fail "$ABI"
 else
-    echo "$RESPONSE" | seth --field result
+    echo "$RESPONSE" | seth --field result | jq '.[0]]'
 fi


### PR DESCRIPTION
Supersedes #432. Although #432 is still relevant, its kind of a big change and not something I'd like to push through right now. Instead, this PR does some easy fixes to ensure `seth debug` doesn't produce ridiculous results when calldata is short enough to be misinterpreted as a decimal string.
Also a small fix related to failing seth source queries