### PR TITLE
Fix dapp use

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `dapp --use` now uses the solc binaries from https://binaries.soliditylang.org/ instead of the
+    versions built from source via nix
 - `dapp remappings` now issues a warning instead of failing with a hard error in case of mistmatched
   package versions in the dependency tree
 

--- a/src/dapp/default.nix
+++ b/src/dapp/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Simple tool for creating Ethereum-based dapps";
     homepage = https://github.com/dapphub/dapptools/src/dapp/;
-    maintainers = [stdenv.lib.maintainers.dbrock];
+    maintainers = [lib.maintainers.dbrock];
     license = lib.licenses.gpl3;
     inherit version;
   };

--- a/src/dapp/libexec/dapp/dapp---use
+++ b/src/dapp/libexec/dapp/dapp---use
@@ -51,9 +51,9 @@ if [[ -z "$bin" ]]; then
   echo >&2 "${0##*/}: Could not find ${solc} in your path or nix store."
   echo >&2 "Temporarily installing ${solc}..."
   echo >&2 "Tip: run \`nix-env -f https://github.com/dapphub/dapptools/archive/master.tar.gz -iA solc-static-versions.${solc//[-.]/_}\` for a lasting installation of this version."
-  dapp --nix-run "dapp.override {solc = solc-static-versions.${solc//[-.]/_};}" dapp "$@"
+  dapp --nix-run "dapp.override {solc = pkgs.runCommand \"solc\" { } \"mkdir -p \$out/bin; ln -s \${solc-static-versions.${solc//[-.]/_}}/bin/${solc} \$out/bin/solc\";}" dapp "$@"
 
-  exit 1
+  exit 0
 else
   set -e
   SOLCBIN="$(realpath -e "${bin}")"

--- a/src/dapp/libexec/dapp/dapp-build
+++ b/src/dapp/libexec/dapp/dapp-build
@@ -29,7 +29,7 @@ info() {
 
 cd "$DAPP_ROOT"
 
-# use a custom path is DAPP_SOLC is set
+# use a custom path if DAPP_SOLC is set
 export SOLC=${DAPP_SOLC:-solc}
 
 if [ "$DAPP_LINK_TEST_LIBRARIES" = 1 ]; then

--- a/src/ethsign/default.nix
+++ b/src/ethsign/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoModule }:
+{ stdenv, lib, buildGoModule }:
 
 buildGoModule rec {
   name = "ethsign-${version}";
@@ -9,7 +9,7 @@ buildGoModule rec {
   vendorSha256 = "1p7gkpv88v6swz8dpjvrzfaa2jkpr5xw26bd3rjazv5wcs6ipwy7";
   runVend = true;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://github.com/dapphub/dapptools;
     description = "Make raw signed Ethereum transactions";
     license = [licenses.agpl3];

--- a/src/seth/default.nix
+++ b/src/seth/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Command-line client for talking to Ethereum nodes";
     homepage = https://github.com/dapphub/dapptools/src/seth/;
-    maintainers = [stdenv.lib.maintainers.dbrock];
+    maintainers = [lib.maintainers.dbrock];
     license = lib.licenses.gpl3;
     inherit version;
   };


### PR DESCRIPTION
The solc binaries from `solc-static-versions` have the version as a suffix (e.g. `solc-0.8.6`), meaning that they needed a bit of massaging to use them in `dapp --use`.

Instead of just using the package definition directly, we instead create a tiny wrapper package that renames the version prefixed binary to `solc` on demand.

I also squashed the warnings about `stdenv.lib` as part of this pr.