### PR TITLE
♻ Add support for Solidity version `0.8.21`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,14 +22,14 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      # v12
-      - uses: cachix/install-nix-action@v20
+      - uses: actions/checkout@v3
+      # v22
+      - uses: cachix/install-nix-action@v22
         with:
           # https://discourse.nixos.org/t/understanding-binutils-darwin-wrapper-nix-support-bad-substitution/11475/2
           nix_path: nixpkgs=channel:nixos-unstable
-      # v8
-      - uses: cachix/cachix-action@v10
+      # v12
+      - uses: cachix/cachix-action@v12
         with:
           name: dapp
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,18 +30,18 @@ jobs:
           apt-get: ${{ matrix.apt-get }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Local
         id: cache-local
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.local/
           key: ${{ runner.os }}-local-v3
 
       - name: Cache Stack
         id: cache-stack
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.stack
           key: ${{ runner.os }}-stack-v3
@@ -82,7 +82,7 @@ jobs:
         run: .github/scripts/build-macos-release.sh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: hevm-${{ runner.os }}
           path: hevm.tar.gz
@@ -92,17 +92,17 @@ jobs:
     needs: macosRelease
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      # v22
+      - uses: cachix/install-nix-action@v22
       # v12
-      - uses: cachix/install-nix-action@v20
-      # v8
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: dapp
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
       - run: nix-build -A hevmUnwrapped --out-link hevmLinux
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: hevm-macOS
           path: hevm-macOS

--- a/nix/solc-static-versions.nix
+++ b/nix/solc-static-versions.nix
@@ -76,6 +76,7 @@ rec {
     solc_0_8_18 = { version = "0.8.18"; path = "solc-linux-amd64-v0.8.18+commit.87f61d96"; sha256 = "0xxa907llrryrsm9nppfc0lds0l3zfhwngj4zfddhfm6954yvrlm"; };
     solc_0_8_19 = { version = "0.8.19"; path = "solc-linux-amd64-v0.8.19+commit.7dd6d404"; sha256 = "0j7bv5yc3jfk7xbyamjalpl5zbkqj4n1jdzcn8msdsx8r4yisp3s"; };
     solc_0_8_20 = { version = "0.8.20"; path = "solc-linux-amd64-v0.8.20+commit.a1b79de6"; sha256 = "10m7zl0cgwd47l17zd479a43nngi34259p3z6cjiql4wvx7x8y84"; };
+    solc_0_8_21 = { version = "0.8.21"; path = "solc-linux-amd64-v0.8.21+commit.d9974bed"; sha256 = "1pw1b8a1y48vpc5rmkm0ci4yjsg1yg9xr62mvvl6jp71if4pm1gj"; };
   };
   x86_64-darwin  = {
     solc_0_3_6 = { version = "0.3.6"; path = "solc-macosx-amd64-v0.3.6+commit.988fe5e5"; sha256 = "1x4xq0j84sfh9jjvv6x3yvhc76785vfr1mkmkq5idn3knfsq3m82"; };
@@ -165,5 +166,6 @@ rec {
     solc_0_8_18 = { version = "0.8.18"; path = "solc-macosx-amd64-v0.8.18+commit.87f61d96"; sha256 = "15ykazy7hccj8swl1gpn7syd99dxd8i544hx4hzv7llsg5y2h5cg"; };
     solc_0_8_19 = { version = "0.8.19"; path = "solc-macosx-amd64-v0.8.19+commit.7dd6d404"; sha256 = "0bb2na5mkgn85s00sbp0kjdqgmlsp6zxd2c1qhhkw2vynqx55j1q"; };
     solc_0_8_20 = { version = "0.8.20"; path = "solc-macosx-amd64-v0.8.20+commit.a1b79de6"; sha256 = "1ahr0pfyfz4ac52a0mxn5bkjb3fwfqvmhyqabnalx3h6w12rjcpw"; };
+    solc_0_8_21 = { version = "0.8.21"; path = "solc-macosx-amd64-v0.8.21+commit.d9974bed"; sha256 = "00m5p4wdk9gg9lg65s3aby366c45ann88lmlyzsbz35hkxs6bl0r"; };
   };
 }

--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for solc 0.8.18
 - Support for solc 0.8.19
 - Support for solc 0.8.20
+- Support for solc 0.8.21
 
 ### Fixed
 


### PR DESCRIPTION
## Description

Add support for solc [`0.8.21`](https://github.com/ethereum/solidity/releases/tag/v0.8.21). The content was generated using `$ ./nix/make-solc-static.sh`. I also bump all the GH actions in `build.yml` and `release.yml` to the latest stable release versions.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog

Cc: @d-xo