### PR TITLE
seth-rpc: send the RPC request to stderr if SETH_VERBOSE

### DIFF
--- a/src/seth/libexec/seth/seth-rpc
+++ b/src/seth/libexec/seth/seth-rpc
@@ -13,6 +13,7 @@ rpc-error() { jshon -Q -e error -j; }
 
 request=$(seth rpc-request -- "$@")
 response=$(seth rpc-curl <<<"$request")
+[[ $SETH_VERBOSE ]] && SETH_KEY_WIDTH=10 seth --show-json <<< "$request" | sed >&2 "s/^/${0##*/}:   /"
 
 if result=$(rpc-result <<<"$response"); then
   seth --show-json <<<"$result"


### PR DESCRIPTION
## Description

It can be useful to see the RPC request that `seth` is making e.g. under `seth call` or `seth send`. Seems natural to put it under `-v`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
