### PR TITLE
UnitTest: fix symbolic rpc tests

### DIFF
--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -528,11 +528,7 @@ symRun opts@UnitTestOptions{..} concreteVm testName types = do
 
     -- get all posible postVMs for the test method
     allPaths <- fst <$> runStateT
-        (EVM.SymExec.interpret
-          (EVM.Fetch.oracle smtState Nothing False)
-          maxIter
-          (execSymTest opts testName cd))
-        vm
+        (EVM.SymExec.interpret oracle maxIter (execSymTest opts testName cd)) vm
     results <- forM allPaths $
       -- If the vm execution succeeded, check if the vm is reachable,
       -- and if any ds-test assertions were triggered


### PR DESCRIPTION
We were using a hardcoded oracle here, and it was breaking when trying to execute symbolic tests against rpc state.

This fix ensures that the oracle used for the symbolic tests is constructed with the required rpc parameters if they are provided at the command line.

Thanks @MrChico for the help :sparkling_heart: 