### PR TITLE
restless-git: read default ref from git config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 result
 result-*
+dist-newstyle/


### PR DESCRIPTION
restless-git was previously assuming that the default branch of a git repo was always `master`. This assumption does not always hold, so this PR makes it so that the `defaultRef` is instead read directly from the git config for the repo in question.