### PR TITLE
hotfix for 3f31ca3

### DIFF
--- a/src/dapp/libexec/dapp/dapp-test
+++ b/src/dapp/libexec/dapp/dapp-test
@@ -36,4 +36,4 @@ trap clean EXIT
 
 opts=$(dapp --hevm-opts "$0" "$@")
 # shellcheck disable=SC2068
-hevm dapp-test --dapp-root="${DAPP_ROOT}" --json-file="${DAPP_JSON}" --dapp-root=. --state="$state" ${opts[@]}
+hevm dapp-test --dapp-root="${DAPP_ROOT}" --json-file="${DAPP_JSON}" --state="$state" ${opts[@]}


### PR DESCRIPTION
Also don't think the `cd $DAPP_ROOT` are necessary, but will address those separately. @lucasvo @MrChico 