### PR TITLE
Use `fetchTarball` instead of `fetchGit` to get `nixpkgs`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,11 @@
 { system ? builtins.currentSystem , ... }:
 
 let
-  nixpkgs = builtins.fetchGit {
-    url = "https://github.com/nixos/nixpkgs";
-    ref = "release-20.03";
-    rev = "5272327b81ed355bbed5659b8d303cf2979b6953";
+  rev = "5272327b81ed355bbed5659b8d303cf2979b6953";
+  nixpkgs = builtins.fetchTarball {
+    name = "nixpkgs-release-20.03";
+    url = "https://github.com/nixos/nixpkgs/tarball/${rev}";
+    sha256 = "0182ys095dfx02vl2a20j1hz92dx3mfgz2a6fhn31bqlp1wa8hlq";
   };
 in
   # Now return the Nixpkgs configured to use our overlay.


### PR DESCRIPTION
Because of excruciating download times for `nixpkgs` when using `fetchGit` on CIs where no cache/store is already populated.