### PR TITLE
ci: fixed macos artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,17 @@ jobs:
       - uses: actions/download-artifact@master
         with:
           name: hevm-macOS
-          path: hevm-macOS.tar.gz
+          path: hevm-macOS
+
+      - name: Rename macOS artifact
+        run: |
+          mv ./hevm-macOS/hevm.tar.gz ./hevm-macOS/hevm-macOS.tar.gz
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             ./hevmLinux/bin/hevm
-            hevm-macOS.tar.gz
+            ./hevm-macOS/hevm-macOS.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes the path of the `macOS-hevm.tar.gz` to correctly include it in the releases.

The Github action for the macOS `hevm` binary is currently not working.

```
// https://github.com/dapphub/dapptools/runs/3255462191
🤔 Pattern 'hevm-macOS.tar.gz' does not match any files.
```

Example pipeline: https://github.com/bernard-wagner/dapptools/actions/runs/1189824034

