### PR TITLE
cachixbump release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,9 +94,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # v12
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v14.1
       # v8
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v10
         with:
           name: dapp
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'


### PR DESCRIPTION
https://github.com/dapphub/dapptools/commit/2fcfa9cce68a430226dc6dddbeb593925279104e updated the cachix version for the build workflow, but was not updated for the release workflow, attempting to unblock release
