### PR TITLE
bump hevm version

### DIFF
--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.2
 name:
   hevm
 version:
-  0.47.0
+  0.47.1
 synopsis:
   Ethereum virtual machine evaluator
 description:


### PR DESCRIPTION
If we leave this on `0.47.0` then cabal always selects the hackage release instead of the version we provide via nix when I try to use hevm master in act. I don't know why that is the case, but bumping the hevm version and increasing the version bound in `act.cabal` finally meant that CI would pass here: https://github.com/ethereum/act/pull/116