### PR TITLE
fix debug bug

### DIFF
--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -623,7 +623,9 @@ initialUiVmStateForTest
   -> IO UiVmState
 initialUiVmStateForTest opts@UnitTestOptions{..} (theContractName, theTestName) = do
   let state' = fromMaybe (error "Internal Error: missing smtState") smtState
-  (buf, len) <- flip runReaderT state' $ SBV.runQueryT $ symCalldata theTestName types []
+  (buf, len) <- case test of
+    SymbolicTest _ -> flip runReaderT state' $ SBV.runQueryT $ symCalldata theTestName types []
+    _ -> return (error "unreachable", error "unreachable")
   let script = do
         Stepper.evm . pushTrace . EntryTrace $
           "test " <> theTestName <> " (" <> theContractName <> ")"


### PR DESCRIPTION
whenever one tries to debug a fuzz test which features a type which doesn't have a corresponding symbolic version (i.e. `bytes` or other dynamically sized types), hevm currently fails as we try to generate a symbolic argument (which will be thrown away regardless). This quick fix ensures that we only create the symbolic argument if it is actually a symbolic test