### PR TITLE
fix: do not set the `gas` field when estimating gas

### DIFF
--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `--use` bug
 - `seth bundle-source` writes the contents of standard-json to the current directory to enable better sourcemaps for multi-file etherscan source code.
-- `seth estimate` now properly calculates the gas limit for transactions which may require >4m gas
+- `seth estimate` no longer sets a gas limit when estimating gas
 
 ## [0.10.1] - 2021-03-22
 

--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `--use` bug
 - `seth bundle-source` writes the contents of standard-json to the current directory to enable better sourcemaps for multi-file etherscan source code.
+- `seth estimate` now properly calculates the gas limit for transactions which may require >4m gas
 
 ## [0.10.1] - 2021-03-22
 

--- a/src/seth/libexec/seth/seth---send-params
+++ b/src/seth/libexec/seth/seth---send-params
@@ -18,9 +18,14 @@ param() {
 }
 
 param ETH_FROM       from      --address
-param ETH_GAS        gas
 param ETH_NONCE      nonce
 param ETH_VALUE      value     --wei
+
+# skip setting ETH_GAS if the NO_GAS var is provided, useful e.g. when
+# doing gas estimation since the gas field should be empty
+if [[ -z $NO_GAS ]]; then
+    param ETH_GAS        gas
+fi
 
 if [[ $ETH_PRIO_FEE ]]; then
   param ETH_GAS_PRICE  maxFeePerGas  --wei

--- a/src/seth/libexec/seth/seth---send-params
+++ b/src/seth/libexec/seth/seth---send-params
@@ -23,7 +23,7 @@ param ETH_VALUE      value     --wei
 
 # skip setting ETH_GAS if the NO_GAS var is provided, useful e.g. when
 # doing gas estimation since the gas field should be empty
-if [[ -z $NO_GAS ]]; then
+if [[ -z $SETH_PARAMS_NO_GAS ]]; then
     param ETH_GAS        gas
 fi
 

--- a/src/seth/libexec/seth/seth-estimate
+++ b/src/seth/libexec/seth/seth-estimate
@@ -33,7 +33,7 @@ jshon+=(-n {})
 [[ $TO ]] && jshon+=(-s "$TO" -i to)
 jshon+=(-s "$DATA" -i data)
 # shellcheck disable=SC2207
-jshon+=($(seth --send-params))
+jshon+=($(NO_GAS=1 seth --send-params))
 jshon+=(-i append)
 [[ $ETH_BLOCK = [0-9]* ]] && ETH_BLOCK=$(seth --to-hex "$ETH_BLOCK")
 : "${ETH_BLOCK:=latest}" # geth doesn't like this argument

--- a/src/seth/libexec/seth/seth-estimate
+++ b/src/seth/libexec/seth/seth-estimate
@@ -33,7 +33,7 @@ jshon+=(-n {})
 [[ $TO ]] && jshon+=(-s "$TO" -i to)
 jshon+=(-s "$DATA" -i data)
 # shellcheck disable=SC2207
-jshon+=($(NO_GAS=1 seth --send-params))
+jshon+=($(SETH_PARAMS_NO_GAS=1 seth --send-params))
 jshon+=(-i append)
 [[ $ETH_BLOCK = [0-9]* ]] && ETH_BLOCK=$(seth --to-hex "$ETH_BLOCK")
 : "${ETH_BLOCK:=latest}" # geth doesn't like this argument


### PR DESCRIPTION
Fixes #765 

When estimating gas, provide the `NO_GAS` flag to `seth --send-params` so that the `gas` field is not populated, and we can let the node do gas estimation for us.