### PR TITLE
hevm: correctly set basefee and gas limit when running with --rpc

### DIFF
--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Contract feching happens synchronously again.
 - Invariants checked before calling methods from targetContracts.
 
+### Fixed
+
+- The block gas limit and basefee are now correctly fetched when running tests via rpc
+
 ## 0.48.0 - 2021-08-03
 
 ### Changed

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -108,9 +108,10 @@ parseBlock j = do
   timestamp  <- litWord . readText <$> j ^? key "timestamp" . _String
   number     <- readText <$> j ^? key "number" . _String
   difficulty <- readText <$> j ^? key "difficulty" . _String
+  gasLimit   <- readText <$> j ^? key "gasLimit" . _String
   let baseFee = readText <$> j ^? key "baseFeePerGas" . _String
   -- default codesize, default gas limit, default feescedule
-  return $ EVM.Block coinbase timestamp number difficulty 0xffffffff (fromMaybe 0 baseFee) 0xffffffff FeeSchedule.berlin
+  return $ EVM.Block coinbase timestamp number difficulty gasLimit (fromMaybe 0 baseFee) 0xffffffff FeeSchedule.berlin
 
 fetchWithSession :: Text -> Session -> Value -> IO (Maybe Value)
 fetchWithSession url sess x = do


### PR DESCRIPTION
The block gas limit and block basefee are now correctly set when running tests via rpc. 

@mds1 this should fix the issue you were seeing [here](https://github.com/dapphub/dapptools/pull/743#issuecomment-899481642).

Thanks @transmissions11 for spotting this! :pray: 