### PR TITLE
Add Polygon Support

### DIFF
--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -20,6 +20,8 @@ set -e
 [[ $2 ]] || (dapp verify-contract --help >&2 && exit 1)
 
 chain=$(seth chain)
+echo "chain: $chain"
+
 case "$chain" in
   ethlive|mainnet)
     export ETHERSCAN_API_URL=https://api.etherscan.io/api

--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -32,6 +32,7 @@ case "$chain" in
   polygon)
     export ETHERSCAN_API_URL=https://api.polygonscan.com/api
     export ETHERSCAN_URL=https://polygonscan.com/address
+    ;;
   *)
     echo >&2 "Verification only works on mainnet, ropsten, kovan, rinkeby, goerli, and polygon."
     exit 1

--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -20,8 +20,6 @@ set -e
 [[ $2 ]] || (dapp verify-contract --help >&2 && exit 1)
 
 chain=$(seth chain)
-echo "chain: $chain"
-
 case "$chain" in
   ethlive|mainnet)
     export ETHERSCAN_API_URL=https://api.etherscan.io/api
@@ -31,8 +29,11 @@ case "$chain" in
     export ETHERSCAN_API_URL=https://api-$chain.etherscan.io/api
     export ETHERSCAN_URL=https://$chain.etherscan.io/address
     ;;
+  polygon)
+    export ETHERSCAN_API_URL=https://api.polygonscan.com/api
+    export ETHERSCAN_URL=https://polygonscan.com/address
   *)
-    echo >&2 "Verification only works on mainnet, ropsten, kovan, rinkeby, and goerli."
+    echo >&2 "Verification only works on mainnet, ropsten, kovan, rinkeby, goerli, and polygon."
     exit 1
 esac
 

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -624,7 +624,7 @@ Print the symbolic name of the current blockchain by checking the
 genesis block hash.
 
 Outputs one of `ethlive`, `etclive`, `kovan`, `ropsten`, `goerli`, `morden`,
-`rinkeby`, `optimism-mainnet`, `optimism-kovan`, `arbitrum-mainnet`, `bsc`, `bsctest`, `kotti`, or `unknown`.
+`rinkeby`, `optimism-mainnet`, `optimism-kovan`, `arbitrum-mainnet`, `bsc`, `bsctest`, `kotti`, `polygon`, or `unknown`.
 
 ### `seth chain-id`
 

--- a/src/seth/libexec/seth/seth
+++ b/src/seth/libexec/seth/seth
@@ -242,6 +242,10 @@ if [[ $SETH_CHAIN ]]; then
       eth_rpc_url=https://bsc-dataseed3.binance.org/
       export ETHERSCAN_API_URL=https://api.bscscan.com/api
       ;;
+    polygon)
+      eth_rpc_url=https://polygon-rpc.com/
+      export ETHERSCAN_API_URL=https://api.polygonscan.com/api
+      ;;
     *)
       echo >&2 "${0##*/}: error: unknown chain: \\'$SETH_CHAIN'"
       exit 1

--- a/src/seth/libexec/seth/seth-chain
+++ b/src/seth/libexec/seth/seth-chain
@@ -33,6 +33,8 @@ case $genesis in
     echo bsctest;;
   0x0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b)
     echo bsc;;
+  0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b)
+    echo polygon;;
   *)
     echo unknown;;
 esac

--- a/src/seth/libexec/seth/seth-etherscan-source
+++ b/src/seth/libexec/seth/seth-etherscan-source
@@ -52,11 +52,8 @@ case "$chain" in
     exit 1
 esac
 
-echo "URL: $URL"
-
 
 RESPONSE=$(seth curl "${URL}/api?module=contract&action=getsourcecode&address=${ADDR}&apikey=${ETHERSCAN_API_KEY}" | seth --show-json)
-echo "RESPONSE: $RESPONSE"
 
 MSG=$(echo "$RESPONSE" | seth --field message)
 

--- a/src/seth/libexec/seth/seth-etherscan-source
+++ b/src/seth/libexec/seth/seth-etherscan-source
@@ -44,8 +44,11 @@ case "$chain" in
   bsc)
     URL="${ETHERSCAN_API_URL:-https://api.bscscan.com}"
     ;;
+  polygon)
+    URL="${ETHERSCAN_API_URL:-https://api.polygonscan.com}"
+    ;;
   *)
-    echo >&2 "Source fetching only works on mainnet, ropsten, kovan, rinkeby, goerli, optimism-mainnet, optimism-kovan, and arbitrum-mainnet."
+    echo >&2 "Source fetching only works on mainnet, ropsten, kovan, rinkeby, goerli, optimism-mainnet, optimism-kovan, arbitrum-mainnet, and polygon."
     exit 1
 esac
 

--- a/src/seth/libexec/seth/seth-etherscan-source
+++ b/src/seth/libexec/seth/seth-etherscan-source
@@ -52,8 +52,11 @@ case "$chain" in
     exit 1
 esac
 
+echo "URL: $URL"
+
 
 RESPONSE=$(seth curl "${URL}/api?module=contract&action=getsourcecode&address=${ADDR}&apikey=${ETHERSCAN_API_KEY}" | seth --show-json)
+echo "RESPONSE: $RESPONSE"
 
 MSG=$(echo "$RESPONSE" | seth --field message)
 


### PR DESCRIPTION
## Description
Add Polygon support for `seth chain`, `seth etherscan-source`, and `dapp verify-contract`. Please let me know how I should update the changelog as well as I am not too sure about that.

Also, it appears that for most chains, `seth etherscan-source` is broken. This is because most of the `ETHERSCAN_API_URL` set at the `seth` entrypoint has the /api portion included, but `seth etherscan-source` expects it to not be included. This is breaking my Polygon integration, as well as several others (I tested myself to confirm that it does not work for mainnet or kovan too but I beleive all but arbitrum are broken). Am I misunderstanding something here? I'd be happy to open a new PR to fix it.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [x] updated the docs
- [ ] updated the changelog
