### PR TITLE
hevm debug: step through the callstack using up and down arrows

### DIFF
--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `hevm dapp-test` now supports symbolic execution of test methods that are prefixed with `prove` or `proveFail`
 - The `hevm interactive` alias has been removed, as it is equivalent to `hevm dapp-test --debug`
 - `hevm dapp-test --match` now matches on contract name and file path, as well as test name
+- Step through the callstack in debug mode using the arrow keys
 
 ## 0.42.0 - 2020-10-31
 

--- a/src/hevm/README.md
+++ b/src/hevm/README.md
@@ -44,6 +44,8 @@ Note: some `hevm` commands (`dapp-test`) assume the use of the `ds-test` framewo
   - `C-n`: step to the next source position and don't enter `CALL` or `CREATE`
   - `C-p`: step previous source position without entering
   - `m`: toggle memory view
+  - `Down` : step to next entry in the callstack / Scroll memory pane\n" <>
+  - `Up` : step to previous entry in the callstack / Scroll memory pane\n" <>
   - `h`: show key-binding help
 
 ### `hevm symbolic`

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -667,8 +667,8 @@ drawHelpView =
         "m      Toggle memory pane\n" <>
         "0      Choose the branch which does not jump \n" <>
         "1      Choose the branch which does jump \n" <>
-        "Down   Scroll memory pane fwds\n" <>
-        "Up     Scroll memory pane back\n" <>
+        "Down   Step to next entry in the callstack / Scroll memory pane\n" <>
+        "Up     Step to previous entry in the callstack / Scroll memory pane\n" <>
         "C-f    Page memory pane fwds\n" <>
         "C-b    Page memory pane back\n\n" <>
         "Enter  Contracts browser"


### PR DESCRIPTION
Adds the ability to step through the callstack (actually the trace tree to be precise) by using the up and down arrow keys in debug mode.
As the trace pane grows, we now follow it so that new entries are always visible. This can look a little wonky when backstepping (sometimes we only see the last entry, hiding previous ones even though there's space), but I think this is good enough for now.
Also fixes an issue where it was possible to step past the end of execution (try pressing `e` and then `N` on master right now).