### PR TITLE
automatic gas estimation

### DIFF
--- a/src/seth/CHANGELOG.md
+++ b/src/seth/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `seth index` command returns the slot number for the specified mapping type and input data
 - `seth --from-fix` command converts fixed point numbers into parsed integers with the specified number of decimals
 - `seth run-tx` now fetches contract source from etherscan if `ETHERSCAN_API_KEY` is set
+- `seth mktx` now estimates gas limit eth `ETH_GAS` is not set
 
 ### Fixed
 

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -238,7 +238,7 @@ wei—the smallest possible amount of ether—to the [Ethereum
 Foundation's donation address]:
 
     $ seth send --value 1 0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359
-    seth-send: warning: `ETH_GAS' not set; using default gas amount
+    seth-send: warning: `ETH_GAS' not set; using estimated gas amount
     Ethereum account passphrase (not echoed):
     seth-send: Published transaction with 0 bytes of calldata.
     seth-send: 0xe428d4bb148ded426777ae892578507e4f394f608ad9d3a9d0229e8348ba72e3
@@ -829,7 +829,7 @@ Sign and publish a transaction to the blockchain.
 | ------------- | --------------- | ------------ | ---------------                   |
 | `--block`     | `ETH_BLOCK`     | `latest`     | block number                      |
 | `--from`      | `ETH_FROM`      | n/a          | sender                            |
-| `--gas`       | `ETH_GAS`       | `200000`     | gas quantity                      |
+| `--gas`       | `ETH_GAS`       | estimated    | gas quantity                      |
 | `--gas-price` | `ETH_GAS_PRICE` |              | gas price                         |
 | `--prio-fee`  | `ETH_PRIO_FEE`  |              | EIP-1559 priority fee (miner tip) |
 | `--value`     | `ETH_VALUE`     | `0`          | ether value                       |

--- a/src/seth/libexec/seth/seth-mktx
+++ b/src/seth/libexec/seth/seth-mktx
@@ -18,7 +18,7 @@ args=(
   --nonce "${ETH_NONCE:-$(seth nonce "$ETH_FROM")}"
   --chain-id "$(seth chain-id)"
   --gas-price "${ETH_GAS_PRICE:-$(seth gas-price)}"
-  --gas-limit "${ETH_GAS:-200000}"
+  --gas-limit "${ETH_GAS:-$(seth estimate $ETH_FROM $data)}"
   --value "$value"
   --data "${data:-0x}"
 )

--- a/src/seth/libexec/seth/seth-mktx
+++ b/src/seth/libexec/seth/seth-mktx
@@ -18,7 +18,7 @@ args=(
   --nonce "${ETH_NONCE:-$(seth nonce "$ETH_FROM")}"
   --chain-id "$(seth chain-id)"
   --gas-price "${ETH_GAS_PRICE:-$(seth gas-price)}"
-  --gas-limit "${ETH_GAS:-$(seth estimate $ETH_FROM $data)}"
+  --gas-limit "${ETH_GAS:-$(seth estimate $ETH_FROM ${$data:-0x})}"
   --value "$value"
   --data "${data:-0x}"
 )

--- a/src/seth/libexec/seth/seth-mktx
+++ b/src/seth/libexec/seth/seth-mktx
@@ -23,7 +23,6 @@ if [[ -z "$ETH_GAS" ]]; then
   jshon+=(-n {})
   [[ $TO ]] && jshon+=(-s "$TO" -i to)
   jshon+=(-s "$data" -i data)
-  # shellcheck disable=SC2207
   jshon+=($(SETH_PARAMS_NO_GAS=1 seth --send-params))
   jshon+=(-i append)
   ETH_GAS=$(seth rpc eth_estimateGas -- "${jshon[@]}")

--- a/src/seth/libexec/seth/seth-mktx
+++ b/src/seth/libexec/seth/seth-mktx
@@ -17,7 +17,7 @@ data=${data:-0x}
 
 if [[ -z "$ETH_GAS" ]]; then
   if [[ $SETH_CREATE ]]; then
-    ETH_GAS=$(seth estimate --create $ETH_FROM $data)
+    ETH_GAS=$(seth estimate --create $data)
   else
     ETH_GAS=$(seth estimate $ETH_FROM $data)
   fi

--- a/src/seth/libexec/seth/seth-mktx
+++ b/src/seth/libexec/seth/seth-mktx
@@ -16,11 +16,16 @@ fi
 data=${data:-0x}
 
 if [[ -z "$ETH_GAS" ]]; then
-  if [[ $SETH_CREATE ]]; then
-    ETH_GAS=$(seth estimate --create $data)
-  else
-    ETH_GAS=$(seth estimate $ETH_FROM $data)
-  fi
+  jshon+=(-n {})
+  [[ $TO ]] && jshon+=(-s "$TO" -i to)
+  jshon+=(-s "$DATA" -i data)
+  # shellcheck disable=SC2207
+  jshon+=($(SETH_PARAMS_NO_GAS=1 seth --send-params))
+  jshon+=(-i append)
+  [[ $ETH_BLOCK = [0-9]* ]] && ETH_BLOCK=$(seth --to-hex "$ETH_BLOCK")
+  : "${ETH_BLOCK:=latest}" # geth doesn't like this argument
+  [[ $ETH_BLOCK = latest ]] || jshon+=(-s "$ETH_BLOCK" -i append)
+  ETH_GAS=$(seth rpc eth_estimateGas -- "${jshon[@]}")
 fi
 
 args=(

--- a/src/seth/libexec/seth/seth-mktx
+++ b/src/seth/libexec/seth/seth-mktx
@@ -15,12 +15,20 @@ fi
 
 data=${data:-0x}
 
+if [[ -z "$ETH_GAS" ]]; then
+  if [[ $SETH_CREATE ]]; then
+    ETH_GAS=$(seth estimate --create $ETH_FROM $data)
+  else
+    ETH_GAS=$(seth estimate $ETH_FROM $data)
+  fi
+fi
+
 args=(
   --from "$(seth --to-address "$ETH_FROM")"
   --nonce "${ETH_NONCE:-$(seth nonce "$ETH_FROM")}"
   --chain-id "$(seth chain-id)"
   --gas-price "${ETH_GAS_PRICE:-$(seth gas-price)}"
-  --gas-limit "${ETH_GAS:-$(seth estimate $ETH_FROM $data)}"
+  --gas-limit "$ETH_GAS"
   --value "$value"
   --data "$data"
 )

--- a/src/seth/libexec/seth/seth-mktx
+++ b/src/seth/libexec/seth/seth-mktx
@@ -22,9 +22,6 @@ if [[ -z "$ETH_GAS" ]]; then
   # shellcheck disable=SC2207
   jshon+=($(SETH_PARAMS_NO_GAS=1 seth --send-params))
   jshon+=(-i append)
-  [[ $ETH_BLOCK = [0-9]* ]] && ETH_BLOCK=$(seth --to-hex "$ETH_BLOCK")
-  : "${ETH_BLOCK:=latest}" # geth doesn't like this argument
-  [[ $ETH_BLOCK = latest ]] || jshon+=(-s "$ETH_BLOCK" -i append)
   ETH_GAS=$(seth rpc eth_estimateGas -- "${jshon[@]}")
 fi
 

--- a/src/seth/libexec/seth/seth-mktx
+++ b/src/seth/libexec/seth/seth-mktx
@@ -18,7 +18,7 @@ data=${data:-0x}
 if [[ -z "$ETH_GAS" ]]; then
   jshon+=(-n {})
   [[ $TO ]] && jshon+=(-s "$TO" -i to)
-  jshon+=(-s "$DATA" -i data)
+  jshon+=(-s "$data" -i data)
   # shellcheck disable=SC2207
   jshon+=($(SETH_PARAMS_NO_GAS=1 seth --send-params))
   jshon+=(-i append)

--- a/src/seth/libexec/seth/seth-mktx
+++ b/src/seth/libexec/seth/seth-mktx
@@ -15,6 +15,10 @@ fi
 
 data=${data:-0x}
 
+if [[ -z "$SETH_CREATE" ]]; then
+  TO=$(seth --to-address "$1")
+fi
+
 if [[ -z "$ETH_GAS" ]]; then
   jshon+=(-n {})
   [[ $TO ]] && jshon+=(-s "$TO" -i to)
@@ -38,7 +42,7 @@ args=(
 if [[ $SETH_CREATE ]]; then
   args+=(--create)
 else
-  args+=(--to "$(seth --to-address "$1")")
+  args+=(--to "$TO")
 fi
 
 if [[ $ETH_PRIO_FEE ]]; then

--- a/src/seth/libexec/seth/seth-mktx
+++ b/src/seth/libexec/seth/seth-mktx
@@ -13,14 +13,16 @@ if [[ $2 ]]; then
   data=$(seth calldata "${@:2}")
 fi
 
+data=${data:-0x}
+
 args=(
   --from "$(seth --to-address "$ETH_FROM")"
   --nonce "${ETH_NONCE:-$(seth nonce "$ETH_FROM")}"
   --chain-id "$(seth chain-id)"
   --gas-price "${ETH_GAS_PRICE:-$(seth gas-price)}"
-  --gas-limit "${ETH_GAS:-$(seth estimate $ETH_FROM ${$data:-0x})}"
+  --gas-limit "${ETH_GAS:-$(seth estimate $ETH_FROM $data)}"
   --value "$value"
-  --data "${data:-0x}"
+  --data "$data"
 )
 
 if [[ $SETH_CREATE ]]; then

--- a/src/seth/libexec/seth/seth-send
+++ b/src/seth/libexec/seth/seth-send
@@ -24,7 +24,7 @@ set -e
 [[ $ETH_FROM ]] ||
 seth --fail "${0##*/}: error: \`ETH_FROM' not set; send from which account?"
 [[ $ETH_GAS ]] ||
-echo >&2 "${0##*/}: warning: \`ETH_GAS' not set; using default gas amount"
+echo >&2 "${0##*/}: warning: \`ETH_GAS' not set; using estimated gas amount"
 if [[ $SETH_RESEND ]]; then
   nonce=$(seth nonce "$ETH_FROM")
   export ETH_NONCE=$nonce


### PR DESCRIPTION
## Description
Adds automatic gas estimation to `seth mktx` if `ETH_GAS` is not set. Since `seth mktx` is the underlying for `seth send` and `dapp create`, dapptools users will likely never have to input gas limits manually.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [x] updated the docs
- [x] updated the changelog
