### PR TITLE
Revert "nix: add libz3.so.4.8 to LD_LIBARY_PATH for static solc binaries"

### DIFF
--- a/nix/solc-static.nix
+++ b/nix/solc-static.nix
@@ -1,26 +1,6 @@
 {path, version, sha256}:
 
-{stdenv, fetchurl, lib, z3, makeWrapper, autoPatchelfHook}:
-let
-  # solc uses dlopen to look for z3 at runtime, and expects to find a library
-  # called libz3.so.4.8 exactly. The z3.lib provided by nixpkgs only has a
-  # libz3.so, so we have to hack around it with this derivation that gives us a
-  # copy of libz3.so with the name that solc expects.
-  # At some point in the future we're going to need some logic to provide
-  # different versions of z3 to different versions of solc, but for now we just
-  # give z3-4.8 to every version of solc
-  split = lib.strings.splitString "." z3.version;
-  z3-exact = stdenv.mkDerivation {
-    pname = z3.pname;
-    version = z3.version;
-    src = null;
-    phases = [ "installPhase" ];
-    installPhase = ''
-      mkdir -p $out/lib
-      cp ${z3.lib}/lib/libz3.so $out/lib/libz3.so.${builtins.elemAt split 0}.${builtins.elemAt split 1}
-    '';
-  };
-in
+{stdenv, fetchurl, lib, pkgs, autoPatchelfHook}:
 
 stdenv.mkDerivation rec {
   pname = "solc-static";
@@ -40,12 +20,8 @@ stdenv.mkDerivation rec {
     sha256 = "${sha256}";
   };
 
-  nativeBuildInputs = [ autoPatchelfHook makeWrapper ];
-
-  postFixup = ''
-      wrapProgram $out/bin/solc-${version} \
-        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ z3-exact ]}
-  '';
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ pkgs.z3.lib ];
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
Getting reports in chat that this is broken on osx, reverting for now....

This reverts commit 2139b124d6ffa458fef433b5c0bdeadd3b3d5a28.