### PR TITLE
Add support for solc 0.8.13

### DIFF
--- a/nix/solc-static-versions.nix
+++ b/nix/solc-static-versions.nix
@@ -68,6 +68,7 @@ rec {
     solc_0_8_10 = { version = "0.8.10"; path = "solc-linux-amd64-v0.8.10+commit.fc410830"; sha256 = "12bds16qmpcx93f1m3vyr07aqrj2py7j4x8vz2al9mmr537zmvy7"; };
     solc_0_8_11 = { version = "0.8.11"; path = "solc-linux-amd64-v0.8.11+commit.d7f03943"; sha256 = "0kyd87krzl56a4haizy8cm39cilz9c5nl10n9j1s9hqx7agj6z3i"; };
     solc_0_8_12 = { version = "0.8.12"; path = "solc-linux-amd64-v0.8.12+commit.f00d7308"; sha256 = "1wzv1cv0ggf4zvdq3rfng34q5gis8258myikg6vgd3xg9z23wv2m"; };
+    solc_0_8_13 = { version = "0.8.13"; path = "solc-linux-amd64-v0.8.13+commit.abaa5c0e"; sha256 = "0qix86zgfik54k07zahna9inzx3grbygr3yikiffvn6chvxdy1d8"; };
   };
   x86_64-darwin  = {
     solc_0_3_6 = { version = "0.3.6"; path = "solc-macosx-amd64-v0.3.6+commit.988fe5e5"; sha256 = "1x4xq0j84sfh9jjvv6x3yvhc76785vfr1mkmkq5idn3knfsq3m82"; };
@@ -149,5 +150,6 @@ rec {
     solc_0_8_10 = { version = "0.8.10"; path = "solc-macosx-amd64-v0.8.10+commit.fc410830"; sha256 = "1k54wb8p7vq5lkvd5awvya1c796gm527r0j6wibfhnxkmqizz7x7"; };
     solc_0_8_11 = { version = "0.8.11"; path = "solc-macosx-amd64-v0.8.11+commit.d7f03943"; sha256 = "1082p03x1zqm8xgsdziii95z4dy7bn49afwmigyykpd4is6wrk8h"; };
     solc_0_8_12 = { version = "0.8.12"; path = "solc-macosx-amd64-v0.8.12+commit.f00d7308"; sha256 = "1yabikdkxzn2gdhzy1jxmwpkv1wa7n7qzzp9hlim04wsj0kqlwwm"; };
+    solc_0_8_13 = { version = "0.8.13"; path = "solc-macosx-amd64-v0.8.13+commit.abaa5c0e"; sha256 = "1sjvdy18pibc7p27j6pzhfj730mplxzrp57xj5gdjam87q0yzm0l"; };
   };
 }

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for solc 0.8.12
+- Support for solc 0.8.13
 
 ## [0.49.0] - 2021-11-12
 


### PR DESCRIPTION
## Description

Add support for solc `0.8.13`. The content was generated using `$ ./nix/make-solc-static.sh`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
