### PR TITLE
dapp: Ignore non-directories in dapp-remappings

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dapp debug respects `DAPP_LINK_TEST_LIBRARIES`
-- Dapp remappings ignores files containing `.` in `DAPP_LIB`
+- Dapp remappings ignores files (not directories) in `DAPP_LIB`
 
 ### Fixed
 

--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Dapp debug respects DAPP_LINK_TEST_LIBRARIES 
+- Dapp debug respects `DAPP_LINK_TEST_LIBRARIES`
+- Dapp remappings ignores files containing `.` in `DAPP_LIB`
 
 ### Fixed
 

--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Dapp remappings ignores non-directories in `DAPP_LIB`
+
 ## [0.34.1] - 2021-09-08
 
 ### Added
@@ -17,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dapp debug respects `DAPP_LINK_TEST_LIBRARIES`
-- Dapp remappings ignores non-directories in `DAPP_LIB`
 
 ### Fixed
 

--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dapp debug respects `DAPP_LINK_TEST_LIBRARIES`
-- Dapp remappings ignores files (not directories) in `DAPP_LIB`
+- Dapp remappings ignores non-directories in `DAPP_LIB`
 
 ### Fixed
 

--- a/src/dapp/libexec/dapp/dapp-remappings
+++ b/src/dapp/libexec/dapp/dapp-remappings
@@ -19,8 +19,8 @@ function findRemappings(prefix) {
     var path = `${lib}/${name}`
     var src = `${path}/${process.env.DAPP_SRC}`.replace(/^.\//, "")
     
-    // If the path is a file, return early.
-    if (isFile(path)) {
+    // If the path is a not a directory, return early.
+    if (!isDir(path)) {
       return
     }
 
@@ -65,8 +65,12 @@ function ls(dir) {
   }
 }
 
-function isFile(path) {
-  return require("fs").lstatSync(path).isFile()
+function isDir(path) {
+  try {
+    return require("fs").lstatSync(path).isDirectory()
+  } catch (error) {
+    return false;
+  }
 }
 
 function run(cmd, args) {

--- a/src/dapp/libexec/dapp/dapp-remappings
+++ b/src/dapp/libexec/dapp/dapp-remappings
@@ -20,7 +20,7 @@ function findRemappings(prefix) {
     
     // If the file has an extension, ignore.
     if (name.includes(".")) {
-      return;
+      return
     }
 
     // Shortcut when we're ignoring all the Git hash stuff.

--- a/src/dapp/libexec/dapp/dapp-remappings
+++ b/src/dapp/libexec/dapp/dapp-remappings
@@ -17,6 +17,11 @@ function findRemappings(prefix) {
   ls(`${prefix}/${process.env.DAPP_LIB}`).forEach(name => {
     var lib = `${prefix}/${process.env.DAPP_LIB}`
     var src = `${lib}/${name}/${process.env.DAPP_SRC}`.replace(/^.\//, "")
+    
+    // If the file has an extension, ignore.
+    if (name.includes(".")) {
+      return;
+    }
 
     // Shortcut when we're ignoring all the Git hash stuff.
     if (process.env.DAPP_IGNORE_HASHES) {

--- a/src/dapp/libexec/dapp/dapp-remappings
+++ b/src/dapp/libexec/dapp/dapp-remappings
@@ -16,22 +16,23 @@ Object.keys(pkg_src).sort((a, b) => a.length - b.length).sort(
 function findRemappings(prefix) {
   ls(`${prefix}/${process.env.DAPP_LIB}`).forEach(name => {
     var lib = `${prefix}/${process.env.DAPP_LIB}`
-    var src = `${lib}/${name}/${process.env.DAPP_SRC}`.replace(/^.\//, "")
+    var path = `${lib}/${name}`
+    var src = `${path}/${process.env.DAPP_SRC}`.replace(/^.\//, "")
     
-    // If the file has an extension, ignore.
-    if (name.includes(".")) {
+    // If the path is a file, return early.
+    if (isFile(path)) {
       return
     }
 
     // Shortcut when we're ignoring all the Git hash stuff.
     if (process.env.DAPP_IGNORE_HASHES) {
       pkg_src[name] = src
-      findRemappings(`${lib}/${name}`)
+      findRemappings(path)
       return
     }
 
-    if (ls(`${lib}/${name}`).includes(".git") != true) {
-      console.error(`${PROGRAM_NAME}: error: ${lib}/${name} is not a Git repository`)
+    if (ls(path).includes(".git") != true) {
+      console.error(`${PROGRAM_NAME}: error: ${path} is not a Git repository`)
       console.error(`${PROGRAM_NAME}: error: try "dapp update" to initialize submodules`)
       process.exit(1)
     }
@@ -52,7 +53,7 @@ function findRemappings(prefix) {
       pkg_hash[name] = hash
     }
 
-    findRemappings(`${lib}/${name}`)
+    findRemappings(path)
   })
 }
 
@@ -62,6 +63,10 @@ function ls(dir) {
   } catch (error) {
     return []
   }
+}
+
+function isFile(path) {
+  return require("fs").lstatSync(path).isFile()
 }
 
 function run(cmd, args) {


### PR DESCRIPTION
Files from MacOS finder like .DS_Store and other junk can end up in the libs folder and mess up remappings, this should fix