### PR TITLE
get storagemodel from PleaseFetchAccount, not in oracle

### DIFF
--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -270,8 +270,8 @@ unitTestOptions cmd testFile = do
   pure EVM.UnitTest.UnitTestOptions
     { EVM.UnitTest.oracle =
         case rpc cmd of
-         Just url -> EVM.Fetch.oracle (Just state) (Just (block', url)) InitialS True
-         Nothing  -> EVM.Fetch.oracle (Just state) Nothing InitialS True
+         Just url -> EVM.Fetch.oracle (Just state) (Just (block', url)) True
+         Nothing  -> EVM.Fetch.oracle (Just state) Nothing True
     , EVM.UnitTest.maxIter = maxIterations cmd
     , EVM.UnitTest.smtTimeout = smttimeout cmd
     , EVM.UnitTest.solver = solver cmd
@@ -477,7 +477,6 @@ assert :: Command Options.Unwrapped -> IO ()
 assert cmd = do
   let block'  = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber (block cmd)
       rpcinfo = (,) block' <$> rpc cmd
-      model = fromMaybe (if create cmd then InitialS else SymbolicS) (storageModel cmd)
       treeShowing :: Tree BranchInfo -> Query ()
       treeShowing tree =
         when (showTree cmd) $ do
@@ -501,7 +500,7 @@ assert cmd = do
       io $ void $ EVM.TTY.runFromVM
         (maxIterations cmd)
         srcInfo
-        (EVM.Fetch.oracle (Just smtState) rpcinfo model True)
+        (EVM.Fetch.oracle (Just smtState) rpcinfo True)
         preState
 
   else

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -156,14 +156,14 @@ fetchSlotFrom n url addr slot =
     (\s -> fetchSlotWithSession n url s addr slot)
 
 http :: BlockNumber -> Text -> Fetcher
-http n url = oracle Nothing (Just (n, url)) EVM.ConcreteS True
+http n url = oracle Nothing (Just (n, url)) True
 
 zero :: Fetcher
-zero = oracle Nothing Nothing EVM.ConcreteS True
+zero = oracle Nothing Nothing True
 
 -- smtsolving + (http or zero)
-oracle :: Maybe SBV.State -> Maybe (BlockNumber, Text) -> StorageModel -> Bool -> Fetcher
-oracle smtstate info model ensureConsistency q = do
+oracle :: Maybe SBV.State -> Maybe (BlockNumber, Text) -> Bool -> Fetcher
+oracle smtstate info ensureConsistency q = do
   case q of
     EVM.PleaseAskSMT branchcondition pathconditions continue ->
       case smtstate of
@@ -175,7 +175,7 @@ oracle smtstate info model ensureConsistency q = do
 
     -- if we are using a symbolic storage model,
     -- we generate a new array to the fetched contract here
-    EVM.PleaseFetchContract addr continue -> do
+    EVM.PleaseFetchContract addr model continue -> do
       contract <- case info of
                     Nothing -> return $ Just $ initialContract (EVM.RuntimeCode mempty)
                     Just (n, url) -> fetchContractFrom n url addr

--- a/src/hevm/src/EVM/Format.hs
+++ b/src/hevm/src/EVM/Format.hs
@@ -201,7 +201,7 @@ showTrace dapp trace =
 
     QueryTrace q ->
       case q of
-        PleaseFetchContract addr _ ->
+        PleaseFetchContract addr _ _ ->
           "fetch contract " <> pack (show addr) <> pos
         PleaseFetchSlot addr slot _ ->
           "fetch storage slot " <> pack (show slot) <> " from " <> pack (show addr) <> pos

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -298,7 +298,7 @@ verify :: VM -> Maybe Integer -> Maybe (Fetch.BlockNumber, Text) -> Maybe Postco
 verify preState maxIter rpcinfo maybepost = do
   let model = view (env . storageModel) preState
   smtState <- queryState
-  tree <- interpret' (Fetch.oracle (Just smtState) rpcinfo model False) maxIter preState
+  tree <- interpret' (Fetch.oracle (Just smtState) rpcinfo False) maxIter preState
   case maybepost of
     (Just post) -> do
       let livePaths = pruneDeadPaths $ leaves tree
@@ -334,10 +334,10 @@ equivalenceCheck bytecodeA bytecodeB maxiter signature' = do
 
   smtState <- queryState
   push 1
-  aVMs <- interpret' (Fetch.oracle (Just smtState) Nothing SymbolicS False) maxiter preStateA
+  aVMs <- interpret' (Fetch.oracle (Just smtState) Nothing False) maxiter preStateA
   pop 1
   push 1
-  bVMs <- interpret' (Fetch.oracle (Just smtState) Nothing SymbolicS False) maxiter preStateB
+  bVMs <- interpret' (Fetch.oracle (Just smtState) Nothing False) maxiter preStateB
   pop 1
   -- Check each pair of endstates for equality:
   let differingEndStates = uncurry distinct <$> [(a,b) | a <- pruneDeadPaths (leaves aVMs), b <- pruneDeadPaths (leaves bVMs)]

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -510,13 +510,12 @@ symRun opts@UnitTestOptions{..} concreteVm testName types = do
     SBV.resetAssertions
     let vm = symbolify concreteVm
     cd <- first SymbolicBuffer <$> symCalldata testName types []
-    let model = view (env . storageModel) vm
-        shouldFail = "proveFail" `isPrefixOf` testName
+    let shouldFail = "proveFail" `isPrefixOf` testName
 
     -- get all posible postVMs for the test method
     allPaths <- fst <$> runStateT
         (EVM.SymExec.interpret
-          (EVM.Fetch.oracle smtState Nothing model False)
+          (EVM.Fetch.oracle smtState Nothing False)
           maxIter
           (execSymTest opts testName cd))
         vm


### PR DESCRIPTION
Passing the storagemodel in oracle can lead to inconsistencies. This solves #541.