### PR TITLE
Fix seth missing grep

### DIFF
--- a/haskell.nix
+++ b/haskell.nix
@@ -14,7 +14,7 @@ in self-hs: super-hs:
         (self-hs.callCabal2nix x y {});
 
     sbv_prepatch = pkgs.haskell.lib.dontCheck (self-hs.callCabal2nix "sbv" (builtins.fetchGit {
-        url = "https://github.com/LeventErkok/sbv/";
+        url = "https://github.com/LeventErkok/sbv";
         rev = "fe5f5aff026307a1582cc7eafbbabd26796ef434";
     })    {inherit (pkgs) z3;});
 

--- a/src/seth/default.nix
+++ b/src/seth/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, makeWrapper, glibcLocales, solc, nix
 , bc, coreutils, curl, ethsign, git, gnused, jq, jshon, nodejs, perl
-,  hevm, shellcheck, dapptoolsSrc }:
+, gnugrep, hevm, shellcheck, dapptoolsSrc }:
 
 stdenv.mkDerivation rec {
   name = "seth-${version}";
@@ -17,6 +17,7 @@ stdenv.mkDerivation rec {
     let
       path = lib.makeBinPath [
         bc coreutils curl ethsign git gnused nix jq hevm jshon nodejs perl solc
+        gnugrep
       ];
     in
       ''


### PR DESCRIPTION
- Fix for reported error: `/nix/store/gb73icd6lliyyn6f33l29bydjqklv01k-seth-0.8.2/libexec/seth/seth---field: line 3: grep: command not found`
- Also couldn't do `nix-build -A seth` because of a trailing slash in `https://github.com/LeventErkok/sbv/` causing `ERROR: Repository not found.`