### PR TITLE
feat: expand sign and send cases

### DIFF
--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `seth resolve-name <name>` to resolve an ENS name to an address
 - `seth lookup-address <address>` to lookup the ENS name an address reverse resolves to
 - Dynamic transaction fee format transactions (EIP-1559) supported by introducing the flag `--prio-fee` and corresponding environment variable `ETH_PRIO_FEE` to seth and ethsign. If `--prio-fee` is provided (or `ETH_PRIO_FEE`) is set, 1559 transaction will be used and `--gas-price` will reflect the maximum gas price, rather than the absolute gas price.
+- If `ETH_RPC_ACCOUNTS` is set and the account corresponding to `ETH_FROM` exists in the keystore,
+Seth will sign the transaction locally and then publish it signed (previously it'd always send it to the node)
 
 ### Changed
 

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -189,6 +189,10 @@ the `ETH_RPC_ACCOUNTS` variable or use the `--rpc-accounts` flag.
 This probably means you need to use Geth's or Parity's account
 management tools to "unlock" your account.
 
+If both `ETH_RPC_ACCOUNTS` and `ETH_FROM` are set, Seth will first check if the
+provided account is in the keystore and only use the RPC node's signer if the
+account does not exist.
+
 Note: Seth uses the [`ethsign`] tool for signing transactions.
 This tool uses Geth as a library.
 

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -189,10 +189,9 @@ the `ETH_RPC_ACCOUNTS` variable or use the `--rpc-accounts` flag.
 This probably means you need to use Geth's or Parity's account
 management tools to "unlock" your account.
 
-If both `ETH_RPC_ACCOUNTS` and `ETH_FROM` are set, Seth will first check if the
-provided account is in the keystore and only use the RPC node's signer if the
-account does not exist.
-
+If both `ETH_RPC_ACCOUNTS` and `ETH_FROM` are set, `seth` will first check if the
+provided account can be found in the keystore, or in any connected hardware
+wallet, and only use the RPC node's signer if the account does not exist.
 Note: Seth uses the [`ethsign`] tool for signing transactions.
 This tool uses Geth as a library.
 

--- a/src/seth/libexec/seth/seth-send
+++ b/src/seth/libexec/seth/seth-send
@@ -51,9 +51,15 @@ jshon+=(-n {})
 jshon+=($(seth --send-params))
 jshon+=(-i append)
 
-if [[ -z $ETH_RPC_ACCOUNTS ]]; then
+function signAndSend() {
   tx=$(seth mktx "$TO" "$DATA")
   tx=$(seth publish "$tx")
+}
+
+if [[ -z $ETH_RPC_ACCOUNTS ]]; then
+  signAndSend
+elif ethsign ls | grep -q $ETH_FROM; then
+  signAndSend
 else
   tx=$(seth rpc eth_sendTransaction -- "${jshon[@]}")
 fi


### PR DESCRIPTION
Previously, if ETH_RPC_ACCOUNTS was set, seth-send would always use the node's
accounts as its signers. Now, even if it's set, it'll first check if the specified
ETH_FROM is in the keystore, and use it if so.