### PR TITLE
hevm: allow symbolic arguments to cheatcodes

### DIFF
--- a/nix/build-dapp-package.nix
+++ b/nix/build-dapp-package.nix
@@ -47,7 +47,6 @@ in
           '')
           passthru.libPaths;
       buildPhase = ''
-        set -x
         mkdir -p out
         export DAPP_REMAPPINGS="$REMAPPINGS"
         export DAPP_SRC=$src

--- a/src/dapp-tests/default.nix
+++ b/src/dapp-tests/default.nix
@@ -26,7 +26,7 @@ let
     owner = "dapphub";
     repo = "ds-auth";
     rev = "8035510b0bdfe90de9e29cac2c538f5ce0d89aea";
-    sha256 = "0s63ffz8wi0h6yaripmigrbzd93i3915jsrxq4iqbiam6mkdgrsc";
+    sha256 = "1j7c60vzcg6cwc3d72q2sh6lzfbm04ipzn7nf8mfcli2yyhap6n1";
   } + "/src";
 
   ds-value-src = pkgs.fetchFromGitHub {

--- a/src/dapp-tests/default.nix
+++ b/src/dapp-tests/default.nix
@@ -4,49 +4,49 @@ let
   ds-test-src = pkgs.fetchFromGitHub {
     owner = "dapphub";
     repo = "ds-test";
-    rev = "eb7148d43c1ca6f9890361e2e2378364af2430ba";
-    sha256 = "1phnqjkbcqg18mh62c8jq0v8fcwxs8yc4sa6dca4y8pq2k35938k";
+    rev = "1ixciazx7w52r5g4za4gpprads83i0rpjx8ax5cyizgpg60i5rgi";
+    sha256 = "0cdzva82kkvj7ck4yf3ffma2n5rfa7miknjnz6jwgfy416a865m0";
   } + "/src";
 
   ds-token-src = pkgs.fetchFromGitHub {
     owner = "dapphub";
     repo = "ds-token";
-    rev = "8b752565a433f7326d38499c0c01cc7d9058721e";
+    rev = "6eb8a5010aad2980645c34c49cbfc1e9aea12c32";
     sha256 = "1rk0vg8gql8rmd399m2v9y86m2g1q8mbcrv97bx0p1wf8k983vym";
   } + "/src";
 
   ds-math-src = pkgs.fetchFromGitHub {
     owner = "dapphub";
     repo = "ds-math";
-    rev = "d0ef6d6a5f1de54a16e5ebb7af4d62bb9632de3e";
+    rev = "fa45427c0e0bb487335ae99a2e39564b3983a355";
     sha256 = "1giimmhlm2gxd7v794nbhykj61pv8ib60jv80ykx5smxh9lf4irr";
   } + "/src";
 
   ds-auth-src = pkgs.fetchFromGitHub {
     owner = "dapphub";
     repo = "ds-auth";
-    rev = "434bf463b255ecc2157b9c671139f6c617795ebf";
-    sha256 = "0lf5kzb9gd2d132bnz4xn8z6fgrq4pmg9fknhj6hig0c3g41a7sy";
+    rev = "8035510b0bdfe90de9e29cac2c538f5ce0d89aea";
+    sha256 = "0s63ffz8wi0h6yaripmigrbzd93i3915jsrxq4iqbiam6mkdgrsc";
   } + "/src";
 
   ds-value-src = pkgs.fetchFromGitHub {
     owner = "dapphub";
     repo = "ds-value";
-    rev = "f3dc6c8656727b74a5469ec2d4cd6851c9db8999";
+    rev = "2e3d06ba1e96dc531f14d0749fa92146b7390ed8";
     sha256 = "1by3q3ndfmpgijckjhbyw4vvbzykg66v8yrl5awvpb76i8z3l8hf";
   } + "/src";
 
   ds-thing-src = pkgs.fetchFromGitHub {
     owner = "dapphub";
     repo = "ds-thing";
-    rev = "f37879a41e817f54db43728cb39178cd99311289";
+    rev = "baf65c78908c846f4e45bb585ee5714551c1492d";
     sha256 = "173hvha10nb9l3p66dv4i1h737knkrvm34y5j5cvmq4g7y8vaa6d";
   } + "/src";
 
   ds-note-src = pkgs.fetchFromGitHub {
     owner = "dapphub";
     repo = "ds-note";
-    rev = "c673c9d1a1464e973db4489221e22dc5b9b02319";
+    rev = "4f2ad380e41e664802c4cb3a34f139ac08700bd8";
     sha256 = "0a9qc04s6hwz2fiwhl4psfga4wnwi6s33fvpcaq3y0gagrrmjidn";
   } + "/src";
 

--- a/src/dapp-tests/default.nix
+++ b/src/dapp-tests/default.nix
@@ -4,7 +4,7 @@ let
   ds-test-src = pkgs.fetchFromGitHub {
     owner = "dapphub";
     repo = "ds-test";
-    rev = "1ixciazx7w52r5g4za4gpprads83i0rpjx8ax5cyizgpg60i5rgi";
+    rev = "c0b770c04474db28d43ab4b2fdb891bd21887e9e";
     sha256 = "0cdzva82kkvj7ck4yf3ffma2n5rfa7miknjnz6jwgfy416a865m0";
   } + "/src";
 

--- a/src/dapp-tests/pass/cheatCodes.sol
+++ b/src/dapp-tests/pass/cheatCodes.sol
@@ -1,0 +1,50 @@
+pragma solidity ^0.6.7;
+
+import "ds-test/test.sol";
+
+interface Hevm {
+    function warp(uint256) external;
+    function roll(uint256) external;
+    function load(address,bytes32) external returns (bytes32);
+    function store(address,bytes32,bytes32) external;
+}
+
+contract HasStorage {
+    uint slot0 = 10;
+}
+
+contract CheatCodes is DSTest {
+    address store = address(new HasStorage());
+    Hevm hevm = Hevm(HEVM_ADDRESS);
+
+    function test_warp_concrete(uint128 jump) public {
+        uint pre = block.timestamp;
+        hevm.warp(block.timestamp + jump);
+        uint post = block.timestamp;
+        assertEq(pre + jump, post);
+    }
+
+    function prove_warp_symbolic(uint128 jump) public {
+        test_warp_concrete(jump);
+    }
+
+    function test_roll_concrete(uint64 jump) public {
+        uint pre = block.number;
+        hevm.roll(block.number + jump);
+        uint post = block.number;
+        assertEq(pre + jump, post);
+    }
+
+    function test_store_load_concrete(uint x) public {
+        uint ten = uint(hevm.load(store, bytes32(0)));
+        assertEq(ten, 10);
+
+        hevm.store(store, bytes32(0), bytes32(x));
+        uint val = uint(hevm.load(store, bytes32(0)));
+        assertEq(val, x);
+    }
+
+    function prove_store_load_symbolic(uint x) public {
+        test_store_load_concrete(x);
+    }
+}

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1881,23 +1881,17 @@ cheatActions :: Map Word32 CheatAction
 cheatActions =
   Map.fromList
     [ action "warp(uint256)" $
-        \sig _ _ input -> let
-          args = decodeStaticArgs input
-        in case args of
+        \sig _ _ input -> case decodeStaticArgs input of
           [x]  -> assign (block . timestamp) (mksym x)
           _ -> vmError (BadCheatCode sig),
 
       action "roll(uint256)" $
-        \sig _ _ input -> let
-          args = decodeStaticArgs input
-        in case args of
+        \sig _ _ input -> case decodeStaticArgs input of
           [x] -> forceConcrete (mksym x) (assign (block . number))
           _ -> vmError (BadCheatCode sig),
 
       action "store(address,bytes32,bytes32)" $
-        \sig _ _ input -> let
-          args = decodeStaticArgs input
-        in case args of
+        \sig _ _ input -> case decodeStaticArgs input of
           [a, slot, new] ->
             makeUnique (mksym $ sFromIntegral a) $ \(C _ (num -> a')) ->
               fetchAccount a' $ \_ -> do
@@ -1905,9 +1899,7 @@ cheatActions =
           _ -> vmError (BadCheatCode sig),
 
       action "load(address,bytes32)" $
-        \sig outOffset _ input -> let
-          args = decodeStaticArgs input
-        in case args of
+        \sig outOffset _ input -> case decodeStaticArgs input of
           [a, slot] ->
             makeUnique (mksym $ sFromIntegral a) $ \(C _ (num -> a'))->
               accessStorage a' (mksym slot) $ \res -> do

--- a/src/hevm/src/EVM/ABI.hs
+++ b/src/hevm/src/EVM/ABI.hs
@@ -47,7 +47,7 @@ module EVM.ABI
   , emptyAbi
   , encodeAbiValue
   , decodeAbiValue
-  , decodeSimpleTypes
+  , decodeStaticArgs
   , formatString
   , parseTypeName
   , makeAbiValue
@@ -540,18 +540,12 @@ listP parser = between (char '[') (char ']') ((do skipSpaces
                                                   skipSpaces
                                                   return a) `sepBy` (char ','))
 
--- TODO: teach this to handle complex types
-decodeSimpleTypes :: [AbiType] -> Buffer -> Maybe ([SWord 256])
-decodeSimpleTypes argTypes buffer
-  | containsComplexTypes argTypes = Nothing
-  | otherwise = let
-     bs = case buffer of
-       ConcreteBuffer b -> litBytes b
-       SymbolicBuffer b -> b
-    in Just $ fmap (\i -> fromBytes $ take 32 (drop (i*32) bs)) [0..((length bs) `div` 32 - 1)]
-
-containsComplexTypes :: [AbiType] -> Bool
-containsComplexTypes = or . fmap (\a -> abiKind a == Dynamic)
+decodeStaticArgs :: Buffer -> [SWord 256]
+decodeStaticArgs buffer = let
+    bs = case buffer of
+      ConcreteBuffer b -> litBytes b
+      SymbolicBuffer b -> b
+  in fmap (\i -> fromBytes $ take 32 (drop (i*32) bs)) [0..((length bs) `div` 32 - 1)]
 
 -- A modification of 'arbitrarySizedBoundedIntegral' quickcheck library
 -- which takes the maxbound explicitly rather than relying on a Bounded instance.

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -228,7 +228,7 @@ data Whiff =
   | SHL Whiff Whiff
   | SHR Whiff Whiff
   | SAR Whiff Whiff
-  
+
   -- integers
   | Add  Whiff Whiff
   | Sub  Whiff Whiff
@@ -295,7 +295,6 @@ class FromSizzleBV a where
 
    default fromSizzle :: (Num (FromSizzle a), Integral a) => a -> FromSizzle a
    fromSizzle = fromIntegral
-
 
 
 maybeLitWord :: SymWord -> Maybe Word


### PR DESCRIPTION
hevm cheat codes can now accept symbolic arguments, allowing symbolic jumps in time, or `store` / `load` for symbolic values. `roll` will still fail with `UnexpectedSymbolicArg` as the block number is currently not symbolic at the VM level.