### PR TITLE
Add `--from-fix` command

### DIFF
--- a/src/dapp-tests/integration/tests.sh
+++ b/src/dapp-tests/integration/tests.sh
@@ -370,3 +370,46 @@ test-lookup-address2() {
      = $(seth lookup-address 0x49c92f2ce8f876b070b114a6b2f8a60b83c281ad --rpc-url=$ETH_RPC_URL) ]] || error
 }
 test-lookup-address2
+
+# SETH FIXED POINT TESTS
+# seth --from-fix
+test-from-fix1() {
+    [[ $(seth --from-fix 6 1) = 1000000 ]] || error
+}
+test-from-fix1
+
+test-from-fix2() {
+    [[ $(seth --from-fix 18 1) = 1000000000000000000 ]] || error
+}
+test-from-fix2
+
+test-from-fix3() {
+    [[ $(seth --from-fix 6 1.2345) = 1234500 ]] || error
+}
+test-from-fix3
+
+test-from-fix4() {
+    [[ $(seth --from-fix 18 1.23456789) = 1234567890000000000 ]] || error
+}
+test-from-fix4
+
+# seth --to-fix
+test-to-fix1() {
+    [[ $(seth --to-fix 6 1000000) = 1.000000 ]] || error
+}
+test-to-fix1
+
+test-to-fix2() {
+    [[ $(seth --to-fix 18 1000000000000000000) = 1.000000000000000000 ]] || error
+}
+test-to-fix2
+
+test-to-fix3() {
+    [[ $(seth --to-fix 6 1234500) = 1.234500 ]] || error
+}
+test-to-fix3
+
+test-to-fix4() {
+    [[ $(seth --to-fix 18 1234567890000000000) = 1.234567890000000000 ]] || error
+}
+test-to-fix4

--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `seth 4byte-event` command returns the response from querying 4byte.directory for a given event topic
 - `seth abi-encode` command returns the ABI encoded values without the function signature
 - `seth index` command returns the slot number for the specified mapping type and input data
+- `seth --from-fix` command converts fixed point numbers into parsed integers with the specified number of decimals
 
 ## [0.11.0] - 2021-09-08
 

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -57,6 +57,7 @@ hardware wallets—even if you use a remote RPC node like Infura's.
   - [`seth --calldata-decode`]
   - [`seth --from-ascii`]
   - [`seth --from-bin`]
+  - [`seth --from-fix`]
   - [`seth --from-wei`]
   - [`seth --max-int`]
   - [`seth --max-uint`]
@@ -65,6 +66,7 @@ hardware wallets—even if you use a remote RPC node like Infura's.
   - [`seth --to-ascii`]
   - [`seth --to-bytes32`]
   - [`seth --to-dec`]
+  - [`seth --to-fix`]
   - [`seth --to-hex`]
   - [`seth --to-int256`]
   - [`seth --to-uint256`]
@@ -374,6 +376,14 @@ Convert binary data into hex data.
 
 Reads binary data from standard input and prints it as hex data.
 
+### `seth --from-fix`
+
+Convert fixed point numbers into parsed integers with the specified number of decimals.
+
+    seth --from-fix <decimals> <value>
+
+For example, use `seth --to-fix 6 1` to convert 1 USDC into the parsed quantity of 1,000,000 USDC
+
 ### `seth --from-wei`
 
 Convert a wei amount into another unit (ETH by default).
@@ -429,6 +439,14 @@ Pad a hex string to the right with zeroes to 32 bytes.
 Convert a hex value with 0x prefix into a decimal number.
 
     seth --to-dec <hexvalue>
+
+### `seth --to-fix`
+
+Convert parsed integers into fixed point with the specified number of decimals.
+
+    seth --to-fix <decimals> <value>
+
+For example, use `seth --to-fix 6 1000000` to convert the parsed amount of 1,000,000 USDC into a formatted amount of 1 USDC.
 
 ### `seth --to-hex`
 
@@ -865,7 +883,9 @@ Show all fields unless `<field>` is given.
 [`seth --abi-decode`]: #seth---abi-decode
 [`seth --from-ascii`]: #seth---from-ascii
 [`seth --from-bin`]: #seth---from-bin
+[`seth --from-fix`]: #seth---from-fix
 [`seth --from-wei`]: #seth---from-wei
+[`seth --to-fix`]: #seth---to-fix
 [`seth --to-wei`]: #seth---to-wei
 [`seth --to-int256`]: #seth---to-int256
 [`seth --to-uint256`]: #seth---to-uint256

--- a/src/seth/libexec/seth/seth---from-fix
+++ b/src/seth/libexec/seth/seth---from-fix
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+### seth---from-fix -- convert fixed point into specified number of decimals
+### Usage: seth --from-fix <decimals> <wei>
+set -e
+[[ $# -eq 2 ]] || seth --fail-usage "$0"
+
+decimals=$1
+number=$2
+
+bc <<<"$number * 10 ^ $decimals / 1" # dividing by 1 ensures integer output

--- a/src/seth/libexec/seth/seth-4byte-decode
+++ b/src/seth/libexec/seth/seth-4byte-decode
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-### seth-4byte-decode -- querys 4byte.directory to find a matching signature, then decodes the calldata with it
+### seth-4byte-decode -- queries 4byte.directory to find a matching signature, then decodes the calldata with it
 ### Usage: seth 4byte-decode <calldata> [<options>]
 ###
 ### Queries 4byte.directory to find matching signatures and prompts the user to to select one. The selected


### PR DESCRIPTION
## Description

- Adds `--from-fix command`
- Add `--from-fix` and `--to-fix` methods to the docs
- Fix unrelated typo in `seth 4byte-decode`

This is a super simple method but let me know if you still want to add tests

## Checklist

- [x] tested locally
- [ ] added automated tests
- [x] updated the docs
- [x] updated the changelog