### PR TITLE
seth/dapp --use: look for systemwide solc installs

### DIFF
--- a/src/dapp/CHANGELOG.md
+++ b/src/dapp/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Dapp can correctly parse replay strings from invariant tests
 - Libraries are properly linked when compiling with solc >= 0.7
+- `dapp --use` will now find solc versions that have been installed systemwide on nixos
 
 ## [0.34.1] - 2021-09-08
 

--- a/src/dapp/libexec/dapp/dapp---use
+++ b/src/dapp/libexec/dapp/dapp---use
@@ -13,7 +13,7 @@ function usage() {
 [[ "$#" -gt 0 ]] || usage
 
 query() {
-  nix-env -q --installed --out-path --no-name "$1" 2>/dev/null
+  nix-store -q --requisites /run/current-system ~/.nix-profile | grep "$1" --color=never 2>/dev/null
 }
 
 shopt -s extglob

--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 Contract creations with Dynamic fee transactions.
+- `seth --use` will now find solc versions that have been installed systemwide on nixos
 
 
 ### Changed

--- a/src/seth/libexec/seth/seth---use
+++ b/src/seth/libexec/seth/seth---use
@@ -13,7 +13,7 @@ function usage() {
 [[ "$#" -gt 0 ]] || usage
 
 query() {
-  nix-env -q --installed --out-path --no-name "$1" 2>/dev/null
+  nix-store -q --requisites /run/current-system ~/.nix-profile | grep "$1" --color=never 2>/dev/null
 }
 
 shopt -s extglob


### PR DESCRIPTION
## Description

`seth --use` and `dapp --use` will now find copies of `solc` that have been installed systemwide from `solc-versions` or `solc-static-versions` on nixos systems, as well as the imperitive versions installed via `nix-env`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
