### PR TITLE
feat: add pass and fail count to dapp test

### DIFF
--- a/src/dapp-tests/integration/diff-fuzz.py
+++ b/src/dapp-tests/integration/diff-fuzz.py
@@ -7,7 +7,7 @@ from hypothesis.strategies import binary
 
 
 @settings(
-    deadline=2000,
+    deadline=10000,
     phases=[Phase.explicit, Phase.reuse]
 )
 @given(binary(min_size=1))

--- a/src/dapp/libexec/dapp/dapp-test
+++ b/src/dapp/libexec/dapp/dapp-test
@@ -56,4 +56,9 @@ export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
 export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 
 # shellcheck disable=SC2068
-hevm dapp-test --dapp-root="${DAPP_ROOT}" --json-file="${DAPP_JSON}" ${opts[@]}
+testreport=$(hevm dapp-test --dapp-root="${DAPP_ROOT}" --json-file="${DAPP_JSON}" ${opts[@]} | tee /dev/tty)
+
+passCount=$(echo $testreport | grep -c "\[PASS]") || true
+failCount=$(echo $testreport | grep -c "\[FAIL]") || true
+
+echo Test results: "$passCount" passed, "$failCount" failed

--- a/src/dapp/libexec/dapp/dapp-test
+++ b/src/dapp/libexec/dapp/dapp-test
@@ -58,7 +58,7 @@ export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 # shellcheck disable=SC2068
 testreport=$(hevm dapp-test --dapp-root="${DAPP_ROOT}" --json-file="${DAPP_JSON}" ${opts[@]} | tee /dev/tty)
 
-passCount=$(echo $testreport | grep -c "\[PASS]") || true
-failCount=$(echo $testreport | grep -c "\[FAIL]") || true
+passCount=$(echo "$testreport" | grep -c "\[PASS]") || true
+failCount=$(echo "$testreport" | grep -c "\[FAIL]") || true
 
 echo Test results: "$passCount" passed, "$failCount" failed


### PR DESCRIPTION
## Description
Tees output to a temp file to then count the number of [PASS] and [FAIL] test cases, then reports it in this format:

`Test results: 10 passed, 2 failed`
## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
