### PR TITLE
seth: non checksum addresses supported in ETH_FROM

### DIFF
--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `seth abi-encode` command returns the ABI encoded values without the function signature
 - `seth index` command returns the slot number for the specified mapping type and input data
 
+### Fixed
+
+- Adress lookup no longer fails if `ETH_RPC_ACCOUNTS` is set, and `ETH_FROM` is an unchecksummed address
+
 ## [0.11.0] - 2021-09-08
 
 ### Added

--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Adress lookup no longer fails if `ETH_RPC_ACCOUNTS` is set, and `ETH_FROM` is an unchecksummed address
+- Address lookup no longer fails if `ETH_RPC_ACCOUNTS` is set, and `ETH_FROM` is an unchecksummed address
 
 ## [0.11.0] - 2021-09-08
 

--- a/src/seth/libexec/seth/seth-send
+++ b/src/seth/libexec/seth/seth-send
@@ -58,7 +58,7 @@ function signAndSend() {
 
 if [[ -z $ETH_RPC_ACCOUNTS ]]; then
   signAndSend
-elif ethsign ls | grep -q $ETH_FROM; then
+elif ethsign ls | grep -qI "$ETH_FROM"; then
   signAndSend
 else
   tx=$(seth rpc eth_sendTransaction -- "${jshon[@]}")


### PR DESCRIPTION
## Description

Fixes an issue in #771, where if `ETH_RPC_ACCOUNTS` was set, and `ETH_FROM` was not a checksummed address, the signing request would be incorrectly forwarded to the rpc node, even if `ETH_FROM` was present in a local keystore.

The issue is fixed by using a case insensitive grep when checking if `ETH_FROM` is present in a local keystore.

## Checklist

- [ ] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
