### PR TITLE
hevm: fix prove tests for latest ds-test

### DIFF
--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Correctly handle concrete returndata when checking the result of a symbolic test
+- Correctly handle reverting branches when checking the result of a symbolic test
 
 ## [0.49.0] - 2021-11-12
 

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -770,10 +770,14 @@ execSymTest opts@UnitTestOptions{ .. } method cd = do
   Stepper.runFully >>= \vm' -> case view result vm' of
     Just (VMFailure err) ->
       -- If we failed, put the error in the trace.
-      Stepper.evm (pushTrace (ErrorTrace err)) >> (pure (True, vm'))
+      Stepper.evm (pushTrace (ErrorTrace err)) >> pure (True, vm')
     Just (VMSuccess _) -> do
       postVm <- checkSymFailures opts
-      pure (False, postVm)
+      -- calls to failed() contain reverting branches since https://github.com/dapphub/ds-test/pull/30
+      case view result postVm of
+        Just (VMSuccess _) -> pure (False, postVm)
+        Just (VMFailure _) -> pure (True, postVm)
+        r -> error $ "unexpected return value after call to failed(): " ++ show r
     Nothing -> error "Internal Error: execSymTest: vm has not completed execution!"
 
 checkSymFailures :: UnitTestOptions -> Stepper VM


### PR DESCRIPTION
Since https://github.com/dapphub/ds-test/pull/30 calls to `failed()` can
contain reverting branches due to the call into abi.decode().

This meant that using prove tests with the latest ds-test version would
always fail with a hard error.

This change updates the symbolic test stepper to correctly report
`bailed` as true for branches that reverted during the call to
`failed()`.

## Description

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
