### PR TITLE
use eth instead of wei as default for `seth --to-wei`

### DIFF
--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- `seth --to-wei` now uses eth instead of wei as the default unit for conversions
+
 ## [0.11.0] - 2021-09-08
 
 ### Added

--- a/src/seth/libexec/seth/seth---to-wei
+++ b/src/seth/libexec/seth/seth---to-wei
@@ -5,7 +5,7 @@ set -e
 [[ $1 ]] || set -- "$(cat)"
 [[ $1 ]] || seth --fail-usage "$0"
 set -- "$*"
-[[ $1 = *" "* ]] || set -- "$1 wei"
+[[ $1 = *" "* ]] || set -- "$1 eth"
 number=${1%% *} unit=${1#* }
 # shellcheck disable=2018,2019
 unit=$(tr A-Z a-z <<<"$unit")


### PR DESCRIPTION
This will make `seth --to-wei` use `eth` as the default unit instead of `wei`. This makes more sense, given the helptext `convert an ETH amount into wei`