### PR TITLE
seth: debug: fix

### DIFF
--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-Contract creations with Dynamic fee transactions.
-
+- Contract creations with Dynamic fee transactions.
+- `seth debug` correctly executes transactions.
 
 ### Changed
 

--- a/src/seth/libexec/seth/seth-debug
+++ b/src/seth/libexec/seth/seth-debug
@@ -50,7 +50,7 @@ for i in "${txs[@]}"; do
 
   if [[ "$1" = "$hash" ]]; then
     echo -e >&2 "\r${0##*/}: info: transaction ($j/$index)"
-    seth run-tx "$tx" --state "$state" --debug "${opts[@]}"
+    seth run-tx "$hash" --state "$state" --debug "${opts[@]}"
     tidy
     break
   else
@@ -58,7 +58,7 @@ for i in "${txs[@]}"; do
       echo -e  >&2 "\r${0##*/}: info: transaction ($j/$index)" ||
       echo -en >&2 "\r${0##*/}: info: transaction ($j/$index)"
     # exit code 2 means REVERT or otherwise acceptable failure
-    seth run-tx "$tx" --state "$state" --timestamp "$timestamp" > /dev/null ||
+    seth run-tx "$hash" --state "$state" --timestamp "$timestamp" > /dev/null ||
       [[ $? == 2 ]] ||
       (tidy; echo ""; seth --fail "${0##*/}: error: hevm error while executing tx: $hash")
     j=$((j + 1))


### PR DESCRIPTION
## Description

Fixes `seth debug` (which was passing the whole tx object instead of just the tx hash into `seth run-tx`). @MrChico has there been an api change since this was written? I don't understand how it ever worked, but it definitely did in the past, so I'm a little confused....

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
