### PR TITLE
Small update to ffi function documentation

### DIFF
--- a/src/hevm/README.md
+++ b/src/hevm/README.md
@@ -341,7 +341,7 @@ These can be accessed by calling into a contract (typically called `Hevm`) at ad
   `BadCheatCode` as `0` is an invalid ECDSA private key.
 
 - `function ffi(string[] calldata) external returns (bytes memory)`
-  Executes the arguments as a command in the system shell and returns stdout. Note that this
+  Executes the arguments as a command in the system shell and returns stdout. Expects abi encoded values to be returned from the shell or an error will be thrown. Note that this
   cheatcode means test authors can execute arbitrary code on user machines as part of a call to `dapp test`, for this reason all calls to `ffi` will fail unless the `--ffi` flag is passed.
 
 ## Contact


### PR DESCRIPTION
## Description
I wanted to make a small change to make the ffi documentation a little more noob friendly. HEVM throws an error if anything in stdout is not encoded properly. Let me know if you want me to change anything up!
## Checklist

- [x] tested locally
- [x] added automated tests
- [x] updated the docs
- [ ] updated the changelog
