### PR TITLE
dapp: Remove verify contract prefix

### DIFF
--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -97,13 +97,6 @@ params=(
 
 source=$(hevm flatten --source-file "$file" --json-file "$DAPP_JSON" --dapp-root "$DAPP_ROOT")
 
-source=$(cat <<.
-// Verified using https://dapp.tools
-
-$source
-.
-)
-
 query=$(printf "&%s" "${params[@]}")
 
 count=0


### PR DESCRIPTION
no pressure to merge this, but I propose removing because verified contracts are already littered with comments indicating the files were flattened with hevm, makes this feel redundant along with taking up extra space