### PR TITLE
fixed typo

### DIFF
--- a/src/seth/README.md
+++ b/src/seth/README.md
@@ -681,7 +681,7 @@ Print the decoded events of a contract.
 
 To use this command, you need to set the `SETH_ABI` variable:
 
-    export SETH_ABI=$(seth abi "event Foo(uint bar);")
+    export SETH_ABI=$(seth abi "event Foo(uint bar)")
 
 To use a JSON ABI file:
 


### PR DESCRIPTION
the ";" was resulting in
```
unknown modifier: ;
[{"anonymous":false,"inputs":[{"type":"uint256","name":"bar","indexed":false}],"name":"Foo","type":"event"}]
```
and without the ";" we now just get
```
[{"anonymous":false,"inputs":[{"type":"uint256","name":"bar","indexed":false}],"name":"Foo","type":"event"}]
```

## Description

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
