### PR TITLE
clearer output for the invalid opcode

### DIFF
--- a/src/hevm/src/EVM/Op.hs
+++ b/src/hevm/src/EVM/Op.hs
@@ -167,4 +167,6 @@ opString (i, o) = let showPc x | x < 0x10 = '0' : showHex x ""
   OpLog x -> "LOG" ++ show x
   OpPush x -> "PUSH " ++ show x
   OpRevert -> "REVERT"
-  OpUnknown x -> "UNKNOWN " ++ show x
+  OpUnknown x -> case x of
+    254 -> "INVALID"
+    _ -> "UNKNOWN " ++ show x

--- a/src/hevm/src/EVM/Op.hs
+++ b/src/hevm/src/EVM/Op.hs
@@ -169,4 +169,4 @@ opString (i, o) = let showPc x | x < 0x10 = '0' : showHex x ""
   OpRevert -> "REVERT"
   OpUnknown x -> case x of
     254 -> "INVALID"
-    _ -> "UNKNOWN " ++ show x
+    _ -> "UNKNOWN " ++ (showHex x "")


### PR DESCRIPTION
## Description

- Pretty printing for `0xfe` in debug view
- Print hex code instead of decimal value for other undefined opcodes

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
