### PR TITLE
identify code modulo `immutable` and fix stdjson bundling from etherscan

### DIFF
--- a/src/dapp/libexec/dapp/dapp-mk-standard-json
+++ b/src/dapp/libexec/dapp/dapp-mk-standard-json
@@ -76,7 +76,8 @@ tmpljson["settings"]["outputSelection"]["*"]["*"]=[
     "evm.bytecode.generatedSources",
     "evm.deployedBytecode.sourceMap",
     "evm.deployedBytecode.linkReferences",
-    "evm.deployedBytecode.generatedSources"
+    "evm.deployedBytecode.generatedSources",
+    "evm.deployedBytecode.immutableReferences"
     ]
 
 tmpljson["settings"]["outputSelection"]["*"][""] = ["ast"]

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # hevm changelog
 
+## unreleased
+
+### Added
+
+Can now identify contracts with `immutable` by comparing bytecode modulo immutableReferences
+
 ## 0.46.0 - 2021-04-29
 
 ### Added

--- a/src/hevm/src/EVM/ABI.hs
+++ b/src/hevm/src/EVM/ABI.hs
@@ -70,7 +70,7 @@ import Data.Text.Encoding (encodeUtf8, decodeUtf8')
 import Data.Vector        (Vector, toList)
 import Data.Word          (Word32)
 import Data.List          (intercalate)
-import Data.SBV           (SWord, fromBytes)
+import Data.SBV           (fromBytes)
 import GHC.Generics
 
 import Test.QuickCheck hiding ((.&.), label)

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -289,9 +289,6 @@ atFileLine dapp wantedFileName wantedLineNumber vm =
   case currentSrcMap dapp vm of
     Nothing -> False
     Just sm ->
-      case view (dappSources . sourceFiles . at (srcMapFile sm)) dapp of
-        Nothing -> False
-        Just _ ->
           let
             (currentFileName, currentLineNumber) =
               fromJust (srcMapCodePos (view dappSources dapp) sm)
@@ -323,7 +320,7 @@ outputVm = do
   fromMaybe noMap $ do
     dapp <- view uiVmDapp s
     sm <- currentSrcMap dapp (view uiVm s)
-    (fileName, _) <- view (dappSources . sourceFiles . at (srcMapFile sm)) dapp
+    let (fileName, _) = view (dappSources . sourceFiles) dapp !! srcMapFile sm
     pure . output $
       L [ A "step"
         , L [A ("vm" :: Text), sexp (view uiVm s)]

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -107,11 +107,6 @@ data SlotType
 --  | StorageArray AbiType
   deriving Eq
 
-data Code = Code
-  { rawCode :: ByteString,
-    immutRefs :: Map W256 [Reference]
-  } deriving Show
-
 instance Show SlotType where
  show (StorageValue t) = show t
  show (StorageMapping s t) =

--- a/src/hevm/src/EVM/Transaction.hs
+++ b/src/hevm/src/EVM/Transaction.hs
@@ -8,15 +8,13 @@ import EVM.FeeSchedule
 import EVM.Precompiled (execute)
 import EVM.RLP
 import EVM.Symbolic (forceLit)
-import EVM.Types (keccak)
 import EVM.Types
 
 import Control.Lens
 
 import Data.Aeson (FromJSON (..))
 import Data.ByteString (ByteString)
-import Data.Map (Map, keys)
-import Data.Set (fromList)
+import Data.Map (Map)
 import Data.Maybe (fromMaybe, isNothing, isJust)
 
 import qualified Data.Aeson        as JSON

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -9,7 +9,6 @@ module EVM.Types where
 
 import Prelude hiding  (Word, LT, GT)
 
-import Data.Aeson (FromJSONKey (..), FromJSONKeyFunction (..))
 import Data.Aeson
 import Crypto.Hash
 import Data.SBV hiding (Word)

--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+### Fixed
+
+- seth bundle-source writes the contents of standard-json to the current directory to enable better sourcemaps for multiple files version of etherscan source.
+
 ## [0.10.1] - 2021-03-22
 
 ### Added

--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- seth bundle-source writes the contents of standard-json to the current directory to enable better sourcemaps for multiple files version of etherscan source.
+- seth bundle-source writes the contents of standard-json to the current directory to enable better sourcemaps for multi-file etherscan source code.
 
 ## [0.10.1] - 2021-03-22
 

--- a/src/seth/libexec/seth/seth-bundle-source
+++ b/src/seth/libexec/seth/seth-bundle-source
@@ -22,6 +22,12 @@ case "$SOURCE" in
     # for some reason etherscan surrounds the actual json with '{}'
     SOURCE="${SOURCE/#\{\{/\{}"
     SOURCE="${SOURCE/%\}\}/\}}"
+
+    # write all source files in the local directory
+    for x in $(echo "$SOURCE" | jq '.sources | keys | .[]' -r); do
+        mkdir -p "$(dirname "$x")"
+        echo "$SOURCE" | jq ".sources.\"$x\".content" -r > $x
+    done;
     export DAPP_SOLC_JSON="$SOURCE"
     seth --use solc:"${SOLC_VERSION}" solc
     ;;

--- a/src/seth/libexec/seth/seth-solc
+++ b/src/seth/libexec/seth/seth-solc
@@ -32,7 +32,9 @@ JSON="${DAPP_SOLC_JSON:-$(jq -n '{}
 # we have what hevm wants
 JSON="$(<<<"$JSON" jq '.
   | .settings.outputSelection["*"]["*"]=[
+      "metadata",
       "evm.bytecode",
+      "evm.deployedBytecode",
       "abi",
       "storageLayout",
       "evm.bytecode.sourceMap",
@@ -40,7 +42,8 @@ JSON="$(<<<"$JSON" jq '.
       "evm.bytecode.generatedSources",
       "evm.deployedBytecode.sourceMap",
       "evm.deployedBytecode.linkReferences",
-      "evm.deployedBytecode.generatedSources"
+      "evm.deployedBytecode.generatedSources",
+      "evm.deployedBytecode.immutableReferences"
     ]
   | .settings.outputSelection["*"][""] = ["ast"]
   ')"


### PR DESCRIPTION
This PR lets us have srcmaps for contracts with immutable variables. If the hash based identification of a contract fails, we look at all the known contracts with immutable vars and see if our current bytecode matches any of them if we overwrite possible mutability locations with zeros.

There's also a fix for `seth bundle-source` to write all relevant contracts to disk when getting dealing with std-json artifacts from etherscan (i.e. multiple srcs, not flattened).