### PR TITLE
warn about SOLC_FLAGS

### DIFF
--- a/src/dapp/libexec/dapp/dapp
+++ b/src/dapp/libexec/dapp/dapp
@@ -56,7 +56,6 @@ export DAPP_LIB=${DAPP_LIB-lib}
 export DAPP_OUT=${DAPP_OUT-out}
 export DAPP_JSON=${DAPP_JSON-${DAPP_OUT}/dapp.sol.json}
 export DAPP_ROOT=${DAPP_ROOT-.}
-export DAPP_LIBRARIES=${DAPP_LIBRARIES-"$links"}
 export DAPP_REMAPPINGS=${DAPP_REMAPPINGS-"$(dapp-remappings)"}
 
 

--- a/src/dapp/libexec/dapp/dapp
+++ b/src/dapp/libexec/dapp/dapp
@@ -56,6 +56,9 @@ export DAPP_LIB=${DAPP_LIB-lib}
 export DAPP_OUT=${DAPP_OUT-out}
 export DAPP_JSON=${DAPP_JSON-${DAPP_OUT}/dapp.sol.json}
 export DAPP_ROOT=${DAPP_ROOT-.}
+export DAPP_LIBRARIES=${DAPP_LIBRARIES-"$links"}
+export DAPP_REMAPPINGS=${DAPP_REMAPPINGS-"$(dapp-remappings)"}
+
 
 if ! [[ $DAPP_INIT ]]; then
   export DAPP_INIT=1

--- a/src/dapp/libexec/dapp/dapp-build
+++ b/src/dapp/libexec/dapp/dapp-build
@@ -51,6 +51,7 @@ else
 fi
 
 export -f info
+export DAPP_LIBRARIES=${DAPP_LIBRARIES-"$links"}
 
 mkdir -p "$DAPP_OUT"
 

--- a/src/dapp/libexec/dapp/dapp-build
+++ b/src/dapp/libexec/dapp/dapp-build
@@ -50,16 +50,17 @@ else
     (set -x; dapp clean)
 fi
 
-export DAPP_LIBRARIES=${DAPP_LIBRARIES-"$links"}
-export DAPP_REMAPPINGS=${DAPP_REMAPPINGS-"$(dapp remappings)"}
 export -f info
 
 mkdir -p "$DAPP_OUT"
 
 if [[ -z "$DAPP_BUILD_LEGACY" && -z "$DAPP_BUILD_EXTRACT" ]]; then
-
+    if [[ "$SOLC_FLAGS" ]]; then
+        info "warning: SOLC_FLAGS are only recognized using '--legacy'"
+        info "consider using --optimize or a custom standard-json instead."
+    fi
     if [[ "$DAPP_STANDARD_JSON" ]]; then
-        "$SOLC" --allow-paths . --standard-json "$DAPP_STANDARD_JSON" > "$DAPP_JSON"
+        "$SOLC" --allow-paths . --standard-json - < "$DAPP_STANDARD_JSON" > "$DAPP_JSON"
     else
         dapp mk-standard-json | "$SOLC" --standard-json --allow-paths . > "$DAPP_JSON"
     fi

--- a/src/seth/libexec/seth/seth
+++ b/src/seth/libexec/seth/seth
@@ -189,7 +189,6 @@ done
 keystores=()
 
 if [[ $SETH_CHAIN ]]; then
-  export ETH_LOGS_API=${SETH_LOGS_API:-etherscan}
 
   case "$SETH_CHAIN" in
     ethlive|mainnet)


### PR DESCRIPTION
- Ensures `dapp mk-standard-json` uses `dapp remappings` correctly.
- Warns if deprecated SOLC_FLAGS is used
- Ensure SETH_CHAIN doesn't influence whether SETH_LOGS_API uses etherscan or rpc. @gakonst