### PR TITLE
hevm: tty: skip null src maps when jumping with shift+n

### DIFF
--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Test contracts with no code (e.g. `abstract` contracts) are now skipped
 - Replay data for invariant tests is now displayed in a form that does not cause errors when used with `dapp test --replay`
+- Stepping through the debugger with `shift + n` now always skips positions in the bytecode that do not have a corresponding position in the solidity source map
 
 ## [0.48.1] - 2021-09-08
 

--- a/src/hevm/src/EVM/TTY.hs
+++ b/src/hevm/src/EVM/TTY.hs
@@ -838,7 +838,12 @@ isNextSourcePosition
 isNextSourcePosition ui vm =
   let dapp' = dapp (view uiTestOpts ui)
       initialPosition = currentSrcMap dapp' (view uiVm ui)
-  in currentSrcMap dapp' vm /= initialPosition
+      currentPosition = currentSrcMap dapp' vm
+  in (not . isNullPosition $ currentPosition) && (currentPosition /= initialPosition)
+
+isNullPosition :: Maybe SrcMap -> Bool
+isNullPosition (Just (SM{..})) = srcMapOffset == -1 && srcMapLength == -1 && srcMapFile == -1
+isNullPosition Nothing = True
 
 isNextSourcePositionWithoutEntering
   :: UiVmState -> Pred VM


### PR DESCRIPTION
## Description

I *think* this fixes https://github.com/dapphub/dapptools/issues/686, but since the source map format and parser are very mysterious to me I'm not really sure that I've done the right thing.

Afaict the issue was that we sometimes get a sourcemap back from `currentPosition` that looks like this:

```
Just (SM {srcMapOffset = -1, srcMapLength = -1, srcMapFile = -1, srcMapJump = JumpRegular, srcMapModifierDepth = 0})
```

Which is treated as distinct by the check in `isNextSourcePosition`. I'm assuming the `-1` in this case is a sentinel value meaning the given source pc does not have a corresponding position in the provided source map? Perhaps there is a cleaner fix here where we make this position unrepresentable? @MrChico thoughts?

cc @transmissions11 for testing.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
