### PR TITLE
nix: add solc-0.8.5/0.8.6

### DIFF
--- a/nix/solc-static-versions.nix
+++ b/nix/solc-static-versions.nix
@@ -60,6 +60,8 @@ rec {
     solc_0_8_2 = { version = "0.8.2"; path = "solc-linux-amd64-v0.8.2+commit.661d1103"; sha256 = "1hk81sffchkvv1ixa47fr8phh8qbxsma0djrg40mjfflf6fl5fdn"; };
     solc_0_8_3 = { version = "0.8.3"; path = "solc-linux-amd64-v0.8.3+commit.8d00100c"; sha256 = "14p2h6b68dc97wdyf3rpls2ls3br98xjsn5d3mkh9myhc7bsyczv"; };
     solc_0_8_4 = { version = "0.8.4"; path = "solc-linux-amd64-v0.8.4+commit.c7e474f2"; sha256 = "1y571l0ngzdwf14afrdg20niyhhlhsgr9258mbrxr68qy755q4gp"; };
+    solc_0_8_5 = { version = "0.8.5"; path = "solc-linux-amd64-v0.8.5+commit.a4f2e591"; sha256 = "1rrkzajrzaxf5k5hy3fdag41dja4dp75l5034z9001fmlw3j0y5x"; };
+    solc_0_8_6 = { version = "0.8.6"; path = "solc-linux-amd64-v0.8.6+commit.11564f7e"; sha256 = "0gpc18jlkb3f62mnhdawk9nzd0wfz5iqr5hvjpbkxg32ybrw9mdb"; };
   };
   x86_64-darwin  = {
     solc_0_3_6 = { version = "0.3.6"; path = "solc-macosx-amd64-v0.3.6+commit.988fe5e5"; sha256 = "1x4xq0j84sfh9jjvv6x3yvhc76785vfr1mkmkq5idn3knfsq3m82"; };
@@ -133,5 +135,7 @@ rec {
     solc_0_8_2 = { version = "0.8.2"; path = "solc-macosx-amd64-v0.8.2+commit.661d1103"; sha256 = "072ckg2n1c41vrc8mv0bgjzg818jv9vbcimnwg7apkf818xw5608"; };
     solc_0_8_3 = { version = "0.8.3"; path = "solc-macosx-amd64-v0.8.3+commit.8d00100c"; sha256 = "1fj6vlplsmhn81kc5jvipbqnghf3pm2pl6l1rv11xv1k9p1gb20i"; };
     solc_0_8_4 = { version = "0.8.4"; path = "solc-macosx-amd64-v0.8.4+commit.c7e474f2"; sha256 = "03q76ma791qcmj6bapfb2ab781yrn2lly3c5pjxm345089ljwvsg"; };
+    solc_0_8_5 = { version = "0.8.5"; path = "solc-macosx-amd64-v0.8.5+commit.a4f2e591"; sha256 = "0f5rvl98p5iylfs0pmxwxyfwivkdp7czyccmwwhagx3fl9kyw89l"; };
+    solc_0_8_6 = { version = "0.8.6"; path = "solc-macosx-amd64-v0.8.6+commit.11564f7e"; sha256 = "0dnvynr264phf34y04gd2x8b63n1sjjbcsb10kx6pqy79zv9kvl6"; };
   };
 }


### PR DESCRIPTION
Adds solc 0.8.5/0.8.6 to `solc-static-versions.nix`

Generated using `./make-solc-static.sh`