### PR TITLE
`seth`: add ENS support

### DIFF
--- a/src/dapp-tests/integration/tests.sh
+++ b/src/dapp-tests/integration/tests.sh
@@ -294,9 +294,9 @@ test_hexdata_3() {
 test_hexdata_3
 
 # SETH ENS TESTS
-# Tests for resolve-name and lookup-address may break in the future as they are dependent on mainnet state
+# Tests for resolve-name and lookup-address use a Rinkeby name that's been registered for 100 years and will not be changed
 # Infura ID source: https://github.com/ethers-io/ethers.js/blob/0d40156fcba5be155aa5def71bcdb95b9c11d889/packages/providers/src.ts/infura-provider.ts#L17
-ETH_RPC_URL=https://mainnet.infura.io/v3/84842078b09946638c03157f83405213
+ETH_RPC_URL=https://rinkeby.infura.io/v3/84842078b09946638c03157f83405213
 
 test_namehash_1() {
     local output
@@ -321,8 +321,8 @@ test_namehash_3
 
 test_namehash_4() {
     local output
-    output=$(seth namehash ricmoo.xyz)
-    [[ $output = "0x7d56aa46358ba2f8b77d8e05bcabdd2358370dcf34e87810f8cea77ecb3fc57d" ]] || error
+    output=$(seth namehash seth-test.eth)
+    [[ $output = "0xc639cb4715c456d2cc8523ee5568222dbae3551e2a42c61a7da4db3ec28ab9e9" ]] || error
 }
 test_namehash_4
 
@@ -336,29 +336,34 @@ test_namehash_6() {
 }
 test_namehash_6
 
+test_namehash_7() {
+    [[ $(seth namehash seth-test.eth) = $(seth namehash sEtH-tESt.etH) ]] || error
+}
+test_namehash_7
+
 test-resolve-name1() {
     # using example from ethers docs: https://docs.ethers.io/v5/single-page/#/v5/api/providers/provider/-%23-Provider-ResolveName
     local output
-    output=$(seth resolve-name ricmoo.eth --rpc-url=$ETH_RPC_URL)
-    [[ $output = "0x5555763613a12D8F3e73be831DFf8598089d3dCa" ]] || error
+    output=$(seth resolve-name seth-test.eth --rpc-url=$ETH_RPC_URL)
+    [[ $output = "0x49c92F2cE8F876b070b114a6B2F8A60b83c281Ad" ]] || error
 }
 test-resolve-name1
 
 test-resolve-name2() {
-    [[ $(seth resolve-name ricmoo.eth --rpc-url=$ETH_RPC_URL) = $(seth resolve-name rICmOO.etH --rpc-url=$ETH_RPC_URL) ]] || error
+    [[ $(seth resolve-name seth-test.eth --rpc-url=$ETH_RPC_URL) = $(seth resolve-name sEtH-tESt.etH --rpc-url=$ETH_RPC_URL) ]] || error
 }
 test-resolve-name2
 
 test-lookup-address1() {
     # using example from ethers docs: https://docs.ethers.io/v5/single-page/#/v5/api/providers/provider/-%23-Provider-lookupAddress
     local output
-    output=$(seth lookup-address 0x5555763613a12D8F3e73be831DFf8598089d3dCa --rpc-url=$ETH_RPC_URL)
-    [[ $output = "ricmoo.eth" ]] || error
+    output=$(seth lookup-address 0x49c92F2cE8F876b070b114a6B2F8A60b83c281Ad --rpc-url=$ETH_RPC_URL)
+    [[ $output = "seth-test.eth" ]] || error
 }
 test-lookup-address1
 
 test-lookup-address2() {
-    [[ $(seth lookup-address 0x5555763613a12D8F3e73be831DFf8598089d3dCa --rpc-url=$ETH_RPC_URL) \
-     = $(seth lookup-address 0x5555763613a12d8f3e73be831dff8598089d3dca --rpc-url=$ETH_RPC_URL) ]] || error
+    [[ $(seth lookup-address 0x49c92F2cE8F876b070b114a6B2F8A60b83c281Ad --rpc-url=$ETH_RPC_URL) \
+     = $(seth lookup-address 0x49c92f2ce8f876b070b114a6b2f8a60b83c281ad --rpc-url=$ETH_RPC_URL) ]] || error
 }
 test-lookup-address2

--- a/src/dapp-tests/integration/tests.sh
+++ b/src/dapp-tests/integration/tests.sh
@@ -292,3 +292,73 @@ test_hexdata_3() {
   [[ $(seth --to-hexdata 0xCA:0xfe:0x) = "0xcafe" ]] || error
 }
 test_hexdata_3
+
+# SETH ENS TESTS
+# Tests for resolve-name and lookup-address may break in the future as they are dependent on mainnet state
+# Infura ID source: https://github.com/ethers-io/ethers.js/blob/0d40156fcba5be155aa5def71bcdb95b9c11d889/packages/providers/src.ts/infura-provider.ts#L17
+ETH_RPC_URL=https://mainnet.infura.io/v3/84842078b09946638c03157f83405213
+
+test_namehash_1() {
+    local output
+    output=$(seth namehash)
+    [[ $output = "0x0000000000000000000000000000000000000000000000000000000000000000" ]] || error
+}
+test_namehash_1
+
+test_namehash_2() {
+    local output
+    output=$(seth namehash eth)
+    [[ $output = "0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae" ]] || error
+}
+test_namehash_2
+
+test_namehash_3() {
+    local output
+    output=$(seth namehash ricmoo.firefly.eth)
+    [[ $output = "0x0bcad17ecf260d6506c6b97768bdc2acfb6694445d27ffd3f9c1cfbee4a9bd6d" ]] || error
+}
+test_namehash_3
+
+test_namehash_4() {
+    local output
+    output=$(seth namehash ricmoo.xyz)
+    [[ $output = "0x7d56aa46358ba2f8b77d8e05bcabdd2358370dcf34e87810f8cea77ecb3fc57d" ]] || error
+}
+test_namehash_4
+
+test_namehash_5() {
+    [[ $(seth namehash eth) = $(seth namehash ETH) ]] || error
+}
+test_namehash_5
+
+test_namehash_6() {
+    [[ $(seth namehash ricmoo.firefly.eth) = $(seth namehash RicMOO.FireFly.eTH) ]] || error
+}
+test_namehash_6
+
+test-resolve-name1() {
+    # using example from ethers docs: https://docs.ethers.io/v5/single-page/#/v5/api/providers/provider/-%23-Provider-ResolveName
+    local output
+    output=$(seth resolve-name ricmoo.eth --rpc-url=$ETH_RPC_URL)
+    [[ $output = "0x5555763613a12D8F3e73be831DFf8598089d3dCa" ]] || error
+}
+test-resolve-name1
+
+test-resolve-name2() {
+    [[ $(seth resolve-name ricmoo.eth --rpc-url=$ETH_RPC_URL) = $(seth resolve-name rICmOO.etH --rpc-url=$ETH_RPC_URL) ]] || error
+}
+test-resolve-name2
+
+test-lookup-address1() {
+    # using example from ethers docs: https://docs.ethers.io/v5/single-page/#/v5/api/providers/provider/-%23-Provider-lookupAddress
+    local output
+    output=$(seth lookup-address 0x5555763613a12D8F3e73be831DFf8598089d3dCa --rpc-url=$ETH_RPC_URL)
+    [[ $output = "ricmoo.eth" ]] || error
+}
+test-lookup-address1
+
+test-lookup-address2() {
+    [[ $(seth lookup-address 0x5555763613a12D8F3e73be831DFf8598089d3dCa --rpc-url=$ETH_RPC_URL) \
+     = $(seth lookup-address 0x5555763613a12d8f3e73be831dff8598089d3dca --rpc-url=$ETH_RPC_URL) ]] || error
+}
+test-lookup-address2

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -94,6 +94,7 @@ hardware wallets—even if you use a remote RPC node like Infura's.
   - [`seth nonce`]
   - [`seth publish`]
   - [`seth receipt`]
+  - [`seth resolve-name`]
   - [`seth run-tx`]
   - [`seth send`]
   - [`seth sign`]
@@ -697,6 +698,14 @@ is specified.
 Unless `--async` is given, wait indefinitely for the receipt
 to appear.
 
+### `seth resolve-name`
+
+Print the address the provided ENS name resolves to. If the name is not
+owned or does not have a resolver configured, an `invalid data for function output`
+error will be thrown.
+
+    seth resolve-name <name>
+
 ### `seth run-tx`
 
 Execute a transaction using `hevm`.
@@ -815,6 +824,7 @@ Show all fields unless `<field>` is given.
 [`seth nonce`]: #seth-nonce
 [`seth publish`]: #seth-publish
 [`seth receipt`]: #seth-receipt
+[`seth resolve-name`]: #seth-resolve-name
 [`seth run-tx`]: #seth-run-tx
 [`seth send`]: #seth-send
 [`seth sign`]: #seth-sign

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -88,6 +88,7 @@ hardware wallets—even if you use a remote RPC node like Infura's.
   - [`seth help`]
   - [`seth keccak`]
   - [`seth logs`]
+  - [`seth lookup-address`]
   - [`seth ls`]
   - [`seth mktx`]
   - [`seth namehash`]
@@ -647,6 +648,15 @@ With `--follow`, the command blocks waiting for new events
 See also [`seth events`] which decodes logs using an
 ABI specification.
 
+### `seth lookup-address`
+
+Print the address the provided ENS name resolves to. If the name is not
+owned or does not have a resolver configured, an `invalid data for
+function output` error will be thrown. An error will also be thrown
+if the forward and reverse resolution do not match.
+
+    seth lookup-address <address>
+
 ### `seth ls`
 
 Display a list of your accounts and their ether balances.
@@ -817,7 +827,7 @@ Show all fields unless `<field>` is given.
 [`seth help`]: #seth-help
 [`seth keccak`]: #seth-keccak
 [`seth logs`]: #seth-logs
-[`seth ls`]: #seth-ls
+[`seth lookup-address`]: #seth-lookup-address
 [`seth ls`]: #seth-ls
 [`seth mktx`]: #seth-mktx
 [`seth namehash`]: #seth-namehash

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -90,6 +90,7 @@ hardware wallets—even if you use a remote RPC node like Infura's.
   - [`seth logs`]
   - [`seth ls`]
   - [`seth mktx`]
+  - [`seth namehash`]
   - [`seth nonce`]
   - [`seth publish`]
   - [`seth receipt`]
@@ -663,6 +664,12 @@ Options are as for [`seth send`] but no transaction is published.
 
 See also [`seth publish`] for publishing a signed transaction.
 
+### `seth namehash`
+
+Print the ENS namehash of the provided name.
+
+    seth namehash <name>
+
 ### `seth nonce`
 
 Show the number of transactions successfully sent from an address (its
@@ -804,6 +811,7 @@ Show all fields unless `<field>` is given.
 [`seth ls`]: #seth-ls
 [`seth ls`]: #seth-ls
 [`seth mktx`]: #seth-mktx
+[`seth namehash`]: #seth-namehash
 [`seth nonce`]: #seth-nonce
 [`seth publish`]: #seth-publish
 [`seth receipt`]: #seth-receipt

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -681,6 +681,10 @@ Print the ENS namehash of the provided name.
 
     seth namehash <name>
 
+ENS names are converted to lowercase before hashing, but note this is
+not the complete [normalization process](https://docs.ens.domains/contract-api-reference/name-processing#normalising-names),
+so users must ensure the ENS names they enter are properly formatted.
+
 ### `seth nonce`
 
 Show the number of transactions successfully sent from an address (its
@@ -715,6 +719,10 @@ owned or does not have a resolver configured, an `invalid data for function outp
 error will be thrown.
 
     seth resolve-name <name>
+
+ENS names are converted to lowercase before hashing, but note this is
+not the complete [normalization process](https://docs.ens.domains/contract-api-reference/name-processing#normalising-names),
+so users must ensure the ENS names they enter are properly formatted.
 
 ### `seth run-tx`
 

--- a/src/seth/libexec/seth/seth-lookup-address
+++ b/src/seth/libexec/seth/seth-lookup-address
@@ -23,7 +23,7 @@ namein=$(echo $addressin.addr.reverse | cut -c3-)
 namehash=0x$(seth namehash $namein | cut -c3-)
 
 # get name from the resolver
-ENS_REGISTRY=0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e # same on all supported networks
+ENS_REGISTRY=${SETH_ENS_REGISTRY:-'0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'} # same on all supported networks
 resolver=$(seth call $ENS_REGISTRY "resolver(bytes32)(address)" $namehash)
 name=$(seth call $resolver "name(bytes32)(string)" $namehash)
 

--- a/src/seth/libexec/seth/seth-lookup-address
+++ b/src/seth/libexec/seth/seth-lookup-address
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+### seth-resolve-name -- returns the address the provided ENS name resolves to
+### Usage: seth resolve-name <name>
+###
+### Print the address the provided ENS name resolves to. If the name is not
+### owned or does not have a resolver configured, an `invalid data for
+### function output` error will be thrown. An error will also be thrown
+### if the forward and reverse resolution do not match 
+
+set -e
+shopt -s extglob
+[[ $# -lt 2 ]] || seth --fail-usage "$0"
+
+# verify chain ID
+chainid=$(seth chain-id)
+if [[ $chainid != @(1|3|4|5) ]]; then
+  seth --fail "${0##*/}: error: using chain ID $chainid, but ENS lookups are only supported for chain IDs 1, 3, 4, and 5"
+fi
+
+# get namehash for <address>.addr.reverse
+addressin=$(seth --to-hexdata $1) # make address lowercase
+namein=$(echo $addressin.addr.reverse | cut -c3-)
+namehash=0x$(seth namehash $namein | cut -c3-)
+
+# get name from the resolver
+ENS_REGISTRY=0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e # same on all supported networks
+resolver=$(seth call $ENS_REGISTRY "resolver(bytes32)(address)" $namehash)
+name=$(seth call $resolver "name(bytes32)(string)" $namehash)
+
+# check the reverse direction and make sure the addresses match
+address=$(seth resolve-name $name)
+if [[ $(seth --to-hexdata $address) != $addressin ]]; then
+  seth --fail "${0##*/}: error: forward resolution of the found ENS name $name did not match"
+fi
+
+# success
+echo $name

--- a/src/seth/libexec/seth/seth-namehash
+++ b/src/seth/libexec/seth/seth-namehash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+### seth-namehash -- returns the ENS namehash of the provided name
+### Usage: seth namehash <name>
+###
+### Print the ENS namehash of the provided name
+
+set -e
+[[ $# -lt 2 ]] || seth --fail-usage "$0"
+
+# ENS namehash process is defined at https://docs.ens.domains/contract-api-reference/name-processing#hashing-names
+namehash() {
+  if [[ $# == 0 ]]; then
+    seth --to-bytes32 0
+  else
+    seth keccak $(namehash "${@:2}")$(seth keccak "$1" | cut -c3-)
+  fi
+}
+
+namelower=$(echo $1 | tr "[:upper:]" "[:lower:]") # to lowercase
+name=${namelower//./ } # convert input from period delimited to space delimited
+namehash=$(namehash $name)
+echo $namehash

--- a/src/seth/libexec/seth/seth-resolve-name
+++ b/src/seth/libexec/seth/seth-resolve-name
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+### seth-resolve-name -- returns the address the provided ENS name resolves to
+### Usage: seth resolve-name <name>
+###
+### Print the address the provided ENS name resolves to. If the name is not
+### owned or does not have a resolver configured, an `invalid data for
+### function output` error will be thrown
+
+set -e
+shopt -s extglob
+[[ $# -lt 2 ]] || seth --fail-usage "$0"
+
+# verify chain ID
+chainid=$(seth chain-id)
+if [[ $chainid != @(1|3|4|5) ]]; then
+  seth --fail "${0##*/}: error: using chain ID $chainid, but ENS lookups are only supported for chain IDs 1, 3, 4, and 5"
+fi
+
+# get namehash
+namehash=$(seth namehash $1)
+
+# resolve name
+ENS_REGISTRY=0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e # same on all supported networks
+resolver=$(seth call $ENS_REGISTRY "resolver(bytes32)(address)" $namehash)
+address=$(seth call $resolver "addr(bytes32)(address)" $namehash)
+echo $address

--- a/src/seth/libexec/seth/seth-resolve-name
+++ b/src/seth/libexec/seth/seth-resolve-name
@@ -20,7 +20,7 @@ fi
 namehash=$(seth namehash $1)
 
 # resolve name
-ENS_REGISTRY=0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e # same on all supported networks
+ENS_REGISTRY=${SETH_ENS_REGISTRY:-'0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'} # same on all supported networks
 resolver=$(seth call $ENS_REGISTRY "resolver(bytes32)(address)" $namehash)
 address=$(seth call $resolver "addr(bytes32)(address)" $namehash)
 echo $address


### PR DESCRIPTION
Adds the following:
- `seth namehash <name>` to get the ENS namehash of a name
- `seth resolve-name <name>` to resolve an ENS name to an address
- `seth lookup-address <address>` to lookup the ENS name an address reverse resolves to

Also adds tests for the ENS methods which are required to run against a forked mainnet. These may break in the future if the resolution for those names changes. To simplify things, I hardcoded a mainnet RPC URL using the same community provided Infura endpoint that ethers uses, but I'm open to other suggestions here

ENS names are converted to lowercase before hashing, but note this is not the complete [normalization process](https://docs.ens.domains/contract-api-reference/name-processing#normalising-names), so users must ensure the ENS names they enter are properly formatted

h/t @livnev for some bash ENS snippets