### PR TITLE
hevm: add env var to control nonce

### DIFF
--- a/nix/build-dapp-package.nix
+++ b/nix/build-dapp-package.nix
@@ -23,8 +23,9 @@ in
   , deps ? []
   , solc ? "${pkgs.solc}/bin/solc"
   , shouldFail ? false
-  , dappFlags ? ""
   , doCheck ? true
+  , dapprc ? ""
+  , testFlags ? ""
   , ... }@args:
     pkgs.stdenv.mkDerivation ( rec {
       inherit doCheck;
@@ -47,6 +48,7 @@ in
           '')
           passthru.libPaths;
       buildPhase = ''
+        source ${pkgs.writeText "dapprc" dapprc}
         mkdir -p out
         export DAPP_SOLC=${solc}
         export DAPP_REMAPPINGS="$REMAPPINGS"
@@ -59,7 +61,7 @@ in
       '';
 
       checkPhase = let
-        cmd = "DAPP_SKIP_BUILD=1 dapp test ${dappFlags}";
+        cmd = "DAPP_SKIP_BUILD=1 dapp test ${testFlags}";
       in
         if shouldFail
           then "${cmd} && exit 1 || echo 0"

--- a/src/dapp-tests/default.nix
+++ b/src/dapp-tests/default.nix
@@ -114,11 +114,10 @@ let
     deps = [ ds-test ds-thing ];
   };
 
-  runTest = { dir, shouldFail, name, dappFlags?"" }: pkgs.buildDappPackage {
-    inherit name shouldFail;
+  runTest = { dir, shouldFail, name, dapprc ? "", testFlags ? "" }: pkgs.buildDappPackage {
+    inherit name shouldFail testFlags dapprc;
     solc=solc-0_6_7;
     src = dir;
-    dappFlags = "${dappFlags}";
     deps = [ ds-test ds-token ds-math ];
     checkInputs = with pkgs; [ hevm jq seth dapp solc ];
   };
@@ -128,7 +127,35 @@ in
       dir = ./pass;
       name = "dappTestsShouldPass";
       shouldFail = false;
-      dappFlags = "--max-iterations 50 --smttimeout 600000 --ffi";
+      testFlags = "--max-iterations 50 --smttimeout 600000 --ffi";
+    };
+
+    envVars = let
+      envVarTest = match : dapprc : runTest {
+        testFlags = "--match ${match}";
+        dir = ./env;
+        name = "dappTestEnvVar";
+        shouldFail = false;
+        inherit dapprc;
+      };
+      seth = "${pkgs.seth}/bin/seth";
+    in pkgs.recurseIntoAttrs {
+      # we get "hevm: insufficient balance for gas cost" if we run these together...
+      origin = envVarTest "origin.sol" "export DAPP_TEST_ORIGIN=$(${seth} --to-hex 256)";
+      rest = envVarTest "rest.sol" ''
+        export DAPP_TEST_BALANCE=$(${seth} --to-wei 998877665544 ether)
+        export DAPP_TEST_ADDRESS=$(${seth} --to-hex 256)
+        export DAPP_TEST_CALLER=$(${seth} --to-hex 100)
+        export DAPP_TEST_GAS_CREATE=$(${seth} --to-wei 4.20 ether)
+        export DAPP_TEST_GAS_CALL=$(${seth} --to-wei 0.69 ether)
+        export DAPP_TEST_NONCE=100
+        export DAPP_TEST_COINBASE=$(${seth} --to-hex 666)
+        export DAPP_TEST_NUMBER=420
+        export DAPP_TEST_TIMESTAMP=69
+        export DAPP_TEST_GAS_LIMIT=$(${seth} --to-wei 4206966 ether)
+        export DAPP_TEST_GAS_PRICE=100
+        export DAPP_TEST_DIFFICULTY=600
+      '';
     };
 
     shouldFail = let
@@ -136,7 +163,7 @@ in
         dir = ./fail;
         shouldFail = true;
         name = "dappTestsShouldFail-${match}";
-        dappFlags = "--match ${match} --smttimeout 600000";
+        testFlags = "--match ${match} --smttimeout 600000";
       };
     in pkgs.recurseIntoAttrs {
       prove-add = fail "prove_add";
@@ -155,7 +182,7 @@ in
       solc = solc-0_6_7;
       src = dss-src;
       name = "dss";
-      dappFlags = "--match '[^dai].t.sol'";
+      testFlags = "--match '[^dai].t.sol'";
       deps = [ ds-test ds-token ds-value ];
     };
   }

--- a/src/dapp-tests/env/origin.sol
+++ b/src/dapp-tests/env/origin.sol
@@ -1,0 +1,8 @@
+import "ds-test/test.sol";
+
+contract Env is DSTest {
+    // DAPP_TEST_ORIGIN
+    function testOrigin() public {
+        assertEq(tx.origin, address(256));
+    }
+}

--- a/src/dapp-tests/env/rest.sol
+++ b/src/dapp-tests/env/rest.sol
@@ -1,0 +1,72 @@
+import "ds-test/test.sol";
+
+contract Env is DSTest {
+    uint creationGas;
+    constructor() public {
+        creationGas = gasleft();
+    }
+
+    // TODO: why does this fail when address == 0?
+    // DAPP_TEST_BALANCE
+    function testBalance() public {
+        assertEq(address(this).balance, 998877665544 ether);
+    }
+    // DAPP_TEST_ADDRESS
+    function testAddress() public {
+        assertEq(address(this), address(256));
+    }
+    // DAPP_TEST_NONCE
+    // we can't test the nonce directly, but can instead check the address of a newly deployed contract
+    function testNonce() public {
+        uint8 nonce = 100;
+        bytes memory payload = abi.encodePacked(hex"d694", address(this), nonce);
+
+        address expected = address(uint160(uint256(keccak256(payload))));
+        address actual = address(new Trivial());
+        assertEq(actual, expected);
+
+    }
+    // DAPP_TEST_CALLER
+    function testCaller() public {
+        assertEq(msg.sender, address(100));
+    }
+    // DAPP_TEST_GAS_CREATE
+    function testGasCreate() public {
+        // we can't be exact since we had to spend some gas to write to storage...
+        assertLt(creationGas, 4.20 ether);
+        assertGt(creationGas, 4.1999999999999 ether);
+    }
+    // DAPP_TEST_GAS_CALL
+    function testGasCall() public {
+        uint gas = gasleft();
+        // we can't be exact since we had to spend some gas to get here...
+        assertLt(gas, 0.69 ether);
+        assertGt(gas, 0.689999999999999 ether);
+    }
+    // DAPP_TEST_COINBASE
+    function testCoinbase() public {
+        assertEq(block.coinbase, address(666));
+    }
+    // DAPP_TEST_NUMBER
+    function testBlockNumber() public {
+        assertEq(block.number, 420);
+    }
+    // DAPP_TEST_TIMESTAMP
+    function testTimestamp() public {
+        assertEq(block.timestamp, 69);
+    }
+    // DAPP_TEST_GAS_LIMIT
+    function testGasLimit() public {
+        assertEq(block.gaslimit, 4206966 ether);
+    }
+    // DAPP_TEST_GAS_PRICE
+    function testGasPrice() public {
+        assertEq(tx.gasprice, 100);
+    }
+    // DAPP_TEST_DIFFICULTY
+    function testDifficulty() public {
+        assertEq(block.difficulty, 600);
+    }
+}
+
+contract Trivial {}

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- A new configuration variable `DAPP_TEST_NONCE` has been added that allows control over the nonce of the testing contract
+
 ### Changed
 
 - The configuration variable `DAPP_TEST_BALANCE_CREATE` has been renamed to `DAPP_TEST_BALANCE`

--- a/src/hevm/README.md
+++ b/src/hevm/README.md
@@ -239,6 +239,7 @@ These environment variables can be used to control block parameters:
 | `DAPP_TEST_GAS_CREATE` | `0xffffffffffff`                             | The gas to provide when creating the testing contract                                                         |
 | `DAPP_TEST_GAS_CALL`   | `0xffffffffffff`                             | The gas to provide to each call made to the testing contract                                                  |
 | `DAPP_TEST_BALANCE`    | `0xffffffffffffffffffffffff`                 | The balance to provide to `DAPP_TEST_ADDRESS`                                                                 |
+| `DAPP_TEST_NONCE  `    | `1`                                          | The initial nonce to use for `DAPP_TEST_ADDRESS`                                                              |
 | `DAPP_TEST_COINBASE`   | `0x0000000000000000000000000000000000000000` | The coinbase address. Will be set to the coinbase for the block at `DAPP_TEST_NUMBER` if rpc is enabled       |
 | `DAPP_TEST_NUMBER`     | `0`                                          | The block number. Will be set to the latest block if rpc is enabled                                           |
 | `DAPP_TEST_TIMESTAMP`  | `0`                                          | The block timestamp. Will be set to the timestamp for the block at `DAPP_TEST_NUMBER` if rpc is enabled       |


### PR DESCRIPTION
- Adds a `DAPP_TEST_NONCE` env var that allows users to control the nonce assigned to the test contract
- Adds unit tests for the various `DAPP_TEST_*` env vars

cc: @kmbarry1 you were asking for this a while back I believe?