### PR TITLE
fetch contract code, nonce and balance asynchronously

### DIFF
--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - The configuration variable `DAPP_TEST_BALANCE_CREATE` has been renamed to `DAPP_TEST_BALANCE`
 - Default `smttimeout` has been increased to 1 minute.
+- Contract fetching now happens asynchronously.
+- Fixed no contract definition crashes
+- Removed NoSuchContract failures
 
 ## 0.47.0 - 2021-07-01
 

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -81,6 +81,7 @@ library
     ethjet/tinykeccak.h, ethjet/ethjet.h, ethjet/ethjet-ff.h, ethjet/blake2.h
   build-depends:
     QuickCheck                        >= 2.13.2 && < 2.15,
+    async,
     Decimal                           >= 0.5.1 && < 0.6,
     containers                        >= 0.6.0 && < 0.7,
     deepseq                           >= 1.4.4 && < 1.5,

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -81,7 +81,7 @@ library
     ethjet/tinykeccak.h, ethjet/ethjet.h, ethjet/ethjet-ff.h, ethjet/blake2.h
   build-depends:
     QuickCheck                        >= 2.13.2 && < 2.15,
-    async,
+    async                             == 2.2.3,
     Decimal                           >= 0.5.1 && < 0.6,
     containers                        >= 0.6.0 && < 0.7,
     deepseq                           >= 1.4.4 && < 1.5,

--- a/src/hevm/src/EVM/Facts.hs
+++ b/src/hevm/src/EVM/Facts.hs
@@ -47,7 +47,6 @@ import Prelude hiding (Word)
 import Control.Lens    (view, set, at, ix, (&), over, assign)
 import Control.Monad.State.Strict (execState, when)
 import Data.ByteString (ByteString)
-import Data.Monoid     ((<>))
 import Data.Ord        (comparing)
 import Data.Set        (Set)
 import Text.Read       (readMaybe)
@@ -119,7 +118,7 @@ contractFacts a x = case view bytecode x of
     , NonceFact   a (view nonce x)
     , CodeFact    a b
     ]
-  SymbolicBuffer b ->
+  SymbolicBuffer _ ->
     -- here simply ignore storing the bytecode
     storageFacts a x ++
     [ BalanceFact a (view balance x)

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -127,7 +127,7 @@ fetchContractWithSession n url addr sess =
   let
     fetch :: Show a => RpcQuery a -> IO (Maybe a)
     fetch = fetchQuery n (fetchWithSession url sess)
-  in do
+  in
    fetch (QueryAccount addr) >>= \case
      Nothing -> return Nothing
      Just (theCode, theBalance, theNonce) ->

--- a/src/hevm/src/EVM/StorageLayout.hs
+++ b/src/hevm/src/EVM/StorageLayout.hs
@@ -6,7 +6,7 @@ import EVM.Dapp (DappInfo, dappAstSrcMap, dappAstIdMap)
 import EVM.Solidity (SolcContract, creationSrcmap, SlotType(..))
 import EVM.ABI (AbiType (..), parseTypeName)
 
-import Data.Aeson (Value (Number))
+import Data.Aeson (Value (..))
 import Data.Aeson.Lens
 
 import Control.Lens
@@ -43,7 +43,7 @@ storageLayout dapp solc =
   let
     root :: Value
     root =
-      fromMaybe (error "no contract definition AST")
+      fromMaybe Null
         (findContractDefinition dapp solc)
   in
     case preview ( key "attributes"


### PR DESCRIPTION
Not the optimization I set out to make, but this one is quite simple and still provides some marginal improvement.
Fetches account code, balance and nonce concurrently instead of sequentially. This provides around 30% speedup of a single account fetching. Against a larger example (`--match test_reward_wound_fully` of https://github.com/rainbreak/crop), the improvement is less pronounced (~1:52 to 1:50), but for the size of the diff it's maybe worth it still