### PR TITLE
seth & dapp-verify-contract: added avalanche and avalanche-fuji

### DIFF
--- a/src/dapp/libexec/dapp/dapp-verify-contract
+++ b/src/dapp/libexec/dapp/dapp-verify-contract
@@ -41,8 +41,16 @@ case "$chain" in
     export ETHERSCAN_API_URL=https://api-testnet.polygonscan.com/api
     export ETHERSCAN_URL=https://mumbai.polygonscan.com/address
     ;;
+  avalanche)
+    export ETHERSCAN_API_URL=https://api.snowtrace.io/api
+    export ETHERSCAN_URL=https://snowtrace.io/
+    ;;
+  avalanche-fuji)
+    export ETHERSCAN_API_URL=https://api-testnet.snowtrace.io/api
+    export ETHERSCAN_URL=https://testnet.snowtrace.io/
+    ;;
   *)
-    echo >&2 "Verification only works on mainnet, ropsten, kovan, rinkeby, goerli, and polygon."
+    echo >&2 "Verification only works on mainnet, ropsten, kovan, rinkeby, goerli, polygon, avalanche and avalanche-fuji."
     exit 1
 esac
 

--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -624,7 +624,7 @@ Print the symbolic name of the current blockchain by checking the
 genesis block hash.
 
 Outputs one of `ethlive`, `etclive`, `kovan`, `ropsten`, `goerli`, `morden`,
-`rinkeby`, `optimism-mainnet`, `optimism-kovan`, `arbitrum-mainnet`, `bsc`, `bsctest`, `kotti`, `polygon`, or `unknown`.
+`rinkeby`, `optimism-mainnet`, `optimism-kovan`, `arbitrum-mainnet`, `bsc`, `bsctest`, `kotti`, `polygon`, `avalanche`, `avalanche-fuji` or `unknown`.
 
 ### `seth chain-id`
 

--- a/src/seth/libexec/seth/seth
+++ b/src/seth/libexec/seth/seth
@@ -246,6 +246,14 @@ if [[ $SETH_CHAIN ]]; then
       eth_rpc_url=https://polygon-rpc.com/
       export ETHERSCAN_API_URL=https://api.polygonscan.com/api
       ;;
+    avalanche)
+      eth_rpc_url=https://api.avax.network/ext/bc/C/rpc
+      export ETHERSCAN_API_URL=https://api.snowtrace.io/api
+      ;;
+    avalanche-fuji)
+      eth_rpc_url=https://api.avax-test.network/ext/bc/C/rpc
+      export ETHERSCAN_API_URL=https://api-testnet.snowtrace.io/api
+      ;;
     *)
       echo >&2 "${0##*/}: error: unknown chain: \\'$SETH_CHAIN'"
       exit 1

--- a/src/seth/libexec/seth/seth-chain
+++ b/src/seth/libexec/seth/seth-chain
@@ -37,6 +37,13 @@ case $genesis in
     echo polygon;;
   0x7b66506a9ebdbf30d32b43c5f15a3b1216269a1ec3a75aa3182b86176a2b1ca7)
     echo polygon-mumbai;;
+  0x31ced5b9beb7f8782b014660da0cb18cc409f121f408186886e1ca3e8eeca96b)
+      case $(seth block 1 hash 2>/dev/null || echo null) in
+      0x738639479dc82d199365626f90caa82f7eafcfe9ed354b456fb3d294597ceb53)
+        echo avalanche-fuji;;
+      *)
+        echo avalanche;;
+    esac;;
   *)
     echo unknown;;
 esac

--- a/src/seth/libexec/seth/seth-etherscan-source
+++ b/src/seth/libexec/seth/seth-etherscan-source
@@ -50,8 +50,14 @@ case "$chain" in
   polygon-mumbai)
     URL="${ETHERSCAN_API_URL:-https://api-testnet.polygonscan.com}"
     ;;
+  avalanche)
+    URL="${ETHERSCAN_API_URL:-https://api.snowtrace.io}"
+    ;;
+  avalanche-fuji)
+    URL="${ETHERSCAN_API_URL:-https://api-testnet.snowtrace.io}"
+    ;;
   *)
-    echo >&2 "Source fetching only works on mainnet, ropsten, kovan, rinkeby, goerli, optimism-mainnet, optimism-kovan, arbitrum-mainnet, and polygon."
+    echo >&2 "Source fetching only works on mainnet, ropsten, kovan, rinkeby, goerli, optimism-mainnet, optimism-kovan, arbitrum-mainnet, polygon, avalanche and avalanche-fuji."
     exit 1
 esac
 


### PR DESCRIPTION
## Description
Deployed and verified from dapptools:

`avalanche` https://snowtrace.io/address/0xcd7a3739382f583dc8074771790d9b5e94d6c630
`avalanche-fuji` https://testnet.snowtrace.io/address/0x99ab21a47b7d3616200947d9e1abda713b925d95

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
