### PR TITLE
tests: integration: disable 4byte due to flakiness

### DIFF
--- a/src/dapp-tests/integration/tests.sh
+++ b/src/dapp-tests/integration/tests.sh
@@ -587,7 +587,8 @@ test_namehash_7() {
 
 # SETH 4BYTE TESTS
 # seth 4byte
-test_4byte() {
+# FIXME: this test is flaky, see https://github.com/dapphub/dapptools/pull/969
+todo_4byte() {
     assert_equals "transfer(address,uint256)" "$(seth 4byte a9059cbb | tail -n 1)"
 }
 


### PR DESCRIPTION
## Description

See https://github.com/dapphub/dapptools/pull/969 and https://github.com/dapphub/dapptools/pull/977#issuecomment-1444421022

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
