### PR TITLE
Fall back to old method for detecting bytecode metadata

### DIFF
--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -103,7 +103,6 @@ library
     directory                         >= 1.3.3 && < 1.4,
     filepath                          >= 1.4.2 && < 1.5,
     vty                               >= 5.25.1 && < 5.31,
-    cborg                             >= 0.2.2 && < 0.3,
     cereal                            >= 0.5.8 && < 0.6,
     cryptonite                        >= 0.25 && < 0.28,
     memory                            >= 0.14.18 && < 0.16,

--- a/src/hevm/src/EVM/Format.hs
+++ b/src/hevm/src/EVM/Format.hs
@@ -294,7 +294,7 @@ showError bs = case BS.take 4 bs of
   _             -> formatBinary bs
 
 showValues :: [AbiType] -> Buffer -> Text
-showValues ts (SymbolicBuffer sbs) = "symbolic: " <> (pack . show $ AbiTupleType (fromList ts))
+showValues ts (SymbolicBuffer  _) = "symbolic: " <> (pack . show $ AbiTupleType (fromList ts))
 showValues ts (ConcreteBuffer bs) =
   case runGetOrFail (getAbiSeq (length ts) ts) (fromStrict bs) of
     Right (_, _, xs) -> showAbiValues xs

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -6,6 +6,7 @@
 module EVM.Solidity
   ( solidity
   , solcRuntime
+  , solidity'
   , JumpType (..)
   , SolcContract (..)
   , StorageItem (..)
@@ -66,7 +67,6 @@ import Data.Sequence        (Seq)
 import Data.Text            (Text, pack, intercalate)
 import Data.Text.Encoding   (encodeUtf8)
 import Data.Text.IO         (readFile, writeFile)
-import Data.Tuple           (swap)
 import Data.Vector          (Vector)
 import Data.Word
 import GHC.Generics         (Generic)
@@ -437,9 +437,8 @@ solidity' src = withSystemTempFile "hevm.sol" $ \path handle -> do
 -- difference there.
 stripBytecodeMetadata :: ByteString -> ByteString
 stripBytecodeMetadata bs =
-  let breakSubstringFromEnd x suff = swap $ (bimap BS.reverse BS.reverse) $ BS.breakSubstring (BS.reverse suff) (BS.reverse x)
-      stripCandidates = breakSubstringFromEnd bs <$> knownBzzrPrefixes in
-    case find ((/= mempty) . fst) stripCandidates of
+  let stripCandidates = flip BS.breakSubstring bs <$> knownBzzrPrefixes in
+    case find ((/= mempty) . snd) stripCandidates of
       Nothing -> bs
       Just (b, _) -> b
 

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -49,18 +49,13 @@ import EVM.ABI
 import EVM.Keccak
 import EVM.Types
 
-import Codec.CBOR.Term      (decodeTerm)
-import Codec.CBOR.Read      (deserialiseFromBytes)
 import Control.Applicative
 import Control.Lens         hiding (Indexed)
 import Data.Aeson           (Value (..))
 import Data.Aeson.Lens
 import Data.Scientific
-import Data.Binary.Get      (runGet, getWord16be)
 import Data.ByteString      (ByteString)
-import Data.ByteString.Lazy (fromStrict)
 import Data.Char            (isDigit)
-import Data.Either          (isRight)
 import Data.Foldable
 import Data.Map.Strict      (Map)
 import Data.Maybe
@@ -71,6 +66,7 @@ import Data.Sequence        (Seq)
 import Data.Text            (Text, pack, intercalate)
 import Data.Text.Encoding   (encodeUtf8)
 import Data.Text.IO         (readFile, writeFile)
+import Data.Tuple           (swap)
 import Data.Vector          (Vector)
 import Data.Word
 import GHC.Generics         (Generic)
@@ -440,14 +436,24 @@ solidity' src = withSystemTempFile "hevm.sol" $ \path handle -> do
 -- as the codehash matches otherwise, we don't care if there is some
 -- difference there.
 stripBytecodeMetadata :: ByteString -> ByteString
-stripBytecodeMetadata bc | BS.length cl /= 2 = bc
-                         | BS.length h >= cl' && (isRight . deserialiseFromBytes decodeTerm $ fromStrict cbor) = bc'
-                         | otherwise = bc
-  where
-      l = BS.length bc
-      (h, cl) = BS.splitAt (l - 2) bc
-      cl' = fromIntegral . runGet getWord16be $ fromStrict cl
-      (bc', cbor) = BS.splitAt (BS.length h - cl') h
+stripBytecodeMetadata bs =
+  let breakSubstringFromEnd x suff = swap $ (bimap BS.reverse BS.reverse) $ BS.breakSubstring (BS.reverse suff) (BS.reverse x)
+      stripCandidates = breakSubstringFromEnd bs <$> knownBzzrPrefixes in
+    case find ((/= mempty) . fst) stripCandidates of
+      Nothing -> bs
+      Just (b, _) -> b
+
+knownBzzrPrefixes :: [ByteString]
+knownBzzrPrefixes = [
+  -- a1 65 "bzzr0" 0x58 0x20 (solc <= 0.5.8)
+  BS.pack [0xa1, 0x65, 98, 122, 122, 114, 48, 0x58, 0x20],
+  -- a2 65 "bzzr0" 0x58 0x20 (solc >= 0.5.9)
+  BS.pack [0xa2, 0x65, 98, 122, 122, 114, 48, 0x58, 0x20],
+  -- a2 65 "bzzr1" 0x58 0x20 (solc >= 0.5.11)
+  BS.pack [0xa2, 0x65, 98, 122, 122, 114, 49, 0x58, 0x20],
+  -- a2 64 "ipfs" 0x58 0x22 (solc >= 0.6.0)
+  BS.pack [0xa2, 0x64, 0x69, 0x70, 0x66, 0x73, 0x58, 0x22]
+  ]
 
 -- | Every node in the AST has an ID, and other nodes reference those
 -- IDs.  This function recurses through the tree looking for objects

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -27,7 +27,6 @@ import Control.Arrow ((***), (&&&))
 import Control.Lens
 import Control.Monad
 
-import Data.ByteString (ByteString)
 import Data.Aeson ((.:), FromJSON (..))
 import Data.Foldable (fold)
 import Data.Map (Map)
@@ -314,10 +313,7 @@ checkTx :: Transaction -> Block -> Map Addr EVM.Contract -> Maybe (Map Addr EVM.
 checkTx tx block prestate = do
   origin <- sender 1 tx
   validateTx tx prestate
-  let gasPrice = EVM.w256 $ txGasPrice tx
-      gasLimit = EVM.w256 $ txGasLimit tx
-      coinbase   = blockCoinbase block
-      isCreate   = isNothing (txToAddr tx)
+  let isCreate   = isNothing (txToAddr tx)
       senderNonce = EVM.wordValue $ view (accountAt origin . nonce) prestate
       toAddr      = fromMaybe (EVM.createAddress origin senderNonce) (txToAddr tx)
       prevCode    = view (accountAt toAddr . contractcode) prestate


### PR DESCRIPTION
as the cborg based detection could not account for constructor args,
resulting in no srcmaps for init methods with arguments.

Revert "fix stripBytecodeMetadata"

This reverts commit 78508c6a8db2d6d3e8e09437dbe122bb5e6b2e7e.