### PR TITLE
dapp/seth: use solc-static for --use

### DIFF
--- a/src/dapp/libexec/dapp/dapp---use
+++ b/src/dapp/libexec/dapp/dapp---use
@@ -51,7 +51,7 @@ if [[ -z "$bin" ]]; then
   echo >&2 "${0##*/}: Could not find ${solc} in your path or nix store."
   echo >&2 "Temporarily installing ${solc}..."
   echo >&2 "Tip: run \`nix-env -f https://github.com/dapphub/dapptools/archive/master.tar.gz -iA solc-static-versions.${solc//[-.]/_}\` for a lasting installation of this version."
-  dapp --nix-run "dapp.override {solc = solc-versions.${solc//[-.]/_};}" dapp "$@"
+  dapp --nix-run "dapp.override {solc = solc-static-versions.${solc//[-.]/_};}" dapp "$@"
 
   exit 1
 else

--- a/src/seth/libexec/seth/seth---use
+++ b/src/seth/libexec/seth/seth---use
@@ -51,7 +51,7 @@ if [[ -z "$bin" ]]; then
   echo >&2 "${0##*/}: Could not find ${solc} in your path or nix store."
   echo >&2 "Temporarily installing ${solc}..."
   echo >&2 "Tip: run \`nix-env -f https://github.com/dapphub/dapptools/archive/master.tar.gz -iA solc-static-versions.${solc//[-.]/_}\` for a lasting installation of this version."
-  seth --nix-run "seth.override {solc = solc-versions.${solc//[-.]/_};}" seth "$@"
+  seth --nix-run "seth.override {solc = solc-static-versions.${solc//[-.]/_};}" seth "$@"
 else
   set -e
   SOLCBIN="$(realpath -e "${bin}")"


### PR DESCRIPTION
i'm not sure if there's a reason we currently use `solc-versions` but trying this out because `solc-versions` is missing most of the modern solc builds that i depend on lol