### PR TITLE
Bump smttimeout / release hevm 0.43.2

### DIFF
--- a/nix/hevm-tests/smt-checker.nix
+++ b/nix/hevm-tests/smt-checker.nix
@@ -236,7 +236,7 @@ let
 
     explore() {
       set -x
-      hevm_output=$(${timeout} 90s ${hevm} symbolic --code "$1" --solver "$2" --json-file "$3" $4 2>&1)
+      hevm_output=$(${timeout} 90s ${hevm} symbolic --smttimeout 20000 --code "$1" --solver "$2" --json-file "$3" $4 2>&1)
       status=$?
       set +x
 

--- a/src/dapp/libexec/dapp/dapp-test
+++ b/src/dapp/libexec/dapp/dapp-test
@@ -15,7 +15,7 @@
 ###   --rpc-block <number>      block number (latest if not specified)
 ###
 ### SMT options:
-###   --smttimeout <number>     timeout passed to the smt solver in ms (default 20000)
+###   --smttimeout <number>     timeout passed to the smt solver in ms (default 30000)
 ###   --solver <string>         name of the smt solver to use (either "z3" or "cvc4")
 ###   --max-iterations <number> number of times we may revisit a particular branching point
 set -e

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.43.2 - 2020-12-10
+
+### Changed
+
+- The default smttimeout has been increased from 20s to 30s
+
 ## 0.43.1 - 2020-12-10
 
 ### Changed

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -121,7 +121,7 @@ data Command w
       , debug         :: w ::: Bool               <?> "Run interactively"
       , getModels     :: w ::: Bool               <?> "Print example testcase for each execution path"
       , showTree      :: w ::: Bool               <?> "Print branches explored in tree view"
-      , smttimeout    :: w ::: Maybe Integer      <?> "Timeout given to SMT solver in milliseconds (default: 20000)"
+      , smttimeout    :: w ::: Maybe Integer      <?> "Timeout given to SMT solver in milliseconds (default: 30000)"
       , maxIterations :: w ::: Maybe Integer      <?> "Number of times we may revisit a particular branching point"
       , solver        :: w ::: Maybe Text         <?> "Used SMT solver: z3 (default) or cvc4"
       , smtdebug      :: w ::: Bool               <?> "Print smt queries sent to the solver"
@@ -130,7 +130,7 @@ data Command w
       { codeA         :: w ::: ByteString    <?> "Bytecode of the first program"
       , codeB         :: w ::: ByteString    <?> "Bytecode of the second program"
       , sig           :: w ::: Maybe Text    <?> "Signature of types to decode / encode"
-      , smttimeout    :: w ::: Maybe Integer <?> "Timeout given to SMT solver in milliseconds (default: 20000)"
+      , smttimeout    :: w ::: Maybe Integer <?> "Timeout given to SMT solver in milliseconds (default: 30000)"
       , maxIterations :: w ::: Maybe Integer <?> "Number of times we may revisit a particular branching point"
       , solver        :: w ::: Maybe Text    <?> "Used SMT solver: z3 (default) or cvc4"
       , smtoutput     :: w ::: Bool          <?> "Print verbose smt output"
@@ -177,7 +177,7 @@ data Command w
       , state         :: w ::: Maybe String             <?> "Path to state repository"
       , cache         :: w ::: Maybe String             <?> "Path to rpc cache repository"
       , match         :: w ::: Maybe String             <?> "Test case filter - only run methods matching regex"
-      , smttimeout    :: w ::: Maybe Integer            <?> "Timeout given to SMT solver in milliseconds (default: 20000)"
+      , smttimeout    :: w ::: Maybe Integer            <?> "Timeout given to SMT solver in milliseconds (default: 30000)"
       , maxIterations :: w ::: Maybe Integer            <?> "Number of times we may revisit a particular branching point"
       , solver        :: w ::: Maybe Text               <?> "Used SMT solver: z3 (default) or cvc4"
       , smtdebug      :: w ::: Bool                     <?> "Print smt queries sent to the solver"
@@ -430,7 +430,7 @@ runSMTWithTimeOut solver maybeTimeout smtdebug sym
   | solver == Just "z3" = runwithz3
   | solver == Nothing = runwithz3
   | otherwise = error "Unknown solver. Currently supported solvers; z3, cvc4"
- where timeout = fromMaybe 20000 maybeTimeout
+ where timeout = fromMaybe 30000 maybeTimeout
        runwithz3 = runSMTWith z3{SBV.verbose=smtdebug} $ (setTimeOut timeout) >> sym
 
 

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.2
 name:
   hevm
 version:
-  0.43.1
+  0.43.2
 synopsis:
   Ethereum virtual machine evaluator
 description:


### PR DESCRIPTION
- bumps the default smt timeout to 30s from 20s
- keeps the old timeout in place for the smt-checker tests
- adds a new hevm release (will tag once the PR is approved)