### PR TITLE
dapp test contract matching

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- `dapp test --match` now matches on file path and contract name, as
+  well as test name
+
 ## [0.30.0] - 2020-10-31
 
 ### Added

--- a/src/dapp/README.md
+++ b/src/dapp/README.md
@@ -106,7 +106,31 @@ To step through a test in `hevm` interactive debugger, use `dapp debug`.
 dapp --use solc:0.5.12 test
 ```
 
-By default, `dapp test` also recompiles your contracts. 
+`dapp test --match <regex>` will only run tests that match the given
+regular expression. This will be matched against the file path of the
+test file, followed by the contract name and the test method, in the
+form `src/my_test_file.sol:TestContract.test_name()`. For example, to
+only run tests from the contract `ContractA`:
+
+```
+dapp test --match ':ContractA\.'
+```
+
+To run all tests, from all contracts, that contain either `foo` or `bar`
+in the test name:
+
+```
+dapp test --match '(foo|bar)'
+```
+
+To only run tests called 'test_this()' from `TheContract` in the
+`src/test/a.t.sol` file:
+
+```
+dapp test --match 'src/test/a\.t\.sol:TheContract\.test_this\(\)'
+```
+
+By default, `dapp test` also recompiles your contracts.
 To skip this, you can set the environment variable `DAPP_SKIP_BUILD=1`.
 
 ### Alternative install

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Some symbolic terms are displayed with richer semantic information, instead of the black box `<symbolic>`.
 - `hevm dapp-test` now supports symbolic execution of test methods that are prefixed with `prove` or `proveFail`
 - The `hevm interactive` alias has been removed, as it is equivalent to `hevm dapp-test --debug`
+- `hevm dapp-test --match` now matches on contract name and file path, as well as test name
 
 ## 0.42.0 - 2020-10-31
 

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -77,11 +77,9 @@ import qualified Data.ByteString        as ByteString
 import qualified Data.ByteString.Char8  as Char8
 import qualified Data.ByteString.Lazy   as LazyByteString
 import qualified Data.Map               as Map
-import qualified Data.Sequence          as Seq
 import qualified System.Timeout         as Timeout
 
 import qualified Paths_hevm      as Paths
-import qualified Text.Regex.TDFA as Regex
 
 import Options.Generic as Options
 
@@ -378,8 +376,7 @@ dappTest opts solcFile cache = do
   out <- liftIO $ readSolc solcFile
   case out of
     Just (contractMap, _) -> do
-      let matcher = regexMatches (EVM.UnitTest.match opts)
-          unitTests = findUnitTests matcher $ Map.elems contractMap
+      let unitTests = findUnitTests (EVM.UnitTest.match opts) $ Map.elems contractMap
       results <- concatMapM (runUnitTestContract opts contractMap) unitTests
       let (passing, vms) = unzip results
       case cache of
@@ -395,17 +392,6 @@ dappTest opts solcFile cache = do
       liftIO $ unless (and passing) exitFailure
     Nothing ->
       error ("Failed to read Solidity JSON for `" ++ solcFile ++ "'")
-
-regexMatches :: Text -> Text -> Bool
-regexMatches regexSource =
-  let
-    compOpts =
-      Regex.defaultCompOpt { Regex.lastStarGreedy = True }
-    execOpts =
-      Regex.defaultExecOpt { Regex.captureGroups = False }
-    regex = Regex.makeRegexOpts compOpts execOpts (unpack regexSource)
-  in
-    Regex.matchTest regex . Seq.fromList . unpack
 
 equivalence :: Command Options.Unwrapped -> IO ()
 equivalence cmd =
@@ -569,10 +555,9 @@ dappCoverage opts _ solcFile =
   readSolc solcFile >>=
     \case
       Just (contractMap, sourceCache) -> do
-        let matcher = regexMatches (EVM.UnitTest.match opts)
-            unitTests = findUnitTests matcher $ Map.elems contractMap
-        covs <- mconcat <$> mapM (coverageForUnitTestContract opts contractMap sourceCache) unitTests
-
+        let unitTests = findUnitTests (EVM.UnitTest.match opts) $ Map.elems contractMap
+        covs <- mconcat <$> mapM
+          (coverageForUnitTestContract opts contractMap sourceCache) unitTests
         let
           dapp = dappInfo "." contractMap sourceCache
           f (k, vs) = do

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -38,7 +38,6 @@ import qualified Control.Monad.Operational as Operational
 import EVM
 import qualified EVM.Exec
 import qualified EVM.Fetch as Fetch
-import Data.Text (Text, isPrefixOf)
 
 concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
 concatMapM op = foldr f (pure [])
@@ -79,8 +78,7 @@ ghciTest root path state =
     readSolc path >>=
       \case
         Just (contractMap, _) -> do
-          let unitTests = findUnitTests
-                (\a -> "test" `isPrefixOf` a || "prove" `isPrefixOf` a) (Map.elems contractMap)
+          let unitTests = findAllUnitTests (Map.elems contractMap)
           results <- runSMT $ query $ concatMapM (runUnitTestContract opts contractMap) unitTests
           let (passing, _) = unzip results
           pure passing


### PR DESCRIPTION
Extends the `dapp test --match` argument with contract name and file path, retaining the current behaviour.