### PR TITLE
hevm/dapp: solc 0.8.10 support

### DIFF
--- a/nix/solc-static-versions.nix
+++ b/nix/solc-static-versions.nix
@@ -65,6 +65,7 @@ rec {
     solc_0_8_7 = { version = "0.8.7"; path = "solc-linux-amd64-v0.8.7+commit.e28d00a7"; sha256 = "16bdi52r67znh8l8sdvckqikpz990gcsvdnh2ac2y8a57qw7ag80"; };
     solc_0_8_8 = { version = "0.8.8"; path = "solc-linux-amd64-v0.8.8+commit.dddeac2f"; sha256 = "1c6bn1wa1m3b0h7qzcks7mrkzpk7iqxdx8rli7in2v0kdchv2xz6"; };
     solc_0_8_9 = { version = "0.8.9"; path = "solc-linux-amd64-v0.8.9+commit.e5eed63a"; sha256 = "156b53bpy3aqmd8s7dyx9xsxk83w0mfcpmpqpam6nj9pmlgz2lgq"; };
+    solc_0_8_10 = { version = "0.8.10"; path = "solc-linux-amd64-v0.8.10+commit.fc410830"; sha256 = "12bds16qmpcx93f1m3vyr07aqrj2py7j4x8vz2al9mmr537zmvy7"; };
   };
   x86_64-darwin  = {
     solc_0_3_6 = { version = "0.3.6"; path = "solc-macosx-amd64-v0.3.6+commit.988fe5e5"; sha256 = "1x4xq0j84sfh9jjvv6x3yvhc76785vfr1mkmkq5idn3knfsq3m82"; };
@@ -143,5 +144,6 @@ rec {
     solc_0_8_7 = { version = "0.8.7"; path = "solc-macosx-amd64-v0.8.7+commit.e28d00a7"; sha256 = "143rcxifcs8543cp3jjz4f2qfsy8g9w574m0mjs4wzg13wyncp6c"; };
     solc_0_8_8 = { version = "0.8.8"; path = "solc-macosx-amd64-v0.8.8+commit.dddeac2f"; sha256 = "1paib39vmh0bb37bswszwdx4cvws40pgnh19yvz5c795ah2f28hl"; };
     solc_0_8_9 = { version = "0.8.9"; path = "solc-macosx-amd64-v0.8.9+commit.e5eed63a"; sha256 = "1klli28jpld11llg1k5iia6wqp4hkrs7wh326b38p67xv3sx86fn"; };
+    solc_0_8_10 = { version = "0.8.10"; path = "solc-macosx-amd64-v0.8.10+commit.fc410830"; sha256 = "1k54wb8p7vq5lkvd5awvya1c796gm527r0j6wibfhnxkmqizz7x7"; };
   };
 }

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support for solc 0.8.10
+
 ### Changed
 
 - Clearer display for the invalid opcode (`0xfe`) in debug view


### PR DESCRIPTION
## Description

Fixes #858 

Ran

```
$ ./nix/make-solc-static.sh
```

To generate the `solc-static-versions.nix` content, in order to support Solidity version 0.8.10.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [x] updated the docs
- [x] updated the changelog
