### PR TITLE
More README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 Hello!
 
-`dapptools` is a suite of Ethereum focused CLI tools following the unix design philosophy,
+`dapptools` is a suite of Ethereum focused CLI tools following the Unix design philosophy,
 favoring composability, configurability and extensibility.
 
 This repository contains the source code for several programs
 hand-crafted and maintained by DappHub, along with dependency management, courtesy of Nix.
 
-- [dapp](./src/dapp) - all you need Ethereum development tool. Build, test, fuzz, formally verify, debug & deploy solidity contracts.
+- [dapp](./src/dapp) - All you need Ethereum development tool. Build, test, fuzz, formally verify, debug & deploy solidity contracts.
 - [seth](./src/seth) - Ethereum CLI. Query contracts, send transactions, follow logs, slice & dice data.
 - [hevm](./src/hevm) - Testing oriented EVM implementation. Debug, fuzz, or symbolically execute code against local or mainnet state.
-- [ethsign](./src/ethsign) - sign Ethereum transactions from a local keystore or hardware wallet.
+- [ethsign](./src/ethsign) - Sign Ethereum transactions from a local keystore or hardware wallet.
 
 ## Installation
 
@@ -51,10 +51,10 @@ Most functionality is available out of the box, but for symbolic execution you w
 
 For more information about the tools, consult the individual README pages:
 
-[seth](./src/seth/README.md)
-[dapp](./src/dapp/README.md)
-[hevm](./src/dapp/README.md)
-[ethsign](./src/ethsign/README.md)
+- [seth](./src/seth/README.md)
+- [dapp](./src/dapp/README.md)
+- [hevm](./src/dapp/README.md)
+- [ethsign](./src/ethsign/README.md)
 
 or use the `--help` flag for any tool.
 
@@ -94,5 +94,4 @@ hevm symbolic --address 0x6b175474e89094c44da98b954eedeac495271d0f --rpc $ETH_RP
 Contributions are always welcome! You may be interested in the 
 [architecture](./ARCHITECTURE.md) of this repository.
 
----
 [![built with nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ We're also happy to answer any questions at https://dapphub.chat/.
 
 ## Examples
 
-Deploy a Hello world contract and call it:
+Deploy a 'Hello World' contract and call it:
 ```sh
 export ETH_RPC_URL=https://mainnet.infura.io/v3/$YOUR_API_KEY
 export ETH_FROM=$YOUR_ADDRESS
@@ -77,7 +77,7 @@ export ETH_RPC_URL=https://mainnet.infura.io/v3/$YOUR_API_KEY
 seth run-tx $(seth block latest transactions | jq .'[0]' -r) --debug
 ```
 
-If Vitaliks next transaction were a contract deployment, calculate the address it would be deployed at:
+If Vitalik's next transaction were a contract deployment, calculate the address it would be deployed at:
 ```
 export ETH_RPC_URL=https://mainnet.infura.io/v3/$YOUR_API_KEY
 dapp address 0xab5801a7d398351b8be11c439e05c5b3259aec9b $(seth nonce 0xab5801a7d398351b8be11c439e05c5b3259aec9b)

--- a/src/dapp/README.md
+++ b/src/dapp/README.md
@@ -275,42 +275,44 @@ The `--verify` flag verifies the contract on etherscan (requires `ETHERSCAN_API_
 The commands of `dapp` can be customized with environment variables or flags.
 These variables can be set at the prompt or in a `.dapprc` file.
 
-Below is a list of the environment variables recognised by `dapp`. You can addionally control
+Below is a list of the environment variables recognized by `dapp`. You can additionally control
 various block parameters when running unit tests by using the [hevm specific environment
 variables](../hevm/README.md#environment-variables).
 
-| Variable                   | Default                    | Synopsis                                                                                                                                          |
-| -------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DAPP_SRC`                 | `src`                      | Directory for the project's Solidity contracts                                                                                                    |
-| `DAPP_LIB`                 | `lib`                      | Directory for installed Dapp packages                                                                                                             |
-| `DAPP_OUT`                 | `out`                      | Directory for compilation artifacts                                                                                                               |
-| `DAPP_ROOT`                | `.`                        | Root directory of compilation                                                                                                                     |
-| `DAPP_SOLC_VERSION`        | `0.8.6`                    | Solidity compiler version to use                                                                                                                  |
-| `DAPP_SOLC`                | n/a                        | solc binary to use                                                                                                                                |
-| `DAPP_LIBRARIES`           | automatically deployed     | Library addresses to link to                                                                                                                      |
-| `DAPP_SKIP_BUILD`          | n/a                        | Avoid compiling this time                                                                                                                         |
-| `DAPP_LINK_TEST_LIBRARIES` | `1` when testing; else `0` | Compile with libraries                                                                                                                            |
-| `DAPP_VERIFY_CONTRACT`     | `yes`                      | Attempt Etherscan verification                                                                                                                    |
-| `DAPP_ASYNC`               | n/a                        | Set to `yes` to skip waiting for etherscan verification to succeed                                                                                |
-| `DAPP_STANDARD_JSON`       | `$(dapp mk-standard-json)` | [Solidity compilation options](https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-input-and-output-json-description)        |
-| `DAPP_REMAPPINGS`          | `$(dapp remappings)`       | [Solidity remappings](https://docs.soliditylang.org/en/latest/using-the-compiler.html#path-remapping)                                             |
-| `DAPP_BUILD_OPTIMIZE`      | `0`                        | Activate Solidity optimizer (`0` or `1`)                                                                                                          |
-| `DAPP_BUILD_OPTIMIZE_RUNS` | `200`                      | Set the optimizer runs                                                                                                                            |
-| `DAPP_TEST_MATCH`          | n/a                        | Only run test methods matching a regex                                                                                                            |
-| `DAPP_TEST_VERBOSITY`      | `0`                        | Sets how much detail `dapp test` logs. Verbosity `1` shows traces for failing tests, `2` shows logs for all tests, `3` shows traces for all tests |
-| `DAPP_TEST_FUZZ_RUNS`      | `200`                      | How many iterations to use for each property test in your project                                                                                 |
-| `DAPP_TEST_SMTTIMEOUT`     | `600000`                   | Timeout passed to the smt solver for symbolic tests (in ms, and per smt query)                                                                    |
-| `DAPP_TEST_FFI `           | `0`                        | Allow use of the ffi cheatcode in tests (`0` or `1`)                                                                                              |
-| `HEVM_RPC`                 | n/a                        | Set to `yes` to have `hevm` fetch state from rpc when running unit tests                                                                          |
-| `ETH_RPC_URL`              | n/a                        | The url of the rpc server that should be used for any rpc calls                                                                                   |
-| `DAPP_TESTNET_RPC_PORT`    | `8545`                     | Which port to expose the rpc server on when running `dapp testnet`                                                                                |
-| `DAPP_TESTNET_RPC_ADDRESS` | `127.0.0.1`                | Which ip address to bind the rpc server to when running `dapp testnet`                                                                            |
-| `DAPP_TESTNET_CHAINID`     | `99`                       | Which chain id to use when running `dapp testnet`                                                                                                 |
-| `DAPP_TESTNET_PERIOD`      | `0`                        | Blocktime to use for `dapp testnet`. `0` means blocks are produced instantly as soon as a transaction is received                                 |
-| `DAPP_TESTNET_ACCOUNTS`    | `0`                        | How many extra accounts to create when running `dapp testnet` (At least one is always created)                                                    |
-| `DAPP_TESTNET_gethdir`     | `$HOME/.dapp/testnet`      | Root directory that should be used for `dapp testnet` data                                                                                        |
-| `DAPP_TESTNET_SAVE`        | n/a                        | Name of the subdirecty under `${DAPP_TESTNET_gethdir}/snapshots` where the chain data from the current `dapp testnet` invocation should be saved  |
-| `DAPP_TESTNET_LOAD`        | n/a                        | Name of the subdirecty under `${DAPP_TESTNET_gethdir}/snapshots` from which `dapp testnet` chain data should be loaded                            |
+| Variable                   | Default                    | Synopsis                                                                                                                                           |
+| -------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DAPP_SRC`                 | `src`                      | Directory for the project's Solidity contracts                                                                                                     |
+| `DAPP_LIB`                 | `lib`                      | Directory for installed Dapp packages                                                                                                              |
+| `DAPP_OUT`                 | `out`                      | Directory for compilation artifacts                                                                                                                |
+| `DAPP_ROOT`                | `.`                        | Root directory of compilation                                                                                                                      |
+| `DAPP_SOLC_VERSION`        | `0.8.6`                    | Solidity compiler version to use                                                                                                                   |
+| `DAPP_SOLC`                | n/a                        | solc binary to use                                                                                                                                 |
+| `DAPP_LIBRARIES`           | automatically deployed     | Library addresses to link to                                                                                                                       |
+| `DAPP_SKIP_BUILD`          | n/a                        | Avoid compiling this time                                                                                                                          |
+| `DAPP_LINK_TEST_LIBRARIES` | `1` when testing; else `0` | Compile with libraries                                                                                                                             |
+| `DAPP_VERIFY_CONTRACT`     | `yes`                      | Attempt Etherscan verification                                                                                                                     |
+| `DAPP_ASYNC`               | n/a                        | Set to `yes` to skip waiting for etherscan verification to succeed                                                                                 |
+| `DAPP_STANDARD_JSON`       | `$(dapp mk-standard-json)` | [Solidity compilation options](https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-input-and-output-json-description)         |
+| `DAPP_REMAPPINGS`          | `$(dapp remappings)`       | [Solidity remappings](https://docs.soliditylang.org/en/latest/using-the-compiler.html#path-remapping)                                              |
+| `DAPP_BUILD_OPTIMIZE`      | `0`                        | Activate Solidity optimizer (`0` or `1`)                                                                                                           |
+| `DAPP_BUILD_OPTIMIZE_RUNS` | `200`                      | Set the optimizer runs                                                                                                                             |
+| `DAPP_TEST_MATCH`          | n/a                        | Only run test methods matching a regex                                                                                                             |
+| `DAPP_TEST_VERBOSITY`      | `0`                        | Sets how much detail `dapp test` logs. Verbosity `1` shows traces for failing tests, `2` shows logs for all tests, `3` shows traces for all tests  |
+| `DAPP_TEST_FUZZ_RUNS`      | `200`                      | How many iterations to use for each property test in your project                                                                                  |
+| `DAPP_TEST_SMTTIMEOUT`     | `600000`                   | Timeout passed to the smt solver for symbolic tests (in ms, and per smt query)                                                                     |
+| `DAPP_TEST_FFI `           | `0`                        | Allow use of the ffi cheatcode in tests (`0` or `1`)                                                                                               |
+| `HEVM_RPC`                 | n/a                        | Set to `yes` to have `hevm` fetch state from rpc when running unit tests                                                                           |
+| `ETH_RPC_URL`              | n/a                        | The url of the rpc server that should be used for any rpc calls                                                                                    |
+| `DAPP_TESTNET_RPC_PORT`    | `8545`                     | Which port to expose the rpc server on when running `dapp testnet`                                                                                 |
+| `DAPP_TESTNET_RPC_ADDRESS` | `127.0.0.1`                | Which ip address to bind the rpc server to when running `dapp testnet`                                                                             |
+| `DAPP_TESTNET_CHAINID`     | `99`                       | Which chain id to use when running `dapp testnet`                                                                                                  |
+| `DAPP_TESTNET_PERIOD`      | `0`                        | Blocktime to use for `dapp testnet`. `0` means blocks are produced instantly as soon as a transaction is received                                  |
+| `DAPP_TESTNET_ACCOUNTS`    | `0`                        | How many extra accounts to create when running `dapp testnet` (At least one is always created)                                                     |
+| `DAPP_TESTNET_gethdir`     | `$HOME/.dapp/testnet`      | Root directory that should be used for `dapp testnet` data                                                                                         |
+| `DAPP_TESTNET_SAVE`        | n/a                        | Name of the subdirectory under `${DAPP_TESTNET_gethdir}/snapshots` where the chain data from the current `dapp testnet` invocation should be saved |
+| `DAPP_TESTNET_LOAD`        | n/a                        | Name of the subdirectory under `${DAPP_TESTNET_gethdir}/snapshots` from which `dapp testnet` chain data should be loaded                           |
+| `DAPP_BUILD_EXTRACT`       | n/a                        | Set to a non null value to output `.abi`, `.bin` and `.bin-runtime` when using `dapp build`. Uses legacy build mode                                |
+| `DAPP_BUILD_LEGACY`        | n/a                        | Set to a non null value to compile using the `--combined-json` flag. This is provided for compatibility with older workflows                       |
 
 A global (always loaded) config file is located in `~/.dapprc`. A local `.dapprc` can also be defined in your project's root, which overrides variables in the global config.
 
@@ -531,7 +533,7 @@ Spins up a geth testnet.
 
 ### `dapp verify-contract`
 
-    dapp-verify-contract -- verify contract souce on etherscan
+    dapp-verify-contract -- verify contract source on etherscan
     Usage: dapp verify-contract <path>:<contractname> <address> [constructorArgs]
 
 Requires `ETHERSCAN_API_KEY` to be set.

--- a/src/ethsign/README.md
+++ b/src/ethsign/README.md
@@ -1,6 +1,6 @@
 # Ethsign
 
-Sign Ethereum transactions using a JSON keyfile or hardware wallet.
+Sign Ethereum transactions using a JSON keystore or hardware wallet.
 
 ## Usage
 

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -165,7 +165,11 @@ you do not need to "unlock" your account in Geth or Parity.**
 Seth looks for keys in the standard directories of Geth and Parity.
 To configure a custom location for your key files, use the
 `ETH_KEYSTORE` variable or the `--keystore` flag. The
-`ETH_KEYSTORE` variable should point to a directory containing [JSON keystore wallet files](https://theethereum.wiki/w/index.php/Accounts,_Addresses,_Public_And_Private_Keys,_And_Tokens). Use `seth accounts` or `seth ls` to list out all wallets in the directory.
+`ETH_KEYSTORE` variable should point to a directory containing [JSON keystore wallet files](https://theethereum.wiki/w/index.php/Accounts,_Addresses,_Public_And_Private_Keys,_And_Tokens).
+If you would like to use an existing private key that you do not have a keystore file for,
+you may use [`ethsign import`](https://github.com/dapphub/dapptools/tree/master/src/ethsign).
+
+Use `seth accounts` or `seth ls` to list out all wallets in the directory.
 
 If your key is protected with a password, Seth will prompt you each
 time you make a transaction.  If you are confident in your computer


### PR DESCRIPTION
<img width="485" alt="Screen Shot 2021-07-19 at 9 35 50 AM" src="https://user-images.githubusercontent.com/26209401/126195354-a8996c6c-031a-486b-ad7f-7c1713050bcb.png">

Originally made this PR was to write down how `ethsign import` can be used to generate a keystore file `seth` can ingest, but got a bit carried away and added some more env vars to the `dapp` table and cleaned up some grammar/spelling/casing 😅 