### PR TITLE
Soundness issue

### DIFF
--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -334,8 +334,9 @@ readCombinedJSON json = do
       let
         theRuntimeCode = toCode (x ^?! key "bin-runtime" . _String)
         theCreationCode = toCode (x ^?! key "bin" . _String)
-        abis =
-          toList ((x ^?! key "abi" . _String) ^?! _Array)
+        abis = toList $ case (x ^?! key "abi") ^? _Array of
+                 Just v -> v                                       -- solc >= 0.8
+                 Nothing -> (x ^?! key "abi" . _String) ^?! _Array -- solc <  0.8
       in SolcContract {
         _runtimeCode      = theRuntimeCode,
         _creationCode     = theCreationCode,

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -347,7 +347,7 @@ readCombinedJSON json = do
         _constructorInputs = mkConstructor abis,
         _abiMap       = mkAbiMap abis,
         _eventMap     = mkEventMap abis,
-        _storageLayout = mkStorageLayout $ x ^? key "storage-layout" . _String,
+        _storageLayout = mkStorageLayout $ x ^? key "storage-layout",
         _immutableReferences = mempty -- TODO: deprecate combined-json
       }
 
@@ -389,7 +389,7 @@ readStdJSON json = do
         _constructorInputs = mkConstructor abis,
         _abiMap        = mkAbiMap abis,
         _eventMap      = mkEventMap abis,
-        _storageLayout = mkStorageLayout $ x ^? key "storageLayout" . _String,
+        _storageLayout = mkStorageLayout $ x ^? key "storageLayout",
         _immutableReferences = fromMaybe mempty $
           do x' <- runtime ^? key "immutableReferences"
              case fromJSON x' of
@@ -444,7 +444,7 @@ mkConstructor abis =
       [] -> [] -- default constructor has zero inputs
       _  -> error "strange: contract has multiple constructors"
 
-mkStorageLayout :: Maybe Text -> Maybe (Map Text StorageItem)
+mkStorageLayout :: Maybe Value -> Maybe (Map Text StorageItem)
 mkStorageLayout Nothing = Nothing
 mkStorageLayout (Just json) = do
   items <- json ^? key "storage" . _Array

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -106,7 +106,7 @@ abstractVM typesignature concreteArgs x storagemodel = do
     case typesignature of
       Nothing -> do cd <- sbytes256
                     len <- freshVar_
-                    return (cd, var "calldataLength" len, (len .<= 256, Todo "calldatalength < 256" []))
+                    return (cd, var "calldataLength" len, (len .<= 256, Todo "calldatalength <= 256" []))
       Just (name, typs) -> do (cd, cdlen) <- symCalldata name typs concreteArgs
                               return (cd, S (Literal cdlen) (literal $ num cdlen), (sTrue, Todo "Trivial" []))
   symstore <- case storagemodel of
@@ -414,7 +414,7 @@ equivalenceCheck bytecodeA bytecodeB maxiter signature' = do
                 error $ "Unexpected symbolic argument at opcode: " <> maybe "??" show (vmOp a) <> ". Not supported (yet!)"
 
               (_, Just (VMFailure UnexpectedSymbolicArg)) ->
-                error $ "Unexpected symbolic argument at opcode: " <> maybe "??" show (vmOp a) <> ". Not supported (yet!)"
+                error $ "Unexpected symbolic argument at opcode: " <> maybe "??" show (vmOp b) <> ". Not supported (yet!)"
 
               (Just (VMFailure _), Just (VMFailure _)) -> sFalse
 

--- a/src/hevm/src/EVM/Symbolic.hs
+++ b/src/hevm/src/EVM/Symbolic.hs
@@ -269,9 +269,6 @@ whiffValue w = case w of
 
 -- | Special cases that have proven useful in practice
 simplifyCondition :: SBool -> Whiff -> SBool
-simplifyCondition _ (IsZero (IsZero (IsZero a))) = whiffValue a .== 0
-
-
 
 -- | Overflow safe math can be difficult for smt solvers to deal with,
 -- especially for 256-bit words. When we recognize terms arising from

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -623,7 +623,9 @@ initialUiVmStateForTest
   -> IO UiVmState
 initialUiVmStateForTest opts@UnitTestOptions{..} (theContractName, theTestName) = do
   let state' = fromMaybe (error "Internal Error: missing smtState") smtState
-  (buf, len) <- flip runReaderT state' $ SBV.runQueryT $ symCalldata theTestName types []
+  (buf, len) <- case test of
+    SymbolicTest _ -> flip runReaderT state' $ SBV.runQueryT $ symCalldata theTestName types []
+    _ -> return (error "unreachable", error "unreachable")
   let script = do
         Stepper.evm . pushTrace . EntryTrace $
           "test " <> theTestName <> " (" <> theContractName <> ")"

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -245,8 +245,8 @@ instance Show Whiff where
       SGT x y     -> infix' " s> " x y
       IsZero x    -> "IsZero(" ++ show x ++ ")"
       SHL x y     -> infix' " << " x y
-      SHR x y     -> infix' " << " x y
-      SAR x y     -> infix' " a<< " x y
+      SHR x y     -> infix' " >> " x y
+      SAR x y     -> infix' " a>> " x y
       Add x y     -> infix' " + " x y
       Sub x y     -> infix' " - " x y
       Mul x y     -> infix' " * " x y


### PR DESCRIPTION
Consider the following yul code, which asserts when the given calldata address has extra bytes beyond the 20 address bytes:
`bugdemo.yul`:
```
object "Token" {
  code {
   // Deploy the contract
   datacopy(0, dataoffset("runtime"), datasize("runtime"))
     return(0, datasize("runtime"))
  }
  object "runtime" {
   code {
    switch selector()
      case 0x70a08231 /* "balanceOf(address)" */ {
       pop(decodeAsAddress(0))
    }
  function selector() -> s {
     s := div(calldataload(0), 0x100000000000000000000000000000000000000000000000000000000)
  }
  function decodeAsAddress(offset) -> v {
     v := calldataload(add(4, mul(offset, 0x20)))
     if iszero(iszero(and(v, not(0xffffffffffffffffffffffffffffffffffffffff)))) {
        invalid()
     }
  }
}
}
}
```

When we supply `--sig balanceOf(address)`, calldata should be properly formed, and we should not end up violating the assertion, and yet:
```
hevm symbolic --code $(hevm exec --code $(erc20-example/solc-0.8.2 bugdemo.yul --strict-assembly | awk '/Binary representation:/{getline; print}') --gas 0xffff) --sig "balanceOf(address)"

Assertion violation found.
Calldata:
0x70a082310000000000000000000000000000000000000000000000000000000000000001
balanceOf(0x0000000000000000000000000000000000000001)
Caller:
0x0000000000000000000000000000000000000000
Callvalue:
0
```

I have tracked down this issue to this simplifcation rule, but why this is problematic is still a bit mysterious to me