### PR TITLE
🥄 Add support for solc 0.8.12

### DIFF
--- a/nix/solc-static-versions.nix
+++ b/nix/solc-static-versions.nix
@@ -67,6 +67,7 @@ rec {
     solc_0_8_9 = { version = "0.8.9"; path = "solc-linux-amd64-v0.8.9+commit.e5eed63a"; sha256 = "156b53bpy3aqmd8s7dyx9xsxk83w0mfcpmpqpam6nj9pmlgz2lgq"; };
     solc_0_8_10 = { version = "0.8.10"; path = "solc-linux-amd64-v0.8.10+commit.fc410830"; sha256 = "12bds16qmpcx93f1m3vyr07aqrj2py7j4x8vz2al9mmr537zmvy7"; };
     solc_0_8_11 = { version = "0.8.11"; path = "solc-linux-amd64-v0.8.11+commit.d7f03943"; sha256 = "0kyd87krzl56a4haizy8cm39cilz9c5nl10n9j1s9hqx7agj6z3i"; };
+    solc_0_8_12 = { version = "0.8.12"; path = "solc-linux-amd64-v0.8.12+commit.f00d7308"; sha256 = "1wzv1cv0ggf4zvdq3rfng34q5gis8258myikg6vgd3xg9z23wv2m"; };
   };
   x86_64-darwin  = {
     solc_0_3_6 = { version = "0.3.6"; path = "solc-macosx-amd64-v0.3.6+commit.988fe5e5"; sha256 = "1x4xq0j84sfh9jjvv6x3yvhc76785vfr1mkmkq5idn3knfsq3m82"; };
@@ -147,5 +148,6 @@ rec {
     solc_0_8_9 = { version = "0.8.9"; path = "solc-macosx-amd64-v0.8.9+commit.e5eed63a"; sha256 = "1klli28jpld11llg1k5iia6wqp4hkrs7wh326b38p67xv3sx86fn"; };
     solc_0_8_10 = { version = "0.8.10"; path = "solc-macosx-amd64-v0.8.10+commit.fc410830"; sha256 = "1k54wb8p7vq5lkvd5awvya1c796gm527r0j6wibfhnxkmqizz7x7"; };
     solc_0_8_11 = { version = "0.8.11"; path = "solc-macosx-amd64-v0.8.11+commit.d7f03943"; sha256 = "1082p03x1zqm8xgsdziii95z4dy7bn49afwmigyykpd4is6wrk8h"; };
+    solc_0_8_12 = { version = "0.8.12"; path = "solc-macosx-amd64-v0.8.12+commit.f00d7308"; sha256 = "1yabikdkxzn2gdhzy1jxmwpkv1wa7n7qzzp9hlim04wsj0kqlwwm"; };
   };
 }

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Support for solc 0.8.12
+
 ## [0.49.0] - 2021-11-12
 
 ### Added


### PR DESCRIPTION
## Description

Ran

```
$ ./nix/make-solc-static.sh
```

To generate the `solc-static-versions.nix` content, in order to support Solidity version 0.8.12.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
