### PR TITLE
UnitTest: tidy result in counter examples

### DIFF
--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -85,6 +85,7 @@ data Error
   | UnexpectedSymbolicArg
   | DeadPath
   | NotUnique
+  | SMTTimeout
 deriving instance Show Error
 
 -- | The possible result states of a VM

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -581,7 +581,9 @@ symFailure UnitTestOptions {..} testName failures' = mconcat
     showRes vm = let Just res = view result vm in
                  case res of
                    VMFailure _ -> prettyvmresult res
-                   VMSuccess _ -> "DSTest Assertion Violation"
+                   VMSuccess _ -> if "proveFail" `isPrefixOf` testName
+                                  then "Successful execution"
+                                  else "DSTest Assertion Violation"
     mkMsg (vm, cd) = pack $ unlines
       ["Counter Example:"
       ,""

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -583,7 +583,7 @@ symFailure UnitTestOptions {..} testName failures' = mconcat
                    VMFailure _ -> prettyvmresult res
                    VMSuccess _ -> if "proveFail" `isPrefixOf` testName
                                   then "Successful execution"
-                                  else "DSTest Assertion Violation"
+                                  else "Failed: DSTest Assertion Violation"
     mkMsg (vm, cd) = pack $ unlines
       ["Counterexample:"
       ,""

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -585,7 +585,7 @@ symFailure UnitTestOptions {..} testName failures' = mconcat
                                   then "Successful execution"
                                   else "DSTest Assertion Violation"
     mkMsg (vm, cd) = pack $ unlines
-      ["Counter Example:"
+      ["Counterexample:"
       ,""
       ,"  result:   " <> showRes vm
       ,"  calldata: " <> unpack cd


### PR DESCRIPTION
This commit tidies the error messages shown for counter examples in symbolic tests.

- Failures due to an SMT timeout are now shown in the result field instead of in the calldata field
- Failures due to a DSTest assertion violation are now shown as such instead of the "32 symbolic bytes shown previously"

Note: the current text in the result field for DSTest assertion violations is perhaps a little too similar to that for an EVM assertion violation, I'm not sure what a better choice would be?

## Old output

SMT Timeout:

```
  Counter Example:

    result:   Return: 32 symbolic bytes
    calldata: SMT Timeout
```

DSTest Assertion Violation:

```
  Counter Example:

    result:   Return: 32 symbolic bytes
    calldata: prove_fail()
```

## New output

SMT timeout:

```
  Counter Example:

    result:   Failed: SMTTimeout
    calldata: unknown
```

DSTest Assertion Violation:

```
  Counter Example:

    result:   DSTest Assertion Violation
    calldata: prove_fail()
```