### PR TITLE
Update seth---send-params for 1559

### DIFF
--- a/src/seth/libexec/seth/seth---send-params
+++ b/src/seth/libexec/seth/seth---send-params
@@ -19,6 +19,12 @@ param() {
 
 param ETH_FROM       from      --address
 param ETH_GAS        gas
-param ETH_GAS_PRICE  gasPrice  --wei
 param ETH_NONCE      nonce
 param ETH_VALUE      value     --wei
+
+if [[ $ETH_PRIO_FEE ]]; then
+  param ETH_GAS_PRICE  maxFeePerGas  --wei
+  param ETH_PRIO_FEE   maxPriorityFeePerGas --wei
+else
+  param ETH_GAS_PRICE  gasPrice  --wei
+fi


### PR DESCRIPTION
This follows a similar pattern as with `seth-mktx` and `seth-publish` but for transactions sent directly to the node using the rpc call `eth_sendTransaction`.

If priority fee is set, it will create a type 0x02 transaction and will use it as `maxPriorityFeePerGas` and use `gasPrice` as `maxFeePerGas`. If no priority fee is set, it will create a legacy type 0x00 transaction.