### PR TITLE
Revert "use eth instead of wei as default for `seth --to-wei`"

### DIFF
--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `seth --to-wei` now uses eth instead of wei as the default unit for conversions
 - `seth 4byte` command returns the response from querying [4byte.directory](https://www.4byte.directory/) for a given function signature
 - `seth 4byte-decode` command queries 4byte.directory for matching function signatures, uses one to decode the calldata, and prints the decoded calldata
 - `seth 4byte-event` command returns the response from querying 4byte.directory for a given event topic

--- a/src/seth/libexec/seth/seth---to-wei
+++ b/src/seth/libexec/seth/seth---to-wei
@@ -5,7 +5,7 @@ set -e
 [[ $1 ]] || set -- "$(cat)"
 [[ $1 ]] || seth --fail-usage "$0"
 set -- "$*"
-[[ $1 = *" "* ]] || set -- "$1 eth"
+[[ $1 = *" "* ]] || set -- "$1 wei"
 number=${1%% *} unit=${1#* }
 # shellcheck disable=2018,2019
 unit=$(tr A-Z a-z <<<"$unit")


### PR DESCRIPTION
This reverts commit 8ab1a85fe6ffc6df23aef800c93c7cf429aa9a98. Changing `--to-wei` also changed the default values used in `seth send` and many other places, which could lead to way too much eth being transferred!

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
