### PR TITLE
hevm: Colored coverage output

### DIFF
--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -593,8 +593,8 @@ dappCoverage opts _ solcFile =
         let
           dapp = dappInfo "." contractMap sourceCache
           f (k, vs) = do
-            putStr ("\x1b[0m" ++ "----- hevm coverage for ") -- Prefixed with color reset
-            putStrLn (unpack k ++ " -----")
+            putStr ("\x1b[0m" ++ "————— hevm coverage for ") -- Prefixed with color reset
+            putStrLn (unpack k ++ " —————")
             putStrLn ""
             forM_ vs $ \(n, bs) -> do
               case ByteString.find (\x -> x /= 0x9 && x /= 0x20 && x /= 0x7d) bs of

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -593,8 +593,8 @@ dappCoverage opts _ solcFile =
         let
           dapp = dappInfo "." contractMap sourceCache
           f (k, vs) = do
-            putStr ("\x1b[0m" ++ "hevm coverage for ") -- Prefixed with color reset
-            putStrLn (unpack k)
+            putStr ("\x1b[0m" ++ "----- hevm coverage for ") -- Prefixed with color reset
+            putStrLn (unpack k ++ " -----")
             putStrLn ""
             forM_ vs $ \(n, bs) -> do
               case ByteString.find (\x -> x /= 0x9 && x /= 0x20 && x /= 0x7d) bs of

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -598,10 +598,10 @@ dappCoverage opts _ solcFile =
             putStrLn ""
             forM_ vs $ \(n, bs) -> do
               case ByteString.find (\x -> x /= 0x9 && x /= 0x20 && x /= 0x7d) bs of
-                Nothing -> putStr "\x1b[33m" -- Yellow (Coverage status isn't relevant)
+                Nothing -> putStr "\x1b[38;5;240m" -- Gray (Coverage status isn't relevant)
                 Just _ ->
                   case n of
-                    -1 -> putStr "\x1b[33m" -- Yellow (Coverage status isn't relevant)
+                    -1 -> putStr "\x1b[38;5;240m" -- Gray (Coverage status isn't relevant)
                     0  -> putStr "\x1b[31m" -- Red (Uncovered)
                     _  -> putStr "\x1b[32m" -- Green (Covered)
               Char8.putStrLn bs

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -593,17 +593,17 @@ dappCoverage opts _ solcFile =
         let
           dapp = dappInfo "." contractMap sourceCache
           f (k, vs) = do
-            putStr "***** hevm coverage for "
+            putStr ("\x1b[0m" ++ "hevm coverage for ") -- Prefixed with color reset
             putStrLn (unpack k)
             putStrLn ""
             forM_ vs $ \(n, bs) -> do
               case ByteString.find (\x -> x /= 0x9 && x /= 0x20 && x /= 0x7d) bs of
-                Nothing -> putStr "..... "
+                Nothing -> putStr "\x1b[33m" -- Yellow (Coverage status isn't relevant)
                 Just _ ->
                   case n of
-                    -1 -> putStr ";;;;; "
-                    0  -> putStr "##### "
-                    _  -> putStr "      "
+                    -1 -> putStr "\x1b[33m" -- Yellow (Coverage status isn't relevant)
+                    0  -> putStr "\x1b[31m" -- Red (Uncovered)
+                    _  -> putStr "\x1b[32m" -- Green (Covered)
               Char8.putStrLn bs
             putStrLn ""
 


### PR DESCRIPTION
replaces the confusing symbols of `hevm --coverage` with pretty terminal colors

<img width="641" alt="Screen Shot 2021-08-10 at 1 42 58 PM" src="https://user-images.githubusercontent.com/26209401/128932253-402fd5d1-9b0c-4e1d-8665-822b84eee3a4.png">

