### PR TITLE
dapp: allow users to skip library linking for dapp-test

### DIFF
--- a/src/dapp/libexec/dapp/dapp-test
+++ b/src/dapp/libexec/dapp/dapp-test
@@ -29,17 +29,23 @@ have hevm || {
   exit 1
 }
 
+export DAPP_LINK_TEST_LIBRARIES=${DAPP_LINK_TEST_LIBRARIES-1}
+
 if ! [[ $DAPP_SKIP_BUILD ]] ; then
-  DAPP_LINK_TEST_LIBRARIES=1 dapp build || exit
+  dapp build || exit
 fi
 
 if [ "$DAPP_VERBOSE" ]; then set -x; fi
 
-state=$(dapp --make-library-state)
-function clean() { rm -rf "$state"; }
-trap clean EXIT
-
 opts=$(dapp --hevm-opts "$0" "$@")
+
+if [ "$DAPP_LINK_TEST_LIBRARIES" = 1 ] ; then
+    state=$(dapp --make-library-state)
+    opts+=("--state ${state}")
+    function clean() { rm -rf "$state"; }
+    trap clean EXIT
+fi
+
 # make sure git commits succeed
 export GIT_CONFIG_NOSYSTEM=1
 export GIT_AUTHOR_NAME=hevm
@@ -48,4 +54,4 @@ export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
 export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 
 # shellcheck disable=SC2068
-hevm dapp-test --dapp-root="${DAPP_ROOT}" --json-file="${DAPP_JSON}" --state="$state" ${opts[@]}
+hevm dapp-test --dapp-root="${DAPP_ROOT}" --json-file="${DAPP_JSON}" ${opts[@]}


### PR DESCRIPTION
The current check for libraries is currently a heuristic one, and can fail, resulting in unescessary library deployments when running dapp test.

This is reasonably time consuming, and so until a more accurate library check is developed (perhaps as part of hevm itself), we allow users to skip library linking by setting `DAPP_LINK_TEST_LIBRARIES=0` before calling `dapp test`.