### PR TITLE
♻ ️ Add support for Solidity version `0.8.20`

### DIFF
--- a/nix/solc-static-versions.nix
+++ b/nix/solc-static-versions.nix
@@ -75,6 +75,7 @@ rec {
     solc_0_8_17 = { version = "0.8.17"; path = "solc-linux-amd64-v0.8.17+commit.8df45f5f"; sha256 = "1m0338ff2vac6v9fi3lkja59gf4rrwlw4hvcyzqi95vffw5hgwlr"; };
     solc_0_8_18 = { version = "0.8.18"; path = "solc-linux-amd64-v0.8.18+commit.87f61d96"; sha256 = "0xxa907llrryrsm9nppfc0lds0l3zfhwngj4zfddhfm6954yvrlm"; };
     solc_0_8_19 = { version = "0.8.19"; path = "solc-linux-amd64-v0.8.19+commit.7dd6d404"; sha256 = "0j7bv5yc3jfk7xbyamjalpl5zbkqj4n1jdzcn8msdsx8r4yisp3s"; };
+    solc_0_8_20 = { version = "0.8.20"; path = "solc-linux-amd64-v0.8.20+commit.a1b79de6"; sha256 = "10m7zl0cgwd47l17zd479a43nngi34259p3z6cjiql4wvx7x8y84"; };
   };
   x86_64-darwin  = {
     solc_0_3_6 = { version = "0.3.6"; path = "solc-macosx-amd64-v0.3.6+commit.988fe5e5"; sha256 = "1x4xq0j84sfh9jjvv6x3yvhc76785vfr1mkmkq5idn3knfsq3m82"; };
@@ -163,5 +164,6 @@ rec {
     solc_0_8_17 = { version = "0.8.17"; path = "solc-macosx-amd64-v0.8.17+commit.8df45f5f"; sha256 = "0ap1k7ga1gyyf5drjy7714g9za3ci9s026s6gys44k2dqa1yy3p4"; };
     solc_0_8_18 = { version = "0.8.18"; path = "solc-macosx-amd64-v0.8.18+commit.87f61d96"; sha256 = "15ykazy7hccj8swl1gpn7syd99dxd8i544hx4hzv7llsg5y2h5cg"; };
     solc_0_8_19 = { version = "0.8.19"; path = "solc-macosx-amd64-v0.8.19+commit.7dd6d404"; sha256 = "0bb2na5mkgn85s00sbp0kjdqgmlsp6zxd2c1qhhkw2vynqx55j1q"; };
+    solc_0_8_20 = { version = "0.8.20"; path = "solc-macosx-amd64-v0.8.20+commit.a1b79de6"; sha256 = "1ahr0pfyfz4ac52a0mxn5bkjb3fwfqvmhyqabnalx3h6w12rjcpw"; };
   };
 }

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for solc 0.8.17
 - Support for solc 0.8.18
 - Support for solc 0.8.19
+- Support for solc 0.8.20
 
 ### Fixed
 


### PR DESCRIPTION
## Description

Add support for solc `0.8.20`. The content was generated using `$ ./nix/make-solc-static.sh`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog

Cc: @d-xo 