### PR TITLE
dapp: fix library linking on solc 0.7+

### DIFF
--- a/src/dapp-tests/default.nix
+++ b/src/dapp-tests/default.nix
@@ -1,6 +1,7 @@
 { pkgs }:
 
 let
+  solc-0_8_6 = "${pkgs.solc-static-versions.solc_0_8_6}/bin/solc-0.8.6";
   solc-0_7_6 = "${pkgs.solc-static-versions.solc_0_7_6}/bin/solc-0.7.6";
   solc-0_6_7 = "${pkgs.solc-static-versions.solc_0_6_7}/bin/solc-0.6.7";
 
@@ -129,6 +130,18 @@ in
       name = "dappTestsShouldPass";
       shouldFail = false;
       dappFlags = "--max-iterations 50 --smttimeout 600000 --ffi";
+    };
+
+    libraries0_8 = pkgs.buildDappPackage {
+      name = "libraries-0.8";
+      shouldFail = false;
+      solc=solc-0_8_6;
+      src = pkgs.runCommand "src" {} ''
+        mkdir -p $out
+        cp ${./pass/libraries.sol} $out/libraries.sol;
+      '';
+      deps = [ ds-test ];
+      checkInputs = with pkgs; [ hevm jq seth dapp solc ];
     };
 
     shouldFail = let

--- a/src/dapp-tests/pass/libraries.sol
+++ b/src/dapp-tests/pass/libraries.sol
@@ -1,18 +1,18 @@
 import "ds-test/test.sol";
 
 library A {
-    function f(uint x) public returns (uint256) {
-        return x * 2;
+    function f(uint128 x) public returns (uint256) {
+        return uint(x) * 2;
     }
 }
 
 contract B is DSTest {
-    using A for uint256;
-    function test_f(uint x) public {
-        assertEq(x * 2, x.f());
+    using A for uint128;
+    function test_f(uint128 x) public {
+        assertEq(uint(x) * 2, x.f());
     }
 
     function testFail_f() public {
-        assertEq(1, uint(1).f());
+        assertEq(1, uint128(1).f());
     }
 }

--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Dapp can correctly parse replay strings from invariant tests
+- Libraries are properly linked when compiling with solc >= 0.7
 
 ## [0.34.1] - 2021-09-08
 

--- a/src/dapp/libexec/dapp/dapp-mk-standard-json
+++ b/src/dapp/libexec/dapp/dapp-mk-standard-json
@@ -60,8 +60,9 @@ else:
     addresses=[]
     for lib in os.getenv('DAPP_LIBRARIES')[1:].split(' '):
         f,c,addr = lib.split(':')
-        tmpljson["settings"]["libraries"][""][f + ":" + c] = addr
-
+        if f not in tmpljson["settings"]["libraries"]:
+            tmpljson["settings"]["libraries"][f] = {}
+        tmpljson["settings"]["libraries"][f][c] = addr
 
 tmpljson["settings"]["outputSelection"]={}
 tmpljson["settings"]["outputSelection"]["*"]={}


### PR DESCRIPTION
## Description

There was an undocumented change in the accepted format for the `libraries` key in the input.json in solc 0.7. It seems as though the format that we were using was only working by accident.

This PR updates `dapp mk-standard-json` to use the expected format for library specifiers.

This fixes #802

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
