### PR TITLE
hevm: symexec: verify: differentiate timeouts and success

### DIFF
--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - The configuration variable `DAPP_TEST_BALANCE_CREATE` has been renamed to `DAPP_TEST_BALANCE`
 - Default `smttimeout` has been increased to 1 minute.
+- A new flag has been added to hevm (`--ask-smt-iterations`) that controls the number of iterations
+    at which the symbolic execution engine will stop eager evaluation and begin to query the smt
+    solver whether a given branch is reachable or not.
 
 ## 0.47.0 - 2021-07-01
 

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -516,12 +516,14 @@ assert cmd = do
       preState <- symvmFromCommand cmd
       let errCodes = fromMaybe defaultPanicCodes (assertions cmd)
       verify preState (maxIterations cmd) rpcinfo (Just $ checkAssertions errCodes) >>= \case
-        Right tree -> do
+        Cex tree -> do
           io $ putStrLn "Assertion violation found."
           showCounterexample preState maybesig
           treeShowing tree
           io $ exitWith (ExitFailure 1)
-        Left tree -> do
+        Perhaps -> do
+          io $ exitWith (ExitFailure 1)
+        Qed tree -> do
           io $ putStrLn $ "Explored: " <> show (length tree)
                        <> " branches without assertion violations"
           treeShowing tree

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -431,7 +431,7 @@ equivalence cmd =
                        <> show (length postBs) <> " paths of B."
            putStrLn "No discrepancies found."
          Timeout () -> io $ do
-           putStrLn "Solver timeout!"
+           hPutStr stderr "Solver timeout!"
            exitFailure
 
 -- cvc4 sets timeout via a commandline option instead of smtlib `(set-option)`

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -290,7 +290,7 @@ unitTestOptions cmd testFile = do
          Just url -> EVM.Fetch.oracle (Just state) (Just (block', url)) True
          Nothing  -> EVM.Fetch.oracle (Just state) Nothing True
     , EVM.UnitTest.maxIter = maxIterations cmd
-    , EVM.UnitTest.askSmtIters = askSmtIterationss cmd
+    , EVM.UnitTest.askSmtIters = askSmtIterations cmd
     , EVM.UnitTest.smtTimeout = smttimeout cmd
     , EVM.UnitTest.solver = solver cmd
     , EVM.UnitTest.smtState = Just state

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -315,7 +315,7 @@ main = do
     root = fromMaybe "." (dappRoot cmd)
   case cmd of
     Version {} -> putStrLn (showVersion Paths.version)
-    Symbolic {} -> assert cmd
+    Symbolic {} -> withCurrentDirectory root $ assert cmd
     Equivalence {} -> equivalence cmd
     Exec {} ->
       launchExec cmd

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -185,11 +185,12 @@ data Command w
       , state         :: w ::: Maybe String             <?> "Path to state repository"
       , cache         :: w ::: Maybe String             <?> "Path to rpc cache repository"
       , match         :: w ::: Maybe String             <?> "Test case filter - only run methods matching regex"
-      , smttimeout    :: w ::: Maybe Integer            <?> "Timeout given to SMT solver in milliseconds (default: 60000)"
-      , maxIterations :: w ::: Maybe Integer            <?> "Number of times we may revisit a particular branching point"
       , solver        :: w ::: Maybe Text               <?> "Used SMT solver: z3 (default) or cvc4"
       , smtdebug      :: w ::: Bool                     <?> "Print smt queries sent to the solver"
       , ffi           :: w ::: Bool                     <?> "Allow the usage of the hevm.ffi() cheatcode (WARNING: this allows test authors to execute arbitrary code on your machine)"
+      , smttimeout    :: w ::: Maybe Integer            <?> "Timeout given to SMT solver in milliseconds (default: 60000)"
+      , maxIterations :: w ::: Maybe Integer            <?> "Number of times we may revisit a particular branching point"
+      , askSmtIterations :: w ::: Maybe Integer         <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 5)"
       }
   | BcTest -- Run an Ethereum Blockhain/GeneralState test
       { file      :: w ::: String    <?> "Path to .json test file"

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1621,9 +1621,9 @@ askSMT codeloc (condition, whiff) continue = do
                      condition' (fst <$> pathconds) choosePath
 
    where condition' = simplifyCondition condition whiff
-     -- Only one path is possible
 
          choosePath :: BranchCondition -> EVM ()
+         -- Only one path is possible
          choosePath (Case v) = do assign result Nothing
                                   pushTo constraints $ if v then (condition', whiff) else (sNot condition', IsZero whiff)
                                   iteration <- use (iterations . at codeloc . non 0)

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -63,6 +63,7 @@ ghciTest root path statePath =
         { oracle = EVM.Fetch.zero
         , verbose = Nothing
         , maxIter = Nothing
+        , askSmtIters = Nothing
         , smtTimeout = Nothing
         , smtState = Nothing
         , solver = Nothing
@@ -73,7 +74,7 @@ ghciTest root path statePath =
         , dapp = emptyDapp
         , testParams = params
         , maxDepth = Nothing
-        , allowFFI = False
+        , ffiAllowed = False
         }
     readSolc path >>=
       \case
@@ -122,6 +123,7 @@ ghciTty root path statePath =
         { oracle = EVM.Fetch.zero
         , verbose = Nothing
         , maxIter = Nothing
+        , askSmtIters = Nothing
         , smtTimeout = Nothing
         , smtState = Nothing
         , solver = Nothing
@@ -132,7 +134,7 @@ ghciTty root path statePath =
         , dapp = emptyDapp
         , testParams = params
         , maxDepth = Nothing
-        , allowFFI = False
+        , ffiAllowed = False
         }
     EVM.TTY.main testOpts root path
 

--- a/src/hevm/src/EVM/Emacs.hs
+++ b/src/hevm/src/EVM/Emacs.hs
@@ -505,20 +505,21 @@ defaultUnitTestOptions :: MonadIO m => m UnitTestOptions
 defaultUnitTestOptions = do
   params <- liftIO $ getParametersFromEnvironmentVariables Nothing
   pure UnitTestOptions
-    { oracle            = Fetch.zero
-    , verbose           = Nothing
-    , maxIter           = Nothing
-    , smtTimeout        = Nothing
-    , smtState          = Nothing
-    , solver            = Nothing
-    , match             = ""
-    , fuzzRuns          = 100
-    , replay            = Nothing
-    , vmModifier        = id
-    , dapp              = emptyDapp
-    , testParams        = params
-    , maxDepth          = Nothing
-    , allowFFI          = False
+    { oracle      = Fetch.zero
+    , verbose     = Nothing
+    , maxIter     = Nothing
+    , askSmtIters = Nothing
+    , smtTimeout  = Nothing
+    , smtState    = Nothing
+    , solver      = Nothing
+    , match       = ""
+    , fuzzRuns    = 100
+    , replay      = Nothing
+    , vmModifier  = id
+    , dapp        = emptyDapp
+    , testParams  = params
+    , maxDepth    = Nothing
+    , ffiAllowed  = False
     }
 
 initialStateForTest

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -300,7 +300,7 @@ yul :: Text -> Text -> IO (Maybe ByteString)
 yul contract src = do
   (json, path) <- yul' src
   let (Just f) = json ^?! key "contracts" ^? key path
-      (Just c) = if not (Text.null contract) then f ^? key contract else f ^? key "object"
+      (Just c) = f ^? key $ if Text.null contract then "object" else contract
       bytecode = c ^?! key "evm" ^?! key "bytecode" ^?! key "object" . _String
   pure $ toCode <$> (Just bytecode)
 

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -299,15 +299,17 @@ readSolc fp =
 yul :: Text -> Text -> IO (Maybe ByteString)
 yul contract src = do
   (json, path) <- yul' src
-  let (Just c) = json ^?! key "contracts" ^?! key path ^? key contract
-  let bytecode = c ^?! key "evm" ^?! key "bytecode" ^?! key "object" . _String
+  let (Just f) = json ^?! key "contracts" ^? key path
+      (Just c) = if not (Text.null contract) then f ^? key contract else f ^? key "object"
+      bytecode = c ^?! key "evm" ^?! key "bytecode" ^?! key "object" . _String
   pure $ toCode <$> (Just bytecode)
 
 yulRuntime :: Text -> Text -> IO (Maybe ByteString)
 yulRuntime contract src = do
   (json, path) <- yul' src
-  let (Just c) = json ^?! key "contracts" ^?! key path ^? key contract
-  let bytecode = c ^?! key "evm" ^?! key "deployedBytecode" ^?! key "object" . _String
+  let (Just f) = json ^?! key "contracts" ^? key path
+      (Just c) = if not (Text.null contract) then f ^? key contract else f ^? key "object"
+      bytecode = c ^?! key "evm" ^?! key "deployedBytecode" ^?! key "object" . _String
   pure $ toCode <$> (Just bytecode)
 
 solidity :: Text -> Text -> IO (Maybe ByteString)

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -300,7 +300,7 @@ yul :: Text -> Text -> IO (Maybe ByteString)
 yul contract src = do
   (json, path) <- yul' src
   let (Just f) = json ^?! key "contracts" ^? key path
-      (Just c) = f ^? key $ if Text.null contract then "object" else contract
+      (Just c) = f ^? key (if Text.null contract then "object" else contract)
       bytecode = c ^?! key "evm" ^?! key "bytecode" ^?! key "object" . _String
   pure $ toCode <$> (Just bytecode)
 
@@ -308,7 +308,7 @@ yulRuntime :: Text -> Text -> IO (Maybe ByteString)
 yulRuntime contract src = do
   (json, path) <- yul' src
   let (Just f) = json ^?! key "contracts" ^? key path
-      (Just c) = if not (Text.null contract) then f ^? key contract else f ^? key "object"
+      (Just c) = f ^? key (if Text.null contract then "object" else contract)
       bytecode = c ^?! key "evm" ^?! key "deployedBytecode" ^?! key "object" . _String
   pure $ toCode <$> (Just bytecode)
 

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -360,11 +360,11 @@ verify preState maxIter rpcinfo maybepost = do
   case maybepost of
     (Just post) -> do
       let livePaths = pruneDeadPaths $ leaves tree
-      -- can also do these queries individually (even concurrently!). Could save time and report multiple violations
+          -- have we hit max iterations for any path?
+          maxReached = or $ mapMaybe (flip maxIterationsReached maxIter) livePaths
+          -- is there any path which can possibly violate the postcondition?
+          -- can also do these queries individually (even concurrently!). Could save time and report multiple violations
           postC = sOr $ fmap (\postState -> (sAnd (fst <$> view constraints postState)) .&& sNot (post (preState, postState))) livePaths
-          maxReached = and $ mapMaybe (flip maxIterationsReached maxIter) livePaths
-      -- is there any path which can possibly violate
-      -- the postcondition?
       resetAssertions
       constrain postC
       io $ putStrLn "checking postcondition..."

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -364,7 +364,6 @@ verify preState maxIter askSmtIters rpcinfo maybepost = do
           maxReached p = case maxIter of
             Just maxI -> any (>= (fromInteger maxI)) (view iterations p)
             Nothing -> False
-          --maxReached = or $ mapMaybe (flip maxIterationsReached maxIter) livePaths
           -- is there any path which can possibly violate the postcondition?
           -- can also do these queries individually (even concurrently!). Could save time and report multiple violations
           postC = sOr $ fmap (\postState -> (sAnd (fst <$> view constraints postState)) .&& sNot (post (preState, postState))) livePaths

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -234,20 +234,21 @@ runFromVM maxIter' dappinfo oracle' vm = do
 
   let
     opts = UnitTestOptions
-      { oracle            = oracle'
-      , verbose           = Nothing
-      , maxIter           = maxIter'
-      , smtTimeout        = Nothing
-      , smtState          = Nothing
-      , solver            = Nothing
-      , maxDepth          = Nothing
-      , match             = ""
-      , fuzzRuns          = 1
-      , replay            = error "irrelevant"
-      , vmModifier        = id
-      , testParams        = error "irrelevant"
-      , dapp              = dappinfo
-      , allowFFI          = False
+      { oracle        = oracle'
+      , verbose       = Nothing
+      , maxIter       = maxIter'
+      , askSmtIters   = Nothing
+      , smtTimeout    = Nothing
+      , smtState      = Nothing
+      , solver        = Nothing
+      , maxDepth      = Nothing
+      , match         = ""
+      , fuzzRuns      = 1
+      , replay        = error "irrelevant"
+      , vmModifier    = id
+      , testParams    = error "irrelevant"
+      , dapp          = dappinfo
+      , ffiAllowed    = False
       }
     ui0 = initUiVmState vm opts (void Stepper.execFully)
 

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -214,7 +214,7 @@ main = defaultMain $ testGroup "hevm"
               in case view result poststate of
                 Just (VMSuccess (SymbolicBuffer out)) -> (fromBytes out) .== x + y
                 _ -> sFalse
-        (Left res, _) <- runSMT $ query $ verifyContract safeAdd (Just ("add(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] SymbolicS pre post
+        (Qed res, _) <- runSMT $ query $ verifyContract safeAdd (Just ("add(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] SymbolicS pre post
         putStrLn $ "successfully explored: " <> show (length res) <> " paths"
      ,
 
@@ -236,7 +236,7 @@ main = defaultMain $ testGroup "hevm"
               in case view result poststate of
                       Just (VMSuccess (SymbolicBuffer out)) -> fromBytes out .== 2 * y
                       _ -> sFalse
-        (Left res, _) <- runSMTWith z3 $ query $
+        (Qed res, _) <- runSMTWith z3 $ query $
           verifyContract safeAdd (Just ("add(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] SymbolicS pre (Just post)
         putStrLn $ "successfully explored: " <> show (length res) <> " paths"
       ,
@@ -266,7 +266,7 @@ main = defaultMain $ testGroup "hevm"
               in case view result poststate of
                 Just (VMSuccess _) -> prex + 2 * y .== postx
                 _ -> sFalse
-        (Left res, _) <- runSMT $ query $ verifyContract c (Just ("f(uint256)", [AbiUIntType 256])) [] SymbolicS pre post
+        (Qed res, _) <- runSMT $ query $ verifyContract c (Just ("f(uint256)", [AbiUIntType 256])) [] SymbolicS pre post
         putStrLn $ "successfully explored: " <> show (length res) <> " paths"
         ,
         -- tests how whiffValue handles Neg via application of the triple IsZero simplification rule
@@ -291,7 +291,7 @@ main = defaultMain $ testGroup "hevm"
                     }
                     |]
             Just c <- yulRuntime "Neg" src
-            (Left res, _) <- runSMTWith cvc4 $ query $ checkAssert defaultPanicCodes c (Just ("hello(address)", [AbiAddressType])) []
+            (Qed res, _) <- runSMTWith cvc4 $ query $ checkAssert defaultPanicCodes c (Just ("hello(address)", [AbiAddressType])) []
             putStrLn $ "successfully explored: " <> show (length res) <> " paths"
         ,
 
@@ -324,7 +324,7 @@ main = defaultMain $ testGroup "hevm"
                 Just (VMSuccess _) -> prex + prey .== postx + (posty :: SWord 256)
                 _ -> sFalse
         bs <- runSMT $ query $ do
-          (Right _, vm) <- verifyContract c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] SymbolicS pre (Just post)
+          (Cex _, vm) <- verifyContract c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] SymbolicS pre (Just post)
           case view (state . calldata . _1) vm of
             SymbolicBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
             ConcreteBuffer _ -> error "unexpected"
@@ -351,7 +351,7 @@ main = defaultMain $ testGroup "hevm"
               }
              }
             |]
-          (Left res, _) <- runSMTWith z3 $ query $ checkAssert defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
+          (Qed res, _) <- runSMTWith z3 $ query $ checkAssert defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
           putStrLn $ "successfully explored: " <> show (length res) <> " paths"
         ,
                 testCase "Deposit contract loop (cvc4)" $ do
@@ -373,7 +373,7 @@ main = defaultMain $ testGroup "hevm"
               }
              }
             |]
-          (Left res, _) <- runSMTWith cvc4 $ query $ checkAssert defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
+          (Qed res, _) <- runSMTWith cvc4 $ query $ checkAssert defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
           putStrLn $ "successfully explored: " <> show (length res) <> " paths"
         ,
         testCase "Deposit contract loop (error version)" $ do
@@ -396,7 +396,7 @@ main = defaultMain $ testGroup "hevm"
              }
             |]
           bs <- runSMT $ query $ do
-            (Right _, vm) <- checkAssert allPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) []
+            (Cex _, vm) <- checkAssert allPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) []
             case view (state . calldata . _1) vm of
               SymbolicBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
               ConcreteBuffer _ -> error "unexpected"
@@ -413,7 +413,7 @@ main = defaultMain $ testGroup "hevm"
             }
           }
           |]
-        (Left res, _) <- runSMTWith z3 $ do
+        (Qed res, _) <- runSMTWith z3 $ do
           setTimeOut 5000
           query $ checkAssert defaultPanicCodes c Nothing []
         putStrLn $ "successfully explored: " <> show (length res) <> " paths"
@@ -428,7 +428,7 @@ main = defaultMain $ testGroup "hevm"
               }
             }
             |]
-          (Left res, _) <- runSMTWith cvc4 $ query $ checkAssert defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) []
+          (Qed res, _) <- runSMTWith cvc4 $ query $ checkAssert defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) []
           putStrLn $ "successfully explored: " <> show (length res) <> " paths"
         ,
         testCase "injectivity of keccak (32 bytes)" $ do
@@ -440,7 +440,7 @@ main = defaultMain $ testGroup "hevm"
               }
             }
             |]
-          (Left res, _) <- runSMTWith z3 $ query $ checkAssert defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) []
+          (Qed res, _) <- runSMTWith z3 $ query $ checkAssert defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) []
           putStrLn $ "successfully explored: " <> show (length res) <> " paths"
        ,
 
@@ -454,7 +454,7 @@ main = defaultMain $ testGroup "hevm"
             }
             |]
           bs <- runSMTWith z3 $ query $ do
-            (Right _, vm) <- checkAssert defaultPanicCodes c (Just ("f(uint256,uint256,uint256,uint256)", replicate 4 (AbiUIntType 256))) []
+            (Cex _, vm) <- checkAssert defaultPanicCodes c (Just ("f(uint256,uint256,uint256,uint256)", replicate 4 (AbiUIntType 256))) []
             case view (state . calldata . _1) vm of
               SymbolicBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
               ConcreteBuffer _ -> error "unexpected"
@@ -484,7 +484,7 @@ main = defaultMain $ testGroup "hevm"
               }
             }
             |]
-          Left res <- runSMTWith z3 $ do
+          Qed res <- runSMTWith z3 $ do
             setTimeOut 5000
             query $ fst <$> checkAssert defaultPanicCodes c Nothing []
           putStrLn $ "successfully explored: " <> show (length res) <> " paths"
@@ -503,7 +503,7 @@ main = defaultMain $ testGroup "hevm"
               }
             |]
           -- should find a counterexample
-          Right _ <- runSMTWith cvc4 $ query $ fst <$> checkAssert defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) []
+          Cex _ <- runSMTWith cvc4 $ query $ fst <$> checkAssert defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) []
           putStrLn "found counterexample:"
 
 
@@ -527,7 +527,7 @@ main = defaultMain $ testGroup "hevm"
               aAddr = Addr 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B
           Just c <- solcRuntime "C" code
           Just a <- solcRuntime "A" code
-          Right _ <- runSMT $ query $ do
+          Cex _ <- runSMT $ query $ do
             vm0 <- abstractVM (Just ("call_A()", [])) [] c SymbolicS
             store <- freshArray (show aAddr) Nothing
             let vm = vm0
@@ -556,7 +556,7 @@ main = defaultMain $ testGroup "hevm"
                   }
                 |]
           Just c <- solcRuntime "C" code
-          Right _ <- runSMT $ query $ do
+          Cex _ <- runSMT $ query $ do
             vm0 <- abstractVM (Just ("call_A()", [])) [] c SymbolicS
             let vm = vm0 & set (state . callvalue) 0
             verify vm Nothing Nothing (Just $ checkAssertions defaultPanicCodes)
@@ -575,14 +575,14 @@ main = defaultMain $ testGroup "hevm"
                   }
                 |]
           Just c <- solcRuntime "C" code
-          Left _ <- runSMT $ query $ do
+          Qed _ <- runSMT $ query $ do
             vm0 <- abstractVM (Just ("kecc(uint256)", [AbiUIntType 256])) [] c SymbolicS
             let vm = vm0 & set (state . callvalue) 0
             verify vm Nothing Nothing (Just $ checkAssertions defaultPanicCodes)
           putStrLn "found counterexample:"
 
       , testCase "safemath distributivity (yul)" $ do
-          Left _ <- runSMTWith cvc4 $ query $ do
+          Qed _ <- runSMTWith cvc4 $ query $ do
             let yulsafeDistributivity = hex "6355a79a6260003560e01c14156016576015601f565b5b60006000fd60a1565b603d602d604435600435607c565b6039602435600435607c565b605d565b6052604b604435602435605d565b600435607c565b141515605a57fe5b5b565b6000828201821115151560705760006000fd5b82820190505b92915050565b6000818384048302146000841417151560955760006000fd5b82820290505b92915050565b"
             vm <- abstractVM (Just ("distributivity(uint256,uint256,uint256)", [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) [] yulsafeDistributivity SymbolicS
             verify vm Nothing Nothing (Just $ checkAssertions defaultPanicCodes)
@@ -610,7 +610,7 @@ main = defaultMain $ testGroup "hevm"
                 |]
           Just c <- solcRuntime "C" code
 
-          Left _ <- runSMTWith cvc4 $ query $ do
+          Qed _ <- runSMTWith cvc4 $ query $ do
             vm <- abstractVM (Just ("distributivity(uint256,uint256,uint256)", [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) [] c SymbolicS
             verify vm Nothing Nothing (Just $ checkAssertions defaultPanicCodes)
           putStrLn "Proven"


### PR DESCRIPTION
the result returned from `verify` did not distinguish between a succesful run and a run where the solver timed out on the postcondition query, meaning that users of `verify` would treat a timeout as a success, and resulted in e.g. act printing `Q.E.D` even if the query timed out.