### PR TITLE
hevm: skip unit test contracts with no code

### DIFF
--- a/src/dapp-tests/pass/abstract.sol
+++ b/src/dapp-tests/pass/abstract.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.6.7;
+
+import {DSTest} from "ds-test/test.sol";
+
+// should not be run (no code)
+abstract contract MyTest is DSTest {}
+
+// should run and pass
+contract TestMy is MyTest {
+    function testTrue() public {
+        assertTrue(true);
+    }
+}

--- a/src/dapp-tests/pass/abstract.sol
+++ b/src/dapp-tests/pass/abstract.sol
@@ -3,7 +3,11 @@ pragma solidity ^0.6.7;
 import {DSTest} from "ds-test/test.sol";
 
 // should not be run (no code)
-abstract contract MyTest is DSTest {}
+abstract contract MyTest is DSTest {
+    function testAbstract() public {
+        assertTrue(true);
+    }
+}
 
 // should run and pass
 contract TestMy is MyTest {

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - The block gas limit and basefee are now correctly fetched when running tests via rpc
+- Test contracts with no code (e.g. `abstract` contracts) are now skipped
 
 ## 0.48.0 - 2021-08-03
 

--- a/src/hevm/src/EVM/Dapp.hs
+++ b/src/hevm/src/EVM/Dapp.hs
@@ -140,9 +140,7 @@ findUnitTests match =
       Nothing -> []
       Just _  ->
         let testNames = unitTestMethodsFiltered (regexMatches match) c
-        in if BS.null (view runtimeCode c)
-           then []
-           else [(view contractName c, testNames) | not (null testNames)]
+        in [(view contractName c, testNames) | not (BS.null (view runtimeCode c)) && not (null testNames)]
 
 unitTestMethodsFiltered :: (Text -> Bool) -> (SolcContract -> [(Test, [AbiType])])
 unitTestMethodsFiltered matcher c =

--- a/src/hevm/src/EVM/Dapp.hs
+++ b/src/hevm/src/EVM/Dapp.hs
@@ -140,7 +140,9 @@ findUnitTests match =
       Nothing -> []
       Just _  ->
         let testNames = unitTestMethodsFiltered (regexMatches match) c
-        in [(view contractName c, testNames) | not (null testNames)]
+        in if BS.null (view runtimeCode c)
+           then []
+           else [(view contractName c, testNames) | not (null testNames)]
 
 unitTestMethodsFiltered :: (Text -> Bool) -> (SolcContract -> [(Test, [AbiType])])
 unitTestMethodsFiltered matcher c =


### PR DESCRIPTION
## Description

Skips execution for unit test contracts with no code. Fixes #769.

## Checklist

- [ ] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
