### PR TITLE
Fix storage layout parsing

### DIFF
--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -334,8 +334,9 @@ readCombinedJSON json = do
       let
         theRuntimeCode = toCode (x ^?! key "bin-runtime" . _String)
         theCreationCode = toCode (x ^?! key "bin" . _String)
-        abis =
-          toList ((x ^?! key "abi" . _String) ^?! _Array)
+        abis = toList $ case (x ^?! key "abi") ^? _Array of
+                 Just v -> v                                       -- solc >= 0.8
+                 Nothing -> (x ^?! key "abi" . _String) ^?! _Array -- solc <  0.8
       in SolcContract {
         _runtimeCode      = theRuntimeCode,
         _creationCode     = theCreationCode,

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -347,7 +347,7 @@ readCombinedJSON json = do
         _constructorInputs = mkConstructor abis,
         _abiMap       = mkAbiMap abis,
         _eventMap     = mkEventMap abis,
-        _storageLayout = mkStorageLayout $ x ^? key "storage-layout" . _String,
+        _storageLayout = mkStorageLayout $ x ^? key "storage-layout",
         _immutableReferences = mempty -- TODO: deprecate combined-json
       }
 
@@ -389,7 +389,7 @@ readStdJSON json = do
         _constructorInputs = mkConstructor abis,
         _abiMap        = mkAbiMap abis,
         _eventMap      = mkEventMap abis,
-        _storageLayout = mkStorageLayout $ x ^? key "storageLayout" . _String,
+        _storageLayout = mkStorageLayout $ x ^? key "storageLayout",
         _immutableReferences = fromMaybe mempty $
           do x' <- runtime ^? key "immutableReferences"
              case fromJSON x' of
@@ -444,7 +444,7 @@ mkConstructor abis =
       [] -> [] -- default constructor has zero inputs
       _  -> error "strange: contract has multiple constructors"
 
-mkStorageLayout :: Maybe Text -> Maybe (Map Text StorageItem)
+mkStorageLayout :: Maybe Value -> Maybe (Map Text StorageItem)
 mkStorageLayout Nothing = Nothing
 mkStorageLayout (Just json) = do
   items <- json ^? key "storage" . _Array


### PR DESCRIPTION
Fixes some issues with json parsing:

1. storage layout was being parsed as a string, when it is an object in the std-json output (and also in the combined json output post solc 0.8)
2. abis were being parsed as a string in the combined json output, but they are an object post solc 0.8

Note that this change currently breaks parsing of storage layout for combined-json output from solc < 0.8. I'm happy to make this work if we consider it important, but since it's a deprecated option, and I couldn't figure out a clean way to make it work after 20 minutes I just left it alone.

We could maybe also just consider removing the `combinedJSON` parsing code as part of this PR as well?