### PR TITLE
♻️  add solc `0.8.18` support

### DIFF
--- a/nix/solc-static-versions.nix
+++ b/nix/solc-static-versions.nix
@@ -73,7 +73,7 @@ rec {
     solc_0_8_15 = { version = "0.8.15"; path = "solc-linux-amd64-v0.8.15+commit.e14f2714"; sha256 = "1k3l5v2r20zdxgqba9gvlkg7wqirj6rxj645bsvpzm92wdf1b2ai"; };
     solc_0_8_16 = { version = "0.8.16"; path = "solc-linux-amd64-v0.8.16+commit.07a7930e"; sha256 = "1qgfpzpb5l2ff87fkk23iw8hbwqjbabyqclji556m18zdin7hchn"; };
     solc_0_8_17 = { version = "0.8.17"; path = "solc-linux-amd64-v0.8.17+commit.8df45f5f"; sha256 = "1m0338ff2vac6v9fi3lkja59gf4rrwlw4hvcyzqi95vffw5hgwlr"; };
-    solc_0_8_18 = { version = "0.8.18"; path = "solc-linux-amd64-v0.8.18+commit.87f61d96"; sha256 = "1g9jbh4xkg4yvyyzyr429xx7spg01qmzdv0rczsjcb28nhzg7h51"; };
+    solc_0_8_18 = { version = "0.8.18"; path = "solc-linux-amd64-v0.8.18+commit.87f61d96"; sha256 = "0xxa907llrryrsm9nppfc0lds0l3zfhwngj4zfddhfm6954yvrlm"; };
   };
   x86_64-darwin  = {
     solc_0_3_6 = { version = "0.3.6"; path = "solc-macosx-amd64-v0.3.6+commit.988fe5e5"; sha256 = "1x4xq0j84sfh9jjvv6x3yvhc76785vfr1mkmkq5idn3knfsq3m82"; };

--- a/nix/solc-static-versions.nix
+++ b/nix/solc-static-versions.nix
@@ -73,6 +73,7 @@ rec {
     solc_0_8_15 = { version = "0.8.15"; path = "solc-linux-amd64-v0.8.15+commit.e14f2714"; sha256 = "1k3l5v2r20zdxgqba9gvlkg7wqirj6rxj645bsvpzm92wdf1b2ai"; };
     solc_0_8_16 = { version = "0.8.16"; path = "solc-linux-amd64-v0.8.16+commit.07a7930e"; sha256 = "1qgfpzpb5l2ff87fkk23iw8hbwqjbabyqclji556m18zdin7hchn"; };
     solc_0_8_17 = { version = "0.8.17"; path = "solc-linux-amd64-v0.8.17+commit.8df45f5f"; sha256 = "1m0338ff2vac6v9fi3lkja59gf4rrwlw4hvcyzqi95vffw5hgwlr"; };
+    solc_0_8_18 = { version = "0.8.18"; path = "solc-linux-amd64-v0.8.18+commit.87f61d96"; sha256 = "1g9jbh4xkg4yvyyzyr429xx7spg01qmzdv0rczsjcb28nhzg7h51"; };
   };
   x86_64-darwin  = {
     solc_0_3_6 = { version = "0.3.6"; path = "solc-macosx-amd64-v0.3.6+commit.988fe5e5"; sha256 = "1x4xq0j84sfh9jjvv6x3yvhc76785vfr1mkmkq5idn3knfsq3m82"; };
@@ -159,5 +160,6 @@ rec {
     solc_0_8_15 = { version = "0.8.15"; path = "solc-macosx-amd64-v0.8.15+commit.e14f2714"; sha256 = "0ybx9yww6nrh9mvqwnd7yih4n0nw1cqi1ps055qc1r146b3nsr80"; };
     solc_0_8_16 = { version = "0.8.16"; path = "solc-macosx-amd64-v0.8.16+commit.07a7930e"; sha256 = "0kfwg52121z1ijl6iax9gfqjd0ps2rz2yh5zgsfg59z9pawiqivx"; };
     solc_0_8_17 = { version = "0.8.17"; path = "solc-macosx-amd64-v0.8.17+commit.8df45f5f"; sha256 = "0ap1k7ga1gyyf5drjy7714g9za3ci9s026s6gys44k2dqa1yy3p4"; };
+    solc_0_8_18 = { version = "0.8.18"; path = "solc-macosx-amd64-v0.8.18+commit.87f61d96"; sha256 = "15ykazy7hccj8swl1gpn7syd99dxd8i544hx4hzv7llsg5y2h5cg"; };
   };
 }

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for solc 0.8.15
 - Support for solc 0.8.16
 - Support for solc 0.8.17
+- Support for solc 0.8.18
 
 ### Fixed
 


### PR DESCRIPTION
## Description

Add support for solc `0.8.18`. The content was generated using `$ ./nix/make-solc-static.sh`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog

Cc: @d-xo 