### PR TITLE
Gethcompliance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      # v10
+      # v12
       - uses: cachix/install-nix-action@v12
         with:
           # we use the nixpkgs defined in default.nix
           skip_adding_nixpkgs_channel: false
-      # v6
-      - uses: cachix/cachix-action@490a246fbc7f92208d309eeb54383a4d828cedc1
+      # v8
+      - uses: cachix/cachix-action@v8
         with:
           name: dapp
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,15 +21,14 @@ jobs:
       # v12
       - uses: cachix/install-nix-action@v12
         with:
-          # we use the nixpkgs defined in default.nix
-          skip_adding_nixpkgs_channel: false
+          nix_path: nixpkgs=channel:nixos-unstable
       # v8
       - uses: cachix/cachix-action@v8
         with:
           name: dapp
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - name: run dapp tests
-        run: nix-env -iA nixpkgs.bashInteractive && nix-shell --pure src/dapp-tests/shell.nix --command 'make --directory src/dapp-tests'
+        run: nix-shell --pure src/dapp-tests/shell.nix --command 'make --directory src/dapp-tests'
       - name: run hevm symbolic tests
         run: nix-build -j 1 -A hevm-tests
       - run: nix-build release.nix -A dapphub.${{ matrix.os_attr }}.stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # v10
-      - uses: cachix/install-nix-action@63cf434de4e4292c6960639d56c5dd550e789d77
+      - uses: cachix/install-nix-action@v12
         with:
           # we use the nixpkgs defined in default.nix
           skip_adding_nixpkgs_channel: false

--- a/src/dapp-tests/Makefile
+++ b/src/dapp-tests/Makefile
@@ -1,3 +1,5 @@
-test:; integration/tests.sh
+test:
+	pytest --hypothesis-show-statistics integration/diff-fuzz.py
+	integration/tests.sh
 
 .PHONY: test

--- a/src/dapp-tests/integration/diff-fuzz.py
+++ b/src/dapp-tests/integration/diff-fuzz.py
@@ -5,7 +5,7 @@ import os
 from hypothesis import given, example, settings
 from hypothesis.strategies import binary
 
-@settings(max_examples=999)
+@settings(max_examples=9999999999)
 @given(binary(min_size=1))
 @example(bytes.fromhex('60016000036000f3'))
 @example(bytes.fromhex('65f3b2bd95ccaa4520ee607eb0825f'))

--- a/src/dapp-tests/integration/diff-fuzz.py
+++ b/src/dapp-tests/integration/diff-fuzz.py
@@ -1,0 +1,58 @@
+from datetime import timedelta
+import json
+import os
+
+from hypothesis import given, example, settings
+from hypothesis.strategies import binary
+
+@settings(max_examples=999)
+@given(binary(min_size=1))
+@example(bytes.fromhex('60016000036000f3'))
+@example(bytes.fromhex('65f3b2bd95ccaa4520ee607eb0825f'))
+@example(bytes.fromhex('6101'))
+@example(bytes.fromhex('32'))
+@example(bytes.fromhex('33'))
+@example(bytes.fromhex('30'))
+@example(bytes.fromhex('45'))
+@example(bytes.fromhex('46'))
+@example(bytes.fromhex('4151'))
+def test_compare_geth_hevm(b):
+    code = b.hex()
+    print("code")
+    print(code)
+    x = os.system('evm --code ' + code + ' --gas 0xfffffffff --json --receiver 0xacab run > gethout')
+    y = os.system('hevm exec --code ' + code + ' --gas 0xfffffffff --chainid 0x539 --gaslimit 0xfffffffff --jsontrace --origin 0x73656e646572 --caller 0x73656e646572 > hevmout')
+    assert x == y
+    gethlines = open('gethout').read().split('\n')
+    hevmlines = open('hevmout').read().split('\n')
+    for i in range(len(hevmlines) - 2):
+        gethline = gethlines[i]
+        hevmline = hevmlines[i]
+        hjson = json.loads(hevmline)
+        gjson = json.loads(gethline)
+        # print('')
+        # print('--- STEP ----')
+        # print('geth thinks that')
+        # print(gethline)
+        # print('while hevm believes')
+        # print(hevmline)
+        # print('')
+
+        assert hjson['pc']      == gjson['pc']
+        assert hjson['stack']   == gjson['stack']
+        # we can't compare memory for now because geth
+        # uses an odd format
+        # assert hjson['memory']  == gjson['memory']
+        # assert hjson['memSize'] == gjson['memSize']
+        assert hjson['gas']     == gjson['gas']
+    gethres = json.loads(gethlines[len(gethlines) - 2])
+    hevmres = json.loads(hevmlines[len(hevmlines) - 2])
+    # print('--- OUTPUT ----')
+    # print('geth thinks that')
+    # print(gethres)
+    # print('while hevm believes')
+    # print(hevmres)
+    assert gethres['output'] == hevmres['output']
+    assert gethres['gasUsed'] == hevmres['gasUsed']
+        
+test_compare_geth_hevm()

--- a/src/dapp-tests/integration/diff-fuzz.py
+++ b/src/dapp-tests/integration/diff-fuzz.py
@@ -17,11 +17,12 @@ from hypothesis.strategies import binary
 @example(bytes.fromhex('46'))
 @example(bytes.fromhex('4151'))
 @example(bytes.fromhex('303b3b'))
+@example(bytes.fromhex('6219000151'))
 def test_compare_geth_hevm(b):
     code = b.hex()
     print("code")
     print(code)
-    x = os.system('evm --code ' + code + ' --gas 0xfffffffff --json --receiver 0xacab run > gethout')
+    x = os.system('evm --code ' + code + ' --gas 0xfffffffff --json --receiver 0xacab run --nomemory > gethout')
     y = os.system('hevm exec --code ' + code + ' --gas 0xfffffffff --chainid 0x539 --gaslimit 0xfffffffff --jsontrace --origin 0x73656e646572 --caller 0x73656e646572 > hevmout')
     assert x == y
     gethlines = open('gethout').read().split('\n')
@@ -41,9 +42,9 @@ def test_compare_geth_hevm(b):
 
         assert hjson['pc']      == gjson['pc']
         assert hjson['stack']   == gjson['stack']
-        # we can't compare memory for now because geth
-        # uses an odd format
-        # assert hjson['memory']  == gjson['memory']
+        # we can't compare memsize for now because geth
+        # measures memory and memsize after the instruction,
+        # as opposed to all other fields...
         # assert hjson['memSize'] == gjson['memSize']
         assert hjson['gas']     == gjson['gas']
     gethres = json.loads(gethlines[len(gethlines) - 2])

--- a/src/dapp-tests/integration/diff-fuzz.py
+++ b/src/dapp-tests/integration/diff-fuzz.py
@@ -22,7 +22,7 @@ def test_compare_geth_hevm(b):
     code = b.hex()
     print("code")
     print(code)
-    x = os.system('evm --code ' + code + ' --gas 0xfffffffff --json --receiver 0xacab run --nomemory > gethout')
+    x = os.system('evm --code ' + code + ' --gas 0xfffffffff --json --receiver 0xacab --nomemory run  > gethout')
     y = os.system('hevm exec --code ' + code + ' --gas 0xfffffffff --chainid 0x539 --gaslimit 0xfffffffff --jsontrace --origin 0x73656e646572 --caller 0x73656e646572 > hevmout')
     assert x == y
     gethlines = open('gethout').read().split('\n')

--- a/src/dapp-tests/integration/diff-fuzz.py
+++ b/src/dapp-tests/integration/diff-fuzz.py
@@ -4,12 +4,14 @@ import os
 from hypothesis import given, example, settings, note, target
 from hypothesis.strategies import binary
 
-@settings(max_examples=999, deadline=1000)
+@settings(max_examples=9999, deadline=1000)
 @given(binary(min_size=1))
+# these are meant without the prefix
 @example(bytes.fromhex('60016000036000f3'))
 @example(bytes.fromhex('65f3b2bd95ccaa4520ee607eb0825f'))
 @example(bytes.fromhex('6101'))
 @example(bytes.fromhex('32'))
+@example(bytes.fromhex('04'))
 @example(bytes.fromhex('33'))
 @example(bytes.fromhex('30'))
 @example(bytes.fromhex('45'))
@@ -18,12 +20,18 @@ from hypothesis.strategies import binary
 @example(bytes.fromhex('303b3b'))
 @example(bytes.fromhex('6219000151'))
 @example(bytes.fromhex('600134f3'))
+@example(bytes.fromhex('600141fd'))
+@example(bytes.fromhex('2d010101'))
+@example(bytes.fromhex('60006000601260136014601560166018f4'))
+
 def test_compare_geth_hevm(b):
     code = b.hex()
     note("code that caused failure: ")
     note(code)
-    x = os.system('evm --code ' + code + ' --gas 0xfffffffff --json --receiver 0xacab --nomemory run  > gethout')
-    y = os.system('hevm exec --code ' + code + ' --gas 0xfffffffff --chainid 0x539 --gaslimit 0xfffffffff --jsontrace --origin 0x73656e646572 --caller 0x73656e646572 > hevmout')
+    # prepopulate the stack a bit
+    prefix = "6000600160026003600460056006600760086009600a600b600c600d600e600f60106011601260136014601560166017"
+    x = os.system('evm --code ' + prefix + code + ' --gas 0xfffffffff --json --receiver 0xacab --nomemory run  > gethout')
+    y = os.system('hevm exec --code ' + prefix + code + ' --gas 0xfffffffff --chainid 0x539 --gaslimit 0xfffffffff --jsontrace --origin 0x73656e646572 --caller 0x73656e646572 > hevmout')
     assert x == y
     gethlines = open('gethout').read().split('\n')
     hevmlines = open('hevmout').read().split('\n')

--- a/src/dapp-tests/integration/diff-fuzz.py
+++ b/src/dapp-tests/integration/diff-fuzz.py
@@ -16,6 +16,7 @@ from hypothesis.strategies import binary
 @example(bytes.fromhex('45'))
 @example(bytes.fromhex('46'))
 @example(bytes.fromhex('4151'))
+@example(bytes.fromhex('303b3b'))
 def test_compare_geth_hevm(b):
     code = b.hex()
     print("code")
@@ -25,7 +26,7 @@ def test_compare_geth_hevm(b):
     assert x == y
     gethlines = open('gethout').read().split('\n')
     hevmlines = open('hevmout').read().split('\n')
-    for i in range(len(hevmlines) - 2):
+    for i in range(len(hevmlines) - 3):
         gethline = gethlines[i]
         hevmline = hevmlines[i]
         hjson = json.loads(hevmline)

--- a/src/dapp-tests/integration/tests.sh
+++ b/src/dapp-tests/integration/tests.sh
@@ -12,11 +12,6 @@ error() {
     exit 1
 }
 
-hevm_diff_fuzz() {
-    python3 ./integration/diff-fuzz.py
-}
-hevm_diff_fuzz
-
 # tests some of the behaviour of
 # `dapp testnet`
 # `seth ls`

--- a/src/dapp-tests/integration/tests.sh
+++ b/src/dapp-tests/integration/tests.sh
@@ -12,6 +12,11 @@ error() {
     exit 1
 }
 
+hevm_diff_fuzz() {
+    python3 ./integration/diff-fuzz.py
+}
+hevm_diff_fuzz
+
 # tests some of the behaviour of
 # `dapp testnet`
 # `seth ls`

--- a/src/dapp-tests/shell.nix
+++ b/src/dapp-tests/shell.nix
@@ -6,6 +6,7 @@ with pkgs;
 let
   my-python-packages = python-packages: with python-packages; [
     hypothesis
+    pytest
     # other python packages you want
   ]; 
   python-with-pkgs = python3.withPackages my-python-packages;

--- a/src/dapp-tests/shell.nix
+++ b/src/dapp-tests/shell.nix
@@ -2,8 +2,16 @@
   pkgs ? import ../.. {}
 }:
 
-pkgs.mkShell {
-  name = "dapp-tests";
+with pkgs;
+let
+  my-python-packages = python-packages: with python-packages; [
+    hypothesis
+    # other python packages you want
+  ]; 
+  python-with-pkgs = python3.withPackages my-python-packages;
+in
 
-  buildInputs = with pkgs; [ killall cacert bashInteractive curl dapp gnumake hevm procps seth solc ];
+mkShell {
+  name = "dapp-tests";
+  buildInputs = [ killall cacert bashInteractive curl dapp gnumake hevm procps seth solc go-ethereum python-with-pkgs ];
 }

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -184,7 +184,7 @@ data Command w
       { file      :: w ::: String    <?> "Path to .json test file"
       , test      :: w ::: [String]  <?> "Test case filter - only run specified test method(s)"
       , debug     :: w ::: Bool      <?> "Run interactively"
-      , jsontrace :: w ::: Bool             <?> "Print json trace output at every step"
+      , jsontrace :: w ::: Bool      <?> "Print json trace output at every step"
       , diff      :: w ::: Bool      <?> "Print expected vs. actual state on failure"
       , timeout   :: w ::: Maybe Int <?> "Execution timeout (default: 10 sec.)"
       }

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -113,7 +113,7 @@ data VM = VM
 
 data Trace = Trace
   { _traceCodehash :: W256
-  , _traceOpIx     :: Int
+  , _traceOpIx     :: Maybe Int
   , _traceData     :: TraceData
   }
   deriving (Show)
@@ -2281,7 +2281,7 @@ withTraceLocation x = do
   pure Trace
     { _traceData = x
     , _traceCodehash = view codehash this
-    , _traceOpIx = (view opIxMap this) Vector.! (view (state . pc) vm)
+    , _traceOpIx = (view opIxMap this) Vector.!? (view (state . pc) vm)
     }
 
 pushTrace :: TraceData -> EVM ()

--- a/src/hevm/src/EVM/Concrete.hs
+++ b/src/hevm/src/EVM/Concrete.hs
@@ -14,6 +14,7 @@ import Data.ByteString (ByteString)
 import Data.Maybe      (fromMaybe)
 import Data.Semigroup  ((<>))
 import Data.Word       (Word8)
+import Data.Aeson
 
 import Text.Printf
 
@@ -61,6 +62,9 @@ w256 :: W256 -> Word
 w256 = C Dull
 
 data Word = C Whiff W256 --maybe to remove completely in the future
+
+instance ToJSON Word where
+  toJSON (C _ x) = toJSON x
 
 wordValue :: Word -> W256
 wordValue (C _ x) = x

--- a/src/hevm/src/EVM/Dapp.hs
+++ b/src/hevm/src/EVM/Dapp.hs
@@ -116,9 +116,9 @@ traceSrcMap dapp trace =
     Nothing ->
       Nothing
     Just (Creation, solc) ->
-      preview (creationSrcmap . ix i) solc
+      i >>= \i' -> preview (creationSrcmap . ix i') solc
     Just (Runtime, solc) ->
-      preview (runtimeSrcmap . ix i) solc
+      i >>= \i' -> preview (runtimeSrcmap . ix i') solc
 
 showTraceLocation :: DappInfo -> Trace -> Either Text Text
 showTraceLocation dapp trace =

--- a/src/hevm/src/EVM/Debug.hs
+++ b/src/hevm/src/EVM/Debug.hs
@@ -15,7 +15,7 @@ import qualified Data.Map              as Map
 
 import Text.PrettyPrint.ANSI.Leijen
 
-data Mode = Debug | Run deriving (Eq, Show)
+data Mode = Debug | Run | JsonTrace deriving (Eq, Show)
 
 object :: [(Doc, Doc)] -> Doc
 object xs =

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -185,6 +185,7 @@ vmres vm =
     gasUsed' = view (tx . txgaslimit) vm - view (state . EVM.gas) vm
     res = case view result vm of
       Just (VMSuccess out) -> forceBuffer out
+      Just (VMFailure (Revert out)) -> out
       _ -> mempty
   in VMTraceResult
      -- more oddities to comply with geth

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -143,7 +143,7 @@ data VMTrace =
   { pc      :: Int
   , op      :: Int
   , stack   :: [Word]
-  , memory  :: ByteStringS
+--  , memory  :: ByteStringS
   , memSize :: Int
   , depth   :: Int
   , gas     :: Word
@@ -174,7 +174,7 @@ vmtrace vm =
              , op = num $ getOp vm
              , gas = the state EVM.gas
              -- pad to match geth format
-             , memory = ByteStringS . padRight memsize $ forceBuffer $ the state EVM.memory
+--             , memory = ByteStringS . padRight memsize $ forceBuffer $ the state EVM.memory
              , memSize = memsize
              -- increment to match geth format
              , depth = 1 + length (view frames vm)

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -1,10 +1,16 @@
+{-# LANGUAGE DeriveAnyClass #-}
 module EVM.Dev where
 
 import System.Directory
 
+import Prelude hiding (Word)
+
+import EVM.Types
 import EVM.Dapp
 import EVM.Solidity
 import EVM.UnitTest
+import EVM.Concrete
+import EVM.Symbolic
 
 import qualified EVM.Fetch
 import qualified EVM.TTY
@@ -14,12 +20,24 @@ import qualified EVM.Facts.Git as Git
 import qualified EVM.Stepper
 import qualified EVM.VMTest    as VMTest
 
-import Data.SBV
+import Data.SBV hiding (Word)
+import qualified Data.Aeson           as JSON
+import Options.Generic
 import Data.SBV.Trans.Control
 import Control.Monad.State.Strict (execStateT)
 
 import qualified Data.Map as Map
 import qualified Data.ByteString.Lazy   as LazyByteString
+import qualified Data.ByteString      as BS
+import qualified Data.ByteString.Lazy.Char8 as B
+import qualified Control.Monad.State.Class as State
+import Control.Monad.State.Strict (runState, liftIO, StateT, get)
+import Control.Lens
+import Control.Monad.Operational (Program, singleton, ProgramViewT(..), ProgramView)
+import qualified Control.Monad.Operational as Operational
+import EVM
+import qualified EVM.Exec
+import qualified EVM.Fetch as Fetch
 import Data.Text (Text, isPrefixOf)
 
 concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
@@ -119,3 +137,108 @@ ghciEmacs =
 
 foo :: IO ()
 foo = ghciEmacs
+
+data VMTrace =
+  VMTrace
+  { pc      :: Int
+  , op      :: Int
+  , stack   :: [Word]
+  , memory  :: ByteStringS
+  , memSize :: Int
+  , depth   :: Int
+  , gas     :: Word
+  } deriving (Generic, JSON.ToJSON)
+
+data VMTraceResult =
+  VMTraceResult
+  { output  :: String
+  , gasUsed :: Word
+  } deriving (Generic, JSON.ToJSON)
+
+vmtrace :: VM -> VMTrace
+vmtrace vm =
+  let
+    -- Convenience function to access parts of the current VM state.
+    -- Arcane type signature needed to avoid monomorphism restriction.
+    the :: (b -> VM -> Const a VM) -> ((a -> Const a a) -> b) -> a
+    the f g = view (f . g) vm
+    op' = if BS.length (the state code) <= the state EVM.pc
+          then 0
+          else fromIntegral $ BS.index (the state code) (the state EVM.pc)
+    memsize = the state memorySize
+  in VMTrace { pc = the state EVM.pc
+             , op = op'
+             , gas = the state EVM.gas
+             -- pad to match geth format
+             , memory = ByteStringS . padRight memsize $ forceBuffer $ the state EVM.memory
+             , memSize = memsize
+             -- increment to match geth format
+             , depth = 1 + length (view frames vm)
+             -- reverse to match geth format
+             , stack = reverse $ forceLit <$> the state EVM.stack
+             }
+
+vmres :: VM -> VMTraceResult
+vmres vm =
+  let
+    gasUsed' = view (tx . txgaslimit) vm - view (state . EVM.gas) vm
+    res = case view result vm of
+      Just (VMSuccess out) -> forceBuffer out
+      _ -> mempty
+  in VMTraceResult
+     -- more oddities to comply with geth
+     { output = if BS.null res then "" else show $ ByteStringS res
+     , gasUsed = gasUsed'
+     }
+
+interpretWithTrace :: Fetch.Fetcher -> EVM.Stepper.Stepper a -> StateT VM IO a
+interpretWithTrace fetcher =
+  eval . Operational.view
+
+  where
+    eval
+      :: ProgramView EVM.Stepper.Action a
+      -> StateT VM IO a
+
+    eval (Return x) =
+      pure x
+
+    eval (action :>>= k) = do
+      vm <- get
+      case action of
+        EVM.Stepper.Run -> do
+          -- Have we reached the final result of this action?
+          use result >>= \case
+            Just _ -> do
+              liftIO $ B.putStrLn $ JSON.encode $ vmres vm
+              -- Yes, proceed with the next action.
+              interpretWithTrace fetcher (k vm)
+            Nothing -> do
+              liftIO $ B.putStrLn $ JSON.encode $ vmtrace vm
+
+              -- No, keep performing the current action
+              State.state (runState exec1)
+              interpretWithTrace fetcher (EVM.Stepper.run >>= k)
+
+        -- Stepper wants to keep executing?
+        EVM.Stepper.Exec -> do
+          -- Have we reached the final result of this action?
+          use result >>= \case
+            Just r -> do
+              liftIO $ B.putStrLn $ JSON.encode $ vmres vm
+              -- Yes, proceed with the next action.
+              interpretWithTrace fetcher (k r)
+            Nothing -> do
+              liftIO $ B.putStrLn $ JSON.encode $ vmtrace vm
+
+              -- No, keep performing the current action
+              State.state (runState exec1)
+              interpretWithTrace fetcher (EVM.Stepper.exec >>= k)
+        EVM.Stepper.Wait q ->
+          do m <- liftIO (fetcher q)
+             State.state (runState m) >> interpretWithTrace fetcher (k ())
+        EVM.Stepper.Ask _ ->
+          error "cannot make choices with this interpretWithTraceer"
+        EVM.Stepper.EVM m -> do
+          r <- State.state (runState m)
+          interpretWithTrace fetcher (k r)

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -143,7 +143,6 @@ data VMTrace =
   { pc      :: Int
   , op      :: Int
   , stack   :: [Word]
---  , memory  :: ByteStringS
   , memSize :: Int
   , depth   :: Int
   , gas     :: Word
@@ -173,8 +172,6 @@ vmtrace vm =
   in VMTrace { pc = the state EVM.pc
              , op = num $ getOp vm
              , gas = the state EVM.gas
-             -- pad to match geth format
---             , memory = ByteStringS . padRight memsize $ forceBuffer $ the state EVM.memory
              , memSize = memsize
              -- increment to match geth format
              , depth = 1 + length (view frames vm)
@@ -191,7 +188,7 @@ vmres vm =
       _ -> mempty
   in VMTraceResult
      -- more oddities to comply with geth
-     { output = if BS.null res then "" else show $ ByteStringS res
+     { output = drop 2 $ show $ ByteStringS res
      , gasUsed = gasUsed'
      }
 

--- a/src/hevm/src/EVM/Transaction.hs
+++ b/src/hevm/src/EVM/Transaction.hs
@@ -65,7 +65,7 @@ signingData chainId tx =
                               rlpWord256 0x0,
                               rlpWord256 0x0]
 
-txGasCost :: FeeSchedule Word -> Transaction -> Word
+txGasCost :: FeeSchedule Integer -> Transaction -> Integer
 txGasCost fs tx =
   let calldata     = txData tx
       zeroBytes    = BS.count 0 calldata

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -133,6 +133,9 @@ instance Read W256 where
 instance Show W256 where
   showsPrec _ s = ("0x" ++) . showHex s
 
+instance JSON.ToJSON W256 where
+  toJSON = JSON.String . Text.pack . show
+
 instance Read Addr where
   readsPrec _ ('0':'x':s) = readHex s
   readsPrec _ s = readHex s
@@ -170,6 +173,9 @@ instance Read ByteStringS where
     readsPrec _ ('0':'x':x) = [bimap ByteStringS (Text.unpack . Text.decodeUtf8) bytes]
        where bytes = BS16.decode (Text.encodeUtf8 (Text.pack x))
     readsPrec _ _ = []
+
+instance JSON.ToJSON ByteStringS where
+  toJSON = JSON.String . Text.pack . show
 
 instance FromJSON W256 where
   parseJSON v = do


### PR DESCRIPTION
superseedes #546.
This PR introduces the json tracing functionality discussed in #288, and sets up some basic infrastructure for differentially testing hevm against geth. In the process I found a couple of issues:
- If a PUSH opcode is given too short data, geth pads it to the appropriate length, while hevm just takes the data it is given, effectively leftpadding the bytestring. I don't believe this can ever actually make a meaningful difference, since the only setting in which this can occur is if the PUSH instruction is the final instruction of a contract, so the value will be ignored on the stack anyway. Regardless, I have adjusted hevm to also rightpad the data.
- hevm can panic in TTY mode if it tries to navigate beyond the final opcode (try for example `hevm exec --code 60006000601260136014601560166018f4 --debug --gas 0xffffff` and press `e`). This is fixed by making `_traceOpIx` into a `Maybe`.

I have added a simple python script that uses `hypothesis` for comparing the traces generated by hevm and geth in `dapp-test/integration/diff-fuzz.py`, but I am currently not asking it to run anything besides the examples provided. 

The reason is that hevm and geth have a slight difference in opinion when it comes to calling empty contracts, where hevm enters the new contracts and immediately calls STOP and exits, while geth skips the call entirely and just moves on to the next opcode. I don't want to address this discrepancy now and don't want to run tests that I know can fail on a particular input. Do you guys still think it's worth including the `diff-fuzz` script in its current form?

EDIT 18 Nov:
Also addresses a performance regression introduced in a001d0e6ca08efbd5f19a5b8ede7b85e6c8c2451 and optimizes `checkJump` further by replacing a `Vector.find` which is `O(n)` with a lookup which is `O(1)`. This is a performance improvement of roughly 35-40% for concrete testing.