### PR TITLE
Admit symbolic bytecode

### DIFF
--- a/src/dapp-tests/pass/dsProvePass.sol
+++ b/src/dapp-tests/pass/dsProvePass.sol
@@ -5,7 +5,7 @@ import "ds-token/token.sol";
 import "ds-math/math.sol";
 
 contract ConstructorArg {
-    address immutable a;
+    address immutable public a;
     constructor(address _a) {
         a = _a;
     }

--- a/src/dapp-tests/pass/dsProvePass.sol
+++ b/src/dapp-tests/pass/dsProvePass.sol
@@ -5,7 +5,7 @@ import "ds-token/token.sol";
 import "ds-math/math.sol";
 
 contract ConstructorArg {
-    address a immutable;
+    address immutable a;
     constructor(address _a) {
         a = _a;
     }

--- a/src/dapp-tests/pass/dsProvePass.sol
+++ b/src/dapp-tests/pass/dsProvePass.sol
@@ -4,6 +4,13 @@ import "ds-test/test.sol";
 import "ds-token/token.sol";
 import "ds-math/math.sol";
 
+contract ConstructorArg {
+    address a immutable;
+    constructor(address _a) {
+        a = _a;
+    }
+}
+
 contract SolidityTest is DSTest, DSMath {
     DSToken token;
 
@@ -26,6 +33,11 @@ contract SolidityTest is DSTest, DSMath {
         token.mint(supply);
         uint actual = token.totalSupply();
         assertEq(supply, actual);
+    }
+
+    function prove_constructorArgs(address b) public {
+        ConstructorArg c = new ConstructorArg(b);
+        assertEq(b, c.a());
     }
 
     function proveFail_revertSmoke() public {
@@ -77,4 +89,3 @@ contract SolidityTest is DSTest, DSMath {
         assertTrue(counter < 100);
     }
 }
-

--- a/src/dapp-tests/pass/dsProvePass.sol
+++ b/src/dapp-tests/pass/dsProvePass.sol
@@ -6,7 +6,7 @@ import "ds-math/math.sol";
 
 contract ConstructorArg {
     address immutable public a;
-    constructor(address _a) {
+    constructor(address _a) public {
         a = _a;
     }
 }

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Two new cheatcodes were added: `sign(uint sk, bytes message)` and `addr(uint sk)`. Taken together
   these should allow for much more ergonomic testing of code that handles signed messages.
+- Symbolic execution can deal with partially symbolic bytecode, allowing for symbolic constructor arguments to be given in tests.
 
 ### Fixed
 

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -47,6 +47,7 @@ import qualified EVM.Facts.Git as Git
 import qualified EVM.UnitTest
 
 import GHC.IO.Encoding
+import GHC.Stack
 import Control.Concurrent.Async   (async, waitCatch)
 import Control.Lens hiding (pre, passing)
 import Control.Monad              (void, when, forM_, unless)
@@ -865,7 +866,7 @@ symvmFromCommand cmd = do
     word f def = fromMaybe def (f cmd)
     addr f def = fromMaybe def (f cmd)
 
-launchTest :: Command Options.Unwrapped ->  IO ()
+launchTest :: HasCallStack => Command Options.Unwrapped ->  IO ()
 launchTest cmd = do
 #if MIN_VERSION_aeson(1, 0, 0)
   parsed <- VMTest.parseBCSuite <$> LazyByteString.readFile (file cmd)
@@ -885,7 +886,7 @@ launchTest cmd = do
 #endif
 
 #if MIN_VERSION_aeson(1, 0, 0)
-runVMTest :: Bool -> Mode -> Maybe Int -> (String, VMTest.Case) -> IO Bool
+runVMTest :: HasCallStack => Bool -> Mode -> Maybe Int -> (String, VMTest.Case) -> IO Bool
 runVMTest diffmode mode timelimit (name, x) =
  do
   let vm0 = VMTest.vmForCase x

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -54,14 +54,14 @@ import Control.Monad.State.Strict (execStateT, liftIO)
 import Data.ByteString            (ByteString)
 import Data.List                  (intercalate, isSuffixOf)
 import Data.Tree
-import Data.Text                  (Text, unpack, pack)
+import Data.Text                  (unpack, pack)
 import Data.Text.Encoding         (encodeUtf8)
 import Data.Text.IO               (hPutStr)
 import Data.Maybe                 (fromMaybe, fromJust)
 import Data.Version               (showVersion)
 import Data.SBV hiding (Word, solver, verbose, name)
 import Data.SBV.Control hiding (Version, timeout, create)
-import System.IO                  (hFlush, stdout, stderr, utf8)
+import System.IO                  (hFlush, stdout, stderr)
 import System.Directory           (withCurrentDirectory, listDirectory)
 import System.Exit                (exitFailure, exitWith, ExitCode(..))
 import System.Environment         (setEnv)
@@ -731,7 +731,7 @@ vmFromCommand cmd = do
         caller'  = addr caller 0
         origin'  = addr origin 0
         calldata' = ConcreteBuffer $ bytes calldata ""
-        codeType = if create cmd then EVM.InitCode else EVM.RuntimeCode
+        codeType = (if create cmd then EVM.InitCode else EVM.RuntimeCode) . ConcreteBuffer
         address' = if create cmd
               then addr address (createAddress origin' (word nonce 0))
               else addr address 0xacab
@@ -837,7 +837,7 @@ symvmFromCommand cmd = do
     decipher = hexByteString "bytes" . strip0x
     block'   = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber (block cmd)
     origin'  = addr origin 0
-    codeType = if create cmd then EVM.InitCode else EVM.RuntimeCode
+    codeType = (if create cmd then EVM.InitCode else EVM.RuntimeCode) . ConcreteBuffer
     address' = if create cmd
           then addr address (createAddress origin' (word nonce 0))
           else addr address 0xacab

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -283,13 +283,6 @@ data ContractCode
   | RuntimeCode Buffer  -- ^ "Instance" code, after contract creation
   deriving (Show)
 
-instance Eq ContractCode where
-  InitCode (ConcreteBuffer a) == InitCode (ConcreteBuffer b) = a == b
-  RuntimeCode (ConcreteBuffer a) == RuntimeCode (ConcreteBuffer b) = a == b
-  InitCode _ == RuntimeCode _ = False
-  RuntimeCode _ == InitCode _ = False
-  _ == _ = error "cannot compare symbolic values"
-
 -- | A contract can either have concrete or symbolic storage
 -- depending on what type of execution we are doing
 data Storage
@@ -320,7 +313,6 @@ data Contract = Contract
   }
 
 deriving instance Show Contract
-deriving instance Eq Contract
 
 -- | When doing symbolic execution, we have three different
 -- ways to model the storage of contracts. This determines

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -2039,8 +2039,8 @@ delegateCall this gasGiven (SAddr xTo) (SAddr xContext) xValue xInOffset xInSize
 collision :: Maybe Contract -> Bool
 collision c' = case c' of
   Just c -> (view nonce c /= 0) || case view contractcode c of
-    RuntimeCode b -> len b == 0
-    _ -> False
+    RuntimeCode b -> len b /= 0
+    _ -> True
   Nothing -> False
 
 create :: (?op :: Word8)
@@ -2474,7 +2474,7 @@ mkOpIxMap xs = Vector.create $ Vector.new (len xs) >>= \v ->
       let (_, _, _, m) =
             foldl (go' v) (0, 0, 0, return ()) (stripBytecodeMetadataSym xs')
       in m >> return v
-      
+
   where
     -- concrete case
     go v (0, !i, !j, !m) x | x >= 0x60 && x <= 0x7f =
@@ -2494,7 +2494,7 @@ mkOpIxMap xs = Vector.create $ Vector.new (len xs) >>= \v ->
         -- other data --
                  else (0,             i + 1, j + 1, m >> Vector.write v i j)
       _ -> error "cannot analyze symbolic code"
-                              
+
       {- Start of PUSH op. -} (x - 0x60 + 1, i + 1, j,     m >> Vector.write v i j)
     go' v (1, !i, !j, !m) _ =
       {- End of PUSH op. -}   (0,            i + 1, j + 1, m >> Vector.write v i j)

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -2448,7 +2448,7 @@ checkJump x xs = do
   self <- use (state . codeContract)
   theCodeOps <- use (env . contracts . ix self . codeOps)
   theOpIxMap <- use (env . contracts . ix self . opIxMap)
-  if x < num (len theCode) && EVM.Symbolic.index (num x) theCode == 0x5b
+  if x < num (len theCode) && 0x5b == (fromMaybe (error "tried to jump to symbolic code location") $ unliteral $ EVM.Symbolic.index (num x) theCode)
     then
       if OpJumpdest == snd (theCodeOps RegularVector.! (theOpIxMap Vector.! num x))
       then do

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -566,7 +566,7 @@ exec1 = do
           let !n = num x - 0x60 + 1
               !xs = case the state code of
                       ConcreteBuffer b -> w256lit $ word $ padRight n $ BS.take n (BS.drop (1 + the state pc) b)
-                      SymbolicBuffer b -> readSWord' 0 $ take n $ drop (1 + the state pc) b
+                      SymbolicBuffer b -> readSWord' 0 $ padLeft' 32 $ take n $ drop (1 + the state pc) b
           limitStack 1 $
             burn g_verylow $ do
               next

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -566,7 +566,7 @@ exec1 = do
           let !n = num x - 0x60 + 1
               !xs = case the state code of
                       ConcreteBuffer b -> w256lit $ word $ padRight n $ BS.take n (BS.drop (1 + the state pc) b)
-                      SymbolicBuffer b -> readSWord' 0 $ padLeft' 32 $ take n $ drop (1 + the state pc) b
+                      SymbolicBuffer b -> readSWord' 0 $ take n $ drop (1 + the state pc) b
           limitStack 1 $
             burn g_verylow $ do
               next

--- a/src/hevm/src/EVM/Debug.hs
+++ b/src/hevm/src/EVM/Debug.hs
@@ -3,6 +3,7 @@ module EVM.Debug where
 import EVM          (Contract, storage, nonce, balance, bytecode, codehash)
 import EVM.Solidity (SrcMap, srcMapFile, srcMapOffset, srcMapLength, SourceCache, sourceFiles)
 import EVM.Types    (Addr)
+import EVM.Symbolic (len)
 
 import Control.Arrow   (second)
 import Control.Lens
@@ -28,11 +29,10 @@ object xs =
 prettyContract :: Contract -> Doc
 prettyContract c =
   object
-    [ (text "codesize", int (ByteString.length (c ^. bytecode)))
+    [ (text "codesize", int (len (c ^. bytecode)))
     , (text "codehash", text (show (c ^. codehash)))
     , (text "balance", int (fromIntegral (c ^. balance)))
     , (text "nonce", int (fromIntegral (c ^. nonce)))
-    , (text "code", text (show (ByteString.take 16 (c ^. bytecode))))
     , (text "storage", text (show (c ^. storage)))
     ]
 

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -162,7 +162,8 @@ getOp vm =
       xs = case code' of
         ConcreteBuffer xs' -> ConcreteBuffer (BS.drop i xs')
         SymbolicBuffer xs' -> SymbolicBuffer (drop i xs')
-  in case xs of
+  in if len xs == 0 then 0
+  else case xs of
        ConcreteBuffer b -> BS.index b 0
        SymbolicBuffer b -> fromSized $ fromMaybe (error "unexpected symbolic code") (unliteral (b !! 0))
 

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -25,7 +25,6 @@ import EVM.Symbolic
 import EVM.Dapp
 import EVM.Debug (srcMapCodePos)
 import EVM.Fetch (Fetcher)
-import EVM.Op
 import EVM.Solidity
 import EVM.Stepper (Stepper)
 import EVM.TTY (currentSrcMap)
@@ -38,7 +37,6 @@ import qualified Control.Monad.Operational as Operational
 import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import qualified Data.Vector as Vector
 import qualified EVM.Fetch as Fetch
 import qualified EVM.Stepper as Stepper
 
@@ -301,7 +299,7 @@ atFileLine dapp wantedFileName wantedLineNumber vm =
             currentFileName == wantedFileName &&
               currentLineNumber == wantedLineNumber
 
-codeByHash :: W256 -> VM -> Maybe ByteString
+codeByHash :: W256 -> VM -> Maybe Buffer
 codeByHash h vm = do
   let cs = view (env . contracts) vm
   c <- List.find (\c -> h == (view codehash c)) (Map.elems cs)
@@ -310,9 +308,6 @@ codeByHash h vm = do
 allHashes :: VM -> Set W256
 allHashes vm = let cs = view (env . contracts) vm
   in Set.fromList ((view codehash) <$> Map.elems cs)
-
-prettifyCode :: ByteString -> String
-prettifyCode b = List.intercalate "\n" (opString <$> (Vector.toList (EVM.mkCodeOps b)))
 
 outputVm :: Console ()
 outputVm = do
@@ -324,7 +319,6 @@ outputVm = do
         output $
         L [ A "step"
           , L [A ("vm" :: Text), sexp (view uiVm s)]
-          , L [A ("newCodes" :: Text), sexp ((fmap prettifyCode) <$> sendCodes)]
           ]
   fromMaybe noMap $ do
     dapp <- view uiVmDapp s
@@ -339,7 +333,6 @@ outputVm = do
             , A (txt (srcMapLength sm))
             , A (txt (srcMapJump sm))
             ]
-        , L [A ("newCodes" :: Text), sexp ((fmap prettifyCode) <$> sendCodes)]
         ]
 
 

--- a/src/hevm/src/EVM/Exec.hs
+++ b/src/hevm/src/EVM/Exec.hs
@@ -21,7 +21,7 @@ ethrunAddress = Addr 0x00a329c0648769a73afac7f9381e08fb43dbea72
 vmForEthrunCreation :: ByteString -> VM
 vmForEthrunCreation creationCode =
   (makeVm $ VMOpts
-    { vmoptContract = initialContract (InitCode creationCode)
+    { vmoptContract = initialContract (InitCode (ConcreteBuffer creationCode))
     , vmoptCalldata = (mempty, 0)
     , vmoptValue = 0
     , vmoptAddress = createAddress ethrunAddress 1

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -6,7 +6,7 @@ module EVM.Fetch where
 
 import Prelude hiding (Word)
 
-import EVM.Types    (Addr, w256, W256, hexText, Word)
+import EVM.Types    (Addr, w256, W256, hexText, Word, Buffer(..))
 import EVM.Symbolic (litWord)
 import EVM          (IsUnique(..), EVM, Contract, Block, initialContract, nonce, balance, external)
 import qualified EVM.FeeSchedule as FeeSchedule
@@ -123,7 +123,7 @@ fetchContractWithSession n url addr sess = runMaybeT $ do
   theBalance <- MaybeT $ fetch (QueryBalance addr)
 
   return $
-    initialContract (EVM.RuntimeCode theCode)
+    initialContract (EVM.RuntimeCode (ConcreteBuffer theCode))
       & set nonce    (w256 theNonce)
       & set balance  (w256 theBalance)
       & set external True

--- a/src/hevm/src/EVM/Op.hs
+++ b/src/hevm/src/EVM/Op.hs
@@ -3,7 +3,7 @@ module EVM.Op
   , opString
   ) where
 
-import EVM.Types (W256)
+import EVM.Types (SymWord)
 import Data.Word (Word8)
 import Numeric (showHex)
 
@@ -83,7 +83,7 @@ data Op
   | OpDup !Word8
   | OpSwap !Word8
   | OpLog !Word8
-  | OpPush !W256
+  | OpPush !SymWord
   | OpUnknown Word8
   deriving (Show, Eq)
 

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -116,7 +116,7 @@ abstractVM typesignature concreteArgs x storagemodel = do
     ConcreteS -> return $ Concrete mempty
   c <- SAddr <$> freshVar_
   value' <- var "CALLVALUE" <$> freshVar_
-  return $ loadSymVM (RuntimeCode x) symstore storagemodel c value' (SymbolicBuffer cd', cdlen) & over constraints ((<>) [cdconstraint])
+  return $ loadSymVM (RuntimeCode (ConcreteBuffer x)) symstore storagemodel c value' (SymbolicBuffer cd', cdlen) & over constraints ((<>) [cdconstraint])
 
 loadSymVM :: ContractCode -> Storage -> StorageModel -> SAddr -> SymWord -> (Buffer, SymWord) -> VM
 loadSymVM x initStore model addr callvalue' calldata' =
@@ -351,7 +351,7 @@ equivalenceCheck bytecodeA bytecodeB maxiter signature' = do
       prestorage = preStateA ^?! env . contracts . ix preself . storage
       (calldata', cdlen) = view (state . calldata) preStateA
       pathconds = view constraints preStateA
-      preStateB = loadSymVM (RuntimeCode bytecodeB) prestorage SymbolicS precaller callvalue' (calldata', cdlen) & set constraints pathconds
+      preStateB = loadSymVM (RuntimeCode (ConcreteBuffer bytecodeB)) prestorage SymbolicS precaller callvalue' (calldata', cdlen) & set constraints pathconds
 
   smtState <- queryState
   push 1

--- a/src/hevm/src/EVM/Symbolic.hs
+++ b/src/hevm/src/EVM/Symbolic.hs
@@ -203,6 +203,10 @@ readSWord :: Word -> Buffer -> SymWord
 readSWord i (SymbolicBuffer x) = readSWord' i x
 readSWord i (ConcreteBuffer x) = num $ Concrete.readMemoryWord i x
 
+index :: Int -> Buffer -> SWord8
+index x (ConcreteBuffer b) = literal $ BS.index b x
+index x (SymbolicBuffer b) = fromSized $ b !! x
+
 -- * Uninterpreted functions
 
 symSHA256N :: SInteger -> SInteger -> SWord 256

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -47,7 +47,6 @@ import Data.Map           (Map)
 import Data.Maybe         (fromMaybe, catMaybes, fromJust, isJust, fromMaybe, mapMaybe)
 import Data.Text          (isPrefixOf, stripSuffix, intercalate, Text, pack, unpack)
 import Data.Text.Encoding (encodeUtf8)
-import Data.Word          (Word32)
 import System.Environment (lookupEnv)
 import System.IO          (hFlush, stdout)
 
@@ -762,7 +761,7 @@ initialUnitTestVm (UnitTestOptions {..}) theContract =
   let
     TestVMParams {..} = testParams
     vm = makeVm $ VMOpts
-           { vmoptContract = initialContract (InitCode (view creationCode theContract))
+           { vmoptContract = initialContract (InitCode (ConcreteBuffer (view creationCode theContract)))
            , vmoptCalldata = (mempty, 0)
            , vmoptValue = 0
            , vmoptAddress = testAddress

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -320,7 +320,7 @@ checkTx tx prestate = do
       toAddr      = fromMaybe (EVM.createAddress origin senderNonce) (txToAddr tx)
       prevCode    = view (accountAt toAddr . contractcode) prestate
       prevNonce   = view (accountAt toAddr . nonce) prestate
-  if isCreate && ((case prevCode of {EVM.RuntimeCode b -> len b == 0; _ -> False}) || (prevNonce /= 0))
+  if isCreate && ((case prevCode of {EVM.RuntimeCode b -> len b /= 0; _ -> True}) || (prevNonce /= 0))
   then mzero
   else
     return $ prestate

--- a/src/hevm/src/EVM/VMTest.hs
+++ b/src/hevm/src/EVM/VMTest.hs
@@ -156,7 +156,7 @@ clearCode = set contractcode (EVM.RuntimeCode mempty)
 
 instance FromJSON EVM.Contract where
   parseJSON (JSON.Object v) = do
-    code <- (EVM.RuntimeCode <$> (hexText <$> v .: "code"))
+    code <- (EVM.RuntimeCode . ConcreteBuffer <$> (hexText <$> v .: "code"))
     storage' <- Map.mapKeys w256 <$> v .: "storage"
     balance' <- v .: "balance"
     nonce'   <- v .: "nonce"
@@ -282,7 +282,7 @@ fromBlockchainCase' block tx preState postState =
             feeSchedule = EVM.FeeSchedule.istanbul
             toCode = Map.lookup toAddr preState
             theCode = if isCreate
-                      then EVM.InitCode (txData tx)
+                      then EVM.InitCode (ConcreteBuffer (txData tx))
                       else maybe (EVM.RuntimeCode mempty) (view contractcode) toCode
             cd = if isCreate
                  then (mempty, 0)

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -526,7 +526,7 @@ main = defaultMain $ testGroup "hevm"
             let vm = vm0
                   & set (state . callvalue) 0
                   & over (env . contracts)
-                       (Map.insert aAddr (initialContract (RuntimeCode a) &
+                       (Map.insert aAddr (initialContract (RuntimeCode $ ConcreteBuffer a) &
                                            set EVM.storage (EVM.Symbolic [] store)))
             verify vm Nothing Nothing (Just checkAssertions)
           putStrLn $ "found counterexample:"
@@ -642,7 +642,7 @@ loadVM x =
     case runState exec (vmForEthrunCreation x) of
        (VMSuccess (ConcreteBuffer targetCode), vm1) -> do
          let target = view (state . contract) vm1
-             vm2 = execState (replaceCodeOfSelf (RuntimeCode targetCode)) vm1
+             vm2 = execState (replaceCodeOfSelf (RuntimeCode (ConcreteBuffer targetCode))) vm1
          return $ snd $ flip runState vm2
                 (do resetState
                     assign (state . gas) 0xffffffffffffffff -- kludge


### PR DESCRIPTION
Allows for constructor arguments to be symbolic, as in [this example](https://github.com/dapphub/dapptools/blob/constructorArg/src/dapp-tests/pass/dsProvePass.sol#L38)