### PR TITLE
dapp: build: strip escape chars and colorize output

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- The output from `dapp build` now uses color to differentiate warnings and errors
+
 ### Changed
 
 - Dapp remappings ignores non-directories in `DAPP_LIB`

--- a/src/dapp/libexec/dapp/dapp-build
+++ b/src/dapp/libexec/dapp/dapp-build
@@ -27,6 +27,13 @@ info() {
   echo >&2 "$FLAGS" "${0##*/}: $ARGS"
 }
 
+colorize() {
+    awk '{
+gsub("Warning:", "\033[1;33m&\033[0m");
+gsub(".*Error:", "\033[1;31m&\033[0m");
+print }'
+}
+
 cd "$DAPP_ROOT"
 
 # use a custom path if DAPP_SOLC is set
@@ -68,7 +75,7 @@ if [[ -z "$DAPP_BUILD_LEGACY" && -z "$DAPP_BUILD_EXTRACT" ]]; then
 
     # pipe errors to stderr
     jq -r 'if .errors then .errors | map(."formattedMessage") | @sh else empty end' "$DAPP_JSON" \
-        | sed -e "s/' //g" -e "s/'//g" 1>&2
+        | sed -e "s/' //g" -e "s/'//g" -e 's/\\\(.\)\\/\1 /g' | colorize 1>&2
     # if sources is empty, the compilation failed
     [[ $(jq -r '.sources' "$DAPP_JSON") = "null" ||  $(jq -r '.sources' "$DAPP_JSON") = {} ]] && exit 1 || exit 0
 


### PR DESCRIPTION
## Description

- strips '\\' chars from the output
- colors errors in red, and warnings in yellow

Fixes  #659 

## Images

![image](https://user-images.githubusercontent.com/6689924/134170690-9ad3c817-27f8-4efb-aa4d-eb8c62340ee7.png)

![image](https://user-images.githubusercontent.com/6689924/134170739-0235ac6a-774f-4ef2-9081-da92b23e0d38.png)

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
