### PR TITLE
Loosen remappings warning

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- `dapp remappings` now issues a warning instead of failing with a hard error in case of mistmatched
+  package versions in the dependency tree
+
 ## [0.33.0] - 2021-07-01
 
 ### Added

--- a/src/dapp/libexec/dapp/dapp-remappings
+++ b/src/dapp/libexec/dapp/dapp-remappings
@@ -53,7 +53,7 @@ function findRemappings(prefix) {
 
 function ls(dir) {
   try {
-    return require("fs").readdirSync(dir)
+    return require("fs").readdirSync(dir).sort()
   } catch (error) {
     return []
   }

--- a/src/dapp/libexec/dapp/dapp-remappings
+++ b/src/dapp/libexec/dapp/dapp-remappings
@@ -11,7 +11,6 @@ Object.keys(pkg_src).sort((a, b) => a.length - b.length).sort(
   }
 ).forEach(name => {
   console.log(`${name}/=${pkg_src[name]}/`)
-  console.log(`${name}=${pkg_src[name]}/index.sol`)
 })
 
 function findRemappings(prefix) {

--- a/src/dapp/libexec/dapp/dapp-remappings
+++ b/src/dapp/libexec/dapp/dapp-remappings
@@ -30,15 +30,15 @@ function findRemappings(prefix) {
       console.error(`${PROGRAM_NAME}: error: try "dapp update" to initialize submodules`)
       process.exit(1)
     }
-    
+
     var hash = run("git", ["-C", src, "rev-parse", "HEAD"])
-  
+
     if (pkg_src[name]) {
       if (hash != pkg_hash[name]) {
-        console.error(`${PROGRAM_NAME}: error: mismatching packages:`)
-        console.error(`${PROGRAM_NAME}: error: (1) ${pkg_src[name]}`)
-        console.error(`${PROGRAM_NAME}: error: (2) ${src}`)
-        process.exit(1)
+        console.error(`${PROGRAM_NAME}: warning: mismatching packages:`)
+        console.error(`${PROGRAM_NAME}: warning: (1) ${pkg_src[name]}`)
+        console.error(`${PROGRAM_NAME}: warning: (2) ${src}`)
+        console.error(`${PROGRAM_NAME}: warning: using ${pkg_src[name]}. You can override this using \`DAPP_REMAPPINGS\``)
       } else if (src.length < pkg_src[name].length) {
         pkg_src[name] = src
       }
@@ -46,7 +46,7 @@ function findRemappings(prefix) {
       pkg_src[name] = src
       pkg_hash[name] = hash
     }
-  
+
     findRemappings(`${lib}/${name}`)
   })
 }


### PR DESCRIPTION
This downgrades the dreaded mismatched packages error to a warning, and removes the useless `index.sol` remappings from the `dapp remappings` output.