### PR TITLE
bugfix for optimizer setting

### DIFF
--- a/src/dapp/libexec/dapp/dapp-mk-standard-json
+++ b/src/dapp/libexec/dapp/dapp-mk-standard-json
@@ -38,7 +38,7 @@ else:
 
 tmpljson["settings"].pop('stopAfter', None)
 
-if os.getenv('DAPP_BUILD_OPTIMIZE') == 1:
+if os.getenv('DAPP_BUILD_OPTIMIZE') == '1':
     tmpljson["settings"]["optimizer"]["enabled"] = True
 else:
     tmpljson["settings"].pop('optimizer', None)


### PR DESCRIPTION
`DAPP_BUILD_OPTIMIZE` env var was ignored because of a wrong data type in the comparison. As a result, the optimizer was always disabled. Fixed.