### PR TITLE
invariant testing fixes

### DIFF
--- a/src/dapp-tests/pass/invariants.sol
+++ b/src/dapp-tests/pass/invariants.sol
@@ -6,16 +6,40 @@ import "ds-math/math.sol";
 
 contract InvariantTest is DSTest {
     DSToken token;
+    User user;
+    address[] targetContracts_;
+
+    function targetContracts() public returns (address[] memory) {
+      return targetContracts_;
+    }
 
     function setUp() public {
         token = new DSToken("TKN");
         token.mint(100 ether);
+        user = new User(token);
+        token.transfer(address(user), 100 ether);
+        targetContracts_.push(address(user));
     }
 
     function invariantTestThisBal() public {
-        assertLe(token.balanceOf(address(this)), 100 ether);
+        assertLe(token.balanceOf(address(user)), 100 ether);
     }
     function invariantTotSupply() public {
         assertEq(token.totalSupply(), 100 ether);
     }
+}
+
+contract User {
+  DSToken token;
+  constructor(DSToken token_) public {
+    token = token_;
+  }
+
+  function doTransfer(address to, uint amount) public {
+    token.transfer(to, amount);
+  }
+
+  function doSelfTransfer(uint amount) public {
+    token.transfer(address(this), amount);
+  }
 }

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -114,9 +114,9 @@ data VM = VM
   deriving (Show)
 
 data Trace = Trace
-  { _traceCode :: ContractCode
-  , _traceOpIx :: Int
-  , _traceData :: TraceData
+  { _traceOpIx     :: Int
+  , _traceContract :: Contract
+  , _traceData     :: TraceData
   }
   deriving (Show)
 
@@ -2420,7 +2420,7 @@ withTraceLocation x = do
       currentContract vm
   pure Trace
     { _traceData = x
-    , _traceCode = view contractcode this
+    , _traceContract = this
     , _traceOpIx = fromMaybe 0 $ (view opIxMap this) Vector.!? (view (state . pc) vm)
     }
 

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -638,14 +638,15 @@ initialUiVmStateForTest opts@UnitTestOptions{..} (theContractName, theTestName) 
             void (runUnitTest opts theTestName args)
           SymbolicTest _ -> do
             Stepper.evm $ modify symbolify
-            void (execSymTest opts theTestName (SymbolicBuffer buf, w256lit len)) -- S (Literal $
+            void (execSymTest opts theTestName (SymbolicBuffer buf, w256lit len))
           InvariantTest _ -> do
-            let randomRun = explorationStepper opts theTestName [] (List []) (fromMaybe 20 maxDepth)
+            targets <- getTargetContracts opts
+            let randomRun = explorationStepper opts theTestName [] targets (List []) (fromMaybe 20 maxDepth)
             void $ case replay of
               Nothing -> randomRun
               Just (sig, cd) ->
                 if theTestName == sig
-                then explorationStepper opts theTestName (decodeCalls cd) (List []) (length (decodeCalls cd))
+                then explorationStepper opts theTestName (decodeCalls cd) targets (List []) (length (decodeCalls cd))
                 else randomRun
   pure $ initUiVmState vm0 opts script
   where
@@ -867,8 +868,7 @@ currentSrcMap :: DappInfo -> VM -> Maybe SrcMap
 currentSrcMap dapp vm = do
   this <- currentContract vm
   i <- (view opIxMap this) SVec.!? (view (state . pc) vm)
-  let h = view contractcode this
-  srcMap dapp h i
+  srcMap dapp this i
 
 drawStackPane :: UiVmState -> UiWidget
 drawStackPane ui =

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -543,7 +543,7 @@ getTargetContracts UnitTestOptions{..} = do
       theAbi = view abiMap $ fromJust $ lookupCode (view contractcode contract) dapp
       setUp  = abiKeccak (encodeUtf8 "targetContracts()")
   case Map.lookup setUp theAbi of
-    Nothing -> error "no method targetContracts"--return []
+    Nothing -> return []
     Just _ -> do
       Stepper.evm $ abiCall testParams (Left ("targetContracts()", emptyAbi))
       res <- Stepper.execFully


### PR DESCRIPTION
Fixes (mostly) a performance regression in dapp debug introduced in #593 and introduces the ability to select which contracts to chose methods from during invariant testing. If a function `targetContracts()(address[])` is present in the current testing contract. See some examples in the testing files