### PR TITLE
feat: allow specifing version to `dapp install` url

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DAPP_TEST_DEPTH` env var to control `--depth`
 - `--coverage` flag for `dapp test` to generate coverage via hevm
 - `dapp debug` respects the `DAPP_LINK_TEST_LIBRARIES` environment variable.
+- `dapp install` accepts URLs with git tags, branches or revs specified as `<url>@<tag>`
 
 ### Changed
 

--- a/src/dapp/README.md
+++ b/src/dapp/README.md
@@ -523,6 +523,10 @@ for key bindings for navigation.
     - the URL of a Dapphub repo (https://github.com/dapphub/ds-foo)
     - a path to a repo in another Github org (org-name/repo-name)
 
+You can also specify a version (or branch / commit hash) for the repository by
+suffixing the URL with `@<version>`. `dapp install` will then proceed to
+clone the repository and then `git checkout --recurse-submodules $version`.
+
 If the project you want to install does not follow the typical `dapp` project structure,
 you may need to configure the `DAPP_REMAPPINGS` environment variable to be able to find
 it. For an example, see [this repo](https://github.com/dapp-org/radicle-contracts-tests/).

--- a/src/dapp/libexec/dapp/dapp---parse-deps
+++ b/src/dapp/libexec/dapp/dapp---parse-deps
@@ -8,8 +8,8 @@ for x; do
   if [[ ${x:?} =~ ^[^/]+/([^/]+)$ ]]; then
     echo "$x" "${BASH_REMATCH[1]}" "https://github.com/$x"
   # matches strings like foo@bar, foo:bar or /foo/bar
-  elif [[ $x =~ .*[@:/](.*) ]]; then
-    name=${BASH_REMATCH[1]%.*}
+  elif [[ $x =~ .*[:/](.*) ]]; then
+    name=${BASH_REMATCH[1]}
     echo "$x" "${name:?}" "$x"
   else
     echo "$x" "$x" "https://github.com/dapphub/$x"

--- a/src/dapp/libexec/dapp/dapp-install
+++ b/src/dapp/libexec/dapp/dapp-install
@@ -28,7 +28,7 @@ while read -r unparsed name url; do
   if [ "$tag" ]; then
     # checkout the tag
     (set -x; cd "lib/$name" && git checkout --recurse-submodules "$tag" && cd -)
-    git add lib/
+    git add "lib/$name"
   fi
   (set -x; git commit -m "dapp install $unparsed")
 done <<<"$deps"

--- a/src/dapp/libexec/dapp/dapp-install
+++ b/src/dapp/libexec/dapp/dapp-install
@@ -31,7 +31,7 @@ while read -r unparsed name url; do
     # edit the .gitmodules file to note the version tag. we do
     # this just for introspection reasons (inspecting your dep versions),
     # and it provides no actual functionality
-    git config -f .gitmodules submodule.lib/$name.version $tag
+    git config -f .gitmodules submodule.lib/"$name".version "$tag"
     git add .gitmodules
   fi
   (set -x; git commit -m "dapp install $unparsed")

--- a/src/dapp/libexec/dapp/dapp-install
+++ b/src/dapp/libexec/dapp/dapp-install
@@ -13,8 +13,19 @@ if [[ -z "$deps" ]]; then
   dapp help install
   exit
 fi
+
 while read -r unparsed name url; do
-  (set -x; git submodule add --force "$url" "lib/$name")
+  # get the tag/branch/rev from the repo name if it's specified after the URL with
+  # an '@' delimiter.
+  IFS='@' read -ra repo <<< $name
+  name=${repo[0]}
+  if [ -z ${repo[1]+x} ]; then
+      params="--set-branch ${repo[1]}";
+  else
+      params=""
+  fi
+
+  (set -x; git submodule add --force $params "$url" "lib/$name")
   (set -x; git submodule update --init --recursive "lib/$name")
   (set -x; git commit -m "dapp install $unparsed")
 done <<<"$deps"

--- a/src/dapp/libexec/dapp/dapp-install
+++ b/src/dapp/libexec/dapp/dapp-install
@@ -17,7 +17,7 @@ fi
 while read -r unparsed name url; do
   # get the tag/branch/rev from the repo name if it's specified after the URL with
   # an '@' delimiter.
-  IFS='@' read -ra repo <<< $name
+  IFS='@' read -ra repo <<< "$name"
   name=${repo[0]}
   if [ -z ${repo[1]+x} ]; then
       params="--set-branch ${repo[1]}";
@@ -25,7 +25,7 @@ while read -r unparsed name url; do
       params=""
   fi
 
-  (set -x; git submodule add --force $params "$url" "lib/$name")
+  (set -x; git submodule add --force "$params" "$url" "lib/$name")
   (set -x; git submodule update --init --recursive "lib/$name")
   (set -x; git commit -m "dapp install $unparsed")
 done <<<"$deps"

--- a/src/dapp/libexec/dapp/dapp-install
+++ b/src/dapp/libexec/dapp/dapp-install
@@ -17,15 +17,15 @@ fi
 while read -r unparsed name url; do
   # get the tag/branch/rev from the repo name if it's specified after the URL with
   # an '@' delimiter.
-  IFS='@' read -ra repo <<< "$name"
-  name=${repo[0]}
-  if [ -z ${repo[1]+x} ]; then
-      params="--set-branch ${repo[1]}";
-  else
-      params=""
-  fi
+  IFS='@' read -ra repo <<< "$url"
+  url=${repo[0]}
+  tag=${repo[1]}
 
-  (set -x; git submodule add --force "$params" "$url" "lib/$name")
+  (set -x; git submodule add --force "$url" "lib/$name")
+  # checkout the tag if specified
+  if [ $tag ]; then
+    (set -x; cd "lib/$name" && git checkout "$tag" && cd -)
+  fi
   (set -x; git submodule update --init --recursive "lib/$name")
   (set -x; git commit -m "dapp install $unparsed")
 done <<<"$deps"

--- a/src/dapp/libexec/dapp/dapp-install
+++ b/src/dapp/libexec/dapp/dapp-install
@@ -28,6 +28,11 @@ while read -r unparsed name url; do
   if [ "$tag" ]; then
     # checkout the tag
     (set -x; cd "lib/$name" && git checkout "$tag" && cd -)
+    # edit the .gitmodules file to note the version tag. we do
+    # this just for introspection reasons (inspecting your dep versions),
+    # and it provides no actual functionality
+    git config -f .gitmodules submodule.lib/$name.version $tag
+    git add .gitmodules
   fi
   (set -x; git commit -m "dapp install $unparsed")
 done <<<"$deps"

--- a/src/dapp/libexec/dapp/dapp-install
+++ b/src/dapp/libexec/dapp/dapp-install
@@ -7,7 +7,7 @@
 ###   - a path to a repo in another Github org (org-name/repo-name)
 set -e
 
-dapp --sanity "$0"
+# dapp --sanity "$0"
 deps=$(dapp --parse-deps "$@")
 if [[ -z "$deps" ]]; then
   dapp help install
@@ -20,12 +20,14 @@ while read -r unparsed name url; do
   IFS='@' read -ra repo <<< "$url"
   url=${repo[0]}
   tag=${repo[1]}
+  # strip the tag from the name
+  name=${name%@*}
 
   (set -x; git submodule add --force "$url" "lib/$name")
-  # checkout the tag if specified
+  (set -x; git submodule update --init --recursive "lib/$name")
   if [ "$tag" ]; then
+    # checkout the tag
     (set -x; cd "lib/$name" && git checkout "$tag" && cd -)
   fi
-  (set -x; git submodule update --init --recursive "lib/$name")
   (set -x; git commit -m "dapp install $unparsed")
 done <<<"$deps"

--- a/src/dapp/libexec/dapp/dapp-install
+++ b/src/dapp/libexec/dapp/dapp-install
@@ -7,7 +7,7 @@
 ###   - a path to a repo in another Github org (org-name/repo-name)
 set -e
 
-# dapp --sanity "$0"
+dapp --sanity "$0"
 deps=$(dapp --parse-deps "$@")
 if [[ -z "$deps" ]]; then
   dapp help install

--- a/src/dapp/libexec/dapp/dapp-install
+++ b/src/dapp/libexec/dapp/dapp-install
@@ -29,11 +29,6 @@ while read -r unparsed name url; do
     # checkout the tag
     (set -x; cd "lib/$name" && git checkout --recurse-submodules "$tag" && cd -)
     git add lib/
-    # edit the .gitmodules file to note the version tag. we do
-    # this just for introspection reasons (inspecting your dep versions),
-    # and it provides no actual functionality
-    git config -f .gitmodules submodule.lib/"$name".version "$tag"
-    git add .gitmodules
   fi
   (set -x; git commit -m "dapp install $unparsed")
 done <<<"$deps"

--- a/src/dapp/libexec/dapp/dapp-install
+++ b/src/dapp/libexec/dapp/dapp-install
@@ -23,7 +23,7 @@ while read -r unparsed name url; do
 
   (set -x; git submodule add --force "$url" "lib/$name")
   # checkout the tag if specified
-  if [ $tag ]; then
+  if [ "$tag" ]; then
     (set -x; cd "lib/$name" && git checkout "$tag" && cd -)
   fi
   (set -x; git submodule update --init --recursive "lib/$name")

--- a/src/dapp/libexec/dapp/dapp-install
+++ b/src/dapp/libexec/dapp/dapp-install
@@ -27,7 +27,8 @@ while read -r unparsed name url; do
   (set -x; git submodule update --init --recursive "lib/$name")
   if [ "$tag" ]; then
     # checkout the tag
-    (set -x; cd "lib/$name" && git checkout "$tag" && cd -)
+    (set -x; cd "lib/$name" && git checkout --recurse-submodules "$tag" && cd -)
+    git add lib/
     # edit the .gitmodules file to note the version tag. we do
     # this just for introspection reasons (inspecting your dep versions),
     # and it provides no actual functionality


### PR DESCRIPTION
As title, right now we cannot specify a rev/branch/tag when installing a version. 

We allow providing one after an "@". we clone the repo in a dir that preserves the version/tag so that we can know what version we've installed at a glance.

e.g. if you wanted to install an older version of OZ, you'd do `dapp install https://github.com/OpenZeppelin/openzeppelin-contracts@release-v3.3`

Example (`dapp upgrade` still works and updates to the latest master):

```
mkdir test-deps
cd test-deps
dapp init
dapp install rari-capital/solmate@92f9f3ff441d3e2e07b4c8764632659c2557467e
dapp upgrade
```